### PR TITLE
fix(contract): restore donor scenario order so stable_ids keep their meaning

### DIFF
--- a/.tieline/manifest.json
+++ b/.tieline/manifest.json
@@ -809,7 +809,7 @@
             {
               "aliases": [],
               "applies_to": null,
-              "contract_hash": "0a80b721aa394d1aec6eb093bbc7a8ba29cb73615e0734af0f1b9157bcc24650",
+              "contract_hash": "6e5b4ac47ad981ab84dc3f047bfaa0f325c2149e645f85899962b064276c286d",
               "criterion": "Tieline must apply retrieval metadata as narrowing filters before combining always-on full-text and identifier recall with optional vector, alias, artifact-overlap, and three-hop graph signals through reciprocal rank fusion.",
               "links": [
                 {
@@ -930,18 +930,18 @@
               "rationale": null,
               "scenarios": [
                 {
-                  "given": "no embedding provider is installed or reachable",
+                  "given": "a caller supplies an Observation anchor with only a dismissed relationship to an Acceptance Criterion",
                   "position": 0,
                   "stable_id": "MATCHING-001-AC2-S1",
-                  "then": "Tieline must return full-text or identifier matches with explicit signal features and match reasons",
-                  "when": "a caller searches with an authorized retrieval profile"
-                },
-                {
-                  "given": "a caller supplies an Observation anchor with only a dismissed relationship to an Acceptance Criterion",
-                  "position": 1,
-                  "stable_id": "MATCHING-001-AC2-S2",
                   "then": "the dismissed relationship must contribute no graph proximity",
                   "when": "Tieline ranks the authorized semantic candidate set"
+                },
+                {
+                  "given": "no embedding provider is installed or reachable",
+                  "position": 1,
+                  "stable_id": "MATCHING-001-AC2-S2",
+                  "then": "Tieline must return full-text or identifier matches with explicit signal features and match reasons",
+                  "when": "a caller searches with an authorized retrieval profile"
                 }
               ],
               "stable_id": "MATCHING-001-AC2",
@@ -1714,7 +1714,7 @@
     },
     {
       "path": ".tieline/spec/matching.yaml",
-      "sha256": "49b4a678b2f6f513bd1b69e28b191db1f1d23ba98706cbee79df16eebdee1421"
+      "sha256": "70b8d8159d3aff9ac9aa164bfd03aeb4f32a47ec0a7aa7451cb18007f119a5df"
     },
     {
       "path": ".tieline/spec/retrieval.yaml",
@@ -1726,7 +1726,7 @@
     }
   ],
   "repository": {
-    "commit": "a67d6d3f3e2980f3c10a4f70c3cf04cc592c8fc9",
+    "commit": "5fc640d13d11aa6d69bf9d39908dc772d83373d6",
     "key": "tieline"
   },
   "schema_version": 1

--- a/.tieline/spec/matching.yaml
+++ b/.tieline/spec/matching.yaml
@@ -42,12 +42,12 @@ capability:
         - key: MATCHING-001-AC2
           criterion: Tieline must apply retrieval metadata as narrowing filters before combining always-on full-text and identifier recall with optional vector, alias, artifact-overlap, and three-hop graph signals through reciprocal rank fusion.
           scenarios:
-            - given: no embedding provider is installed or reachable
-              when: a caller searches with an authorized retrieval profile
-              then: Tieline must return full-text or identifier matches with explicit signal features and match reasons
             - given: a caller supplies an Observation anchor with only a dismissed relationship to an Acceptance Criterion
               when: Tieline ranks the authorized semantic candidate set
               then: the dismissed relationship must contribute no graph proximity
+            - given: no embedding provider is installed or reachable
+              when: a caller searches with an authorized retrieval profile
+              then: Tieline must return full-text or identifier matches with explicit signal features and match reasons
           links:
             - relation: implements
               target:


### PR DESCRIPTION
## Why

Scenario `stable_id`s are generated **positionally** at manifest-compile time — `${criterion.key}-S${position + 1}` (`src/contract/manifest.ts:419`) — so they are only stable under append. The port in #6 inserted the new embedding-free scenario at position 0 of `MATCHING-001-AC2`, which reassigned `MATCHING-001-AC2-S1` from the donor's dismissed-relationship scenario to the new content.

That matters because `contract sync` reconciles scenarios by upserting on `(criterion_id, stable_id)` while preserving the row uuid (`src/adapters/postgres/contract-sync-repository.ts`). Against an already-synced database, re-syncing would overwrite the S1 row's given/when/then in place, and polymorphic references keyed to that uuid (`attribution_suggestions`, `embedding_documents`, the revisions table) would silently point at a scenario with different semantics. No live database is affected today (#6 ships a clean baseline), but this keeps the hazard from being exercised and sets the append-only precedent.

## What

- Reorder `MATCHING-001-AC2` scenarios in `.tieline/spec/matching.yaml`: dismissed-relationship scenario back to S1, embedding-free scenario appended as S2.
- Recompile `.tieline/manifest.json` (`tieline contract compile`): scenario content swaps under the existing S1/S2 ids, `contract_hash` and spec sha256 refreshed, `repository.commit` stamped.

## Verification

- `tieline contract validate`: 12 Stories, 23 ACs, 0 warnings
- `npm run test:contract`: all passing (contract, manifest, contract-command)
- `tieline contract coverage`: 23/23 ACs evidenced; 70/70 eligible files mapped (100%)

Follow-up worth considering (not in this PR): explicit author-assigned scenario ids in the yaml, so ids survive reordering the way Story/AC `key`s already do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)