### PR TITLE
fix(search): address Codex review findings on FTS

### DIFF
--- a/src/adapters/postgres/search-repository.ts
+++ b/src/adapters/postgres/search-repository.ts
@@ -209,14 +209,25 @@ export async function lexicalCandidates(opts: {
       select us.id, ts_rank_cd(us.search_tsv, q.tsq) as raw
       from user_stories us, q
       where us.search_tsv @@ q.tsq
+      union all
+      -- Section-level vocabulary: a query matching a section's name/definition
+      -- surfaces that section's stories (sections.search_tsv from 0019).
+      select us.id, ts_rank_cd(s.search_tsv, q.tsq) as raw
+      from sections s
+      join user_stories us on us.section_id = s.id
+      cross join q
+      where s.search_tsv @@ q.tsq
     ),
     ident as (
+      -- word_similarity(needle, haystack): the query is the needle found within
+      -- the stored path/slug, so a short identifier query isn't penalized by the
+      -- path's unmatched trigrams. Arg order matters.
       select id, max(sim) as raw from (
-        select sc.story_id as id, word_similarity(ca.path, ${query}) as sim
+        select sc.story_id as id, word_similarity(${query}, ca.path) as sim
         from story_code_assets sc
         join code_assets ca on ca.id = sc.code_asset_id
         union all
-        select se.story_id as id, word_similarity(e.entity_slug, ${query}) as sim
+        select se.story_id as id, word_similarity(${query}, e.entity_slug) as sim
         from story_entities se
         join entities e on e.id = se.entity_id
       ) sims

--- a/src/ranking.ts
+++ b/src/ranking.ts
@@ -309,7 +309,10 @@ export function toAreaHits(
     bySection.set(s.candidate.section_key, arr);
   }
 
-  const areas: AreaHit[] = [];
+  // Carry the top member's RRF alongside each area so sections are ORDERED by
+  // RRF (consistent with toStoryHits), while the reported `score` stays the
+  // interpretable absolute blend.
+  const areas: { rrf: number; area: AreaHit }[] = [];
   for (const [, members] of bySection) {
     members.sort((a, b) => b.rrf - a.rrf || b.absBlend - a.absBlend);
     const top = members[0];
@@ -319,26 +322,32 @@ export function toAreaHits(
     const codePaths = dedupeCap(members.flatMap((m) => m.candidate.code_paths), 20);
 
     areas.push({
-      section_key: top.candidate.section_key,
-      section_name: top.candidate.section_name,
-      score: round(top.absBlend),
-      score_breakdown: roundBreakdown(top.breakdown),
-      matched_stories: members.slice(0, storiesPerArea).map((m) => ({
-        story_key: m.candidate.story_key,
-        title: m.candidate.title,
-        story_text: m.candidate.story_text,
-        actor: m.candidate.actor,
-        status: m.candidate.status,
-        score: round(m.absBlend),
-        help_articles: m.candidate.help_articles,
-        help_article_count: m.candidate.help_article_count,
-      })),
-      code_paths: codePaths,
-      why: { shared_entities: sharedEntities, shared_code_paths: sharedPaths },
+      rrf: top.rrf,
+      area: {
+        section_key: top.candidate.section_key,
+        section_name: top.candidate.section_name,
+        score: round(top.absBlend),
+        score_breakdown: roundBreakdown(top.breakdown),
+        matched_stories: members.slice(0, storiesPerArea).map((m) => ({
+          story_key: m.candidate.story_key,
+          title: m.candidate.title,
+          story_text: m.candidate.story_text,
+          actor: m.candidate.actor,
+          status: m.candidate.status,
+          score: round(m.absBlend),
+          help_articles: m.candidate.help_articles,
+          help_article_count: m.candidate.help_article_count,
+        })),
+        code_paths: codePaths,
+        why: { shared_entities: sharedEntities, shared_code_paths: sharedPaths },
+      },
     });
   }
 
-  return areas.sort((a, b) => b.score - a.score).slice(0, limit);
+  return areas
+    .sort((a, b) => b.rrf - a.rrf || b.area.score - a.area.score)
+    .slice(0, limit)
+    .map((a) => a.area);
 }
 
 function round(x: number): number {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -356,6 +356,7 @@ export const findCrossoverOutputShape = {
 export const findHelpOutputShape = {
   query: z.object({
     min_score: z.number(),
+    min_lexical_score: z.number(),
     candidate_pool_size: z.number(),
     product_area: z.array(z.string()).optional(),
     audience: z.array(z.string()).optional(),


### PR DESCRIPTION
Follow-up to #2 (FTS). Codex's automated cross-model review of #2 surfaced **four P2 findings that the same-family reviewers missed** — all legitimate. This addresses them.

| # | Finding | Fix | Verified |
|---|---|---|---|
| 1 | `word_similarity(path, query)` arg order penalizes short-identifier queries | Swap to `word_similarity(query, path/slug)` (query = needle) | PGlite: 0.464 → 1.000 on a short identifier |
| 2 | `lexicalCandidates` never searched `sections.search_tsv` (dead index) | Union section name/definition matches into the prose candidates | PGlite: a section-definition-only word now surfaces its stories |
| 3 | `toAreaHits` ordered sections by `absBlend`, not RRF (inconsistent with `toStoryHits`) | Order areas by the top member's RRF; reported score stays the interpretable blend | 25/25 ranking tests |
| 4 | `find_help` emits `min_lexical_score` but `findHelpOutputShape` didn't declare it | Added the field (closes schema drift my own review-fix introduced) | build/tsc |

Two were genuine functional gaps (identifier matching underperformed; section vocabulary couldn't surface stories), one an ordering inconsistency, one schema drift.

**Verification:** build clean, `npm run test:ranking` 25/25, `npm run test:retrieval` 7/7, and the two SQL behavior changes confirmed against PGlite + pgvector + pg_trgm (short-identifier match + section-text surfacing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)