### PR TITLE
feat(cli): commander migration, Clack onboarding UX, and logo banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ converges definitions without deleting history.
 
 ## Requirements and installation
 
-- Node.js 18 or newer.
+- Node.js 20.12 or newer.
 - Docker with a running daemon when using `--database local`.
 - An existing PostgreSQL database with pgvector when using
   `--database existing`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,11 @@
       "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
+        "@clack/prompts": "^1.7.0",
         "@modelcontextprotocol/sdk": "^1.12.0",
+        "commander": "^14.0.3",
         "express": "^4.21.2",
+        "picocolors": "^1.1.1",
         "postgres": "^3.4.5",
         "yaml": "^2.8.1",
         "zod": "^3.23.8"
@@ -26,6 +29,34 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.3.tgz",
+      "integrity": "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.7.0.tgz",
+      "integrity": "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.4.3",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1064,6 +1095,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -1366,6 +1406,21 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -1381,6 +1436,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/finalhandler": {
       "version": "1.3.2",
@@ -1763,6 +1827,12 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -2081,6 +2151,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -54,11 +54,14 @@
     "test:integration:baseline": "tsx scripts/integration-baseline.ts"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20.12"
   },
   "dependencies": {
+    "@clack/prompts": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.12.0",
+    "commander": "^14.0.3",
     "express": "^4.21.2",
+    "picocolors": "^1.1.1",
     "postgres": "^3.4.5",
     "yaml": "^2.8.1",
     "zod": "^3.23.8"

--- a/scripts/test-impact.ts
+++ b/scripts/test-impact.ts
@@ -107,7 +107,7 @@ capability:
   const baselineOutput: string[] = [];
   assert.equal(
     await runCheckCommand(
-      ["--base", "HEAD", root, "--json"],
+      { base: "HEAD", repository: root, json: true },
       { write: (message) => baselineOutput.push(message) }
     ),
     0
@@ -172,7 +172,7 @@ capability:
   const output: string[] = [];
   assert.equal(
     await runCheckCommand(
-      ["--base", "HEAD", root, "--json"],
+      { base: "HEAD", repository: root, json: true },
       { write: (message) => output.push(message) }
     ),
     0
@@ -186,7 +186,7 @@ capability:
 
   await assert.rejects(
     runCheckCommand(
-      ["--base", "HEAD", `${root}-missing`],
+      { base: "HEAD", repository: `${root}-missing` },
       { write: () => undefined }
     ),
     /unreadable/i

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -280,7 +281,7 @@ try {
     runCli(["init", target, "--yes", "--force"], io().adapter, {
       TIELINE_CONFIG_HOME: configHome,
     }),
-    /Unknown init option: --force/
+    /unknown option '--force'/
   );
 
   await assert.rejects(
@@ -401,9 +402,56 @@ try {
       runCli([removed], io().adapter, {
         TIELINE_CONFIG_HOME: configHome,
       }),
-      /Unknown command/
+      /unknown command/i
     );
   }
+
+  // The stdin questioner lives in main(), so runCli-based tests bypass it;
+  // spawn the built CLI with piped stdin to exercise buffering and EOF.
+  const cliBin = resolve(process.cwd(), "dist/cli.js");
+  const pipedTarget = resolve(root, "piped-init");
+  mkdirSync(resolve(pipedTarget, "src"), { recursive: true });
+  writeFileSync(
+    resolve(pipedTarget, "package.json"),
+    JSON.stringify({ name: "piped-product" })
+  );
+  const piped = spawnSync(
+    "node",
+    [cliBin, "init", pipedTarget, "--embedding", "hash"],
+    {
+      input: "Piped Product\npiped-repo\n",
+      encoding: "utf8",
+      env: { ...process.env, TIELINE_CONFIG_HOME: configHome },
+    }
+  );
+  assert.equal(piped.status, 0, piped.stderr);
+  const pipedWorkspace = findTielineWorkspace(pipedTarget);
+  assert.ok(pipedWorkspace);
+  assert.equal(pipedWorkspace.config.product.name, "Piped Product");
+  assert.equal(pipedWorkspace.config.product.repo_name, "piped-repo");
+
+  const eofTarget = resolve(root, "eof-init");
+  mkdirSync(resolve(eofTarget, "src"), { recursive: true });
+  const eof = spawnSync(
+    "node",
+    [cliBin, "init", eofTarget, "--embedding", "hash"],
+    {
+      input: "",
+      encoding: "utf8",
+      env: { ...process.env, TIELINE_CONFIG_HOME: configHome },
+    }
+  );
+  assert.equal(eof.status, 1);
+  assert.match(eof.stderr, /Input ended before a response was received/);
+
+  // Bare group commands print clean help on stderr, not a "Tieline error:".
+  const bareContract = spawnSync("node", [cliBin, "contract"], {
+    encoding: "utf8",
+    env: { ...process.env, TIELINE_CONFIG_HOME: configHome },
+  });
+  assert.equal(bareContract.status, 1);
+  assert.match(bareContract.stderr, /Usage: tieline contract/);
+  assert.doesNotMatch(bareContract.stderr, /Tieline error:/);
 } finally {
   rmSync(root, { recursive: true, force: true });
 }

--- a/src/cli-ui.ts
+++ b/src/cli-ui.ts
@@ -1,0 +1,90 @@
+import pc from "picocolors";
+import type { TielineCliIO } from "./cli.js";
+
+export type Palette = ReturnType<typeof pc.createColors>;
+
+export function createPalette(enabled: boolean): Palette {
+  return pc.createColors(enabled);
+}
+
+export function paletteFor(io: TielineCliIO): Palette {
+  return createPalette(io.interactive === true && pc.isColorSupported);
+}
+
+// Diamond mark echoing the Tieline logo: stacked diamonds pierced by a
+// vertical tieline of three nodes, with the dotted band through the middle.
+const MARK = [
+  "      .",
+  "     / \\",
+  "    / ● \\",
+  "  ·:· ● ·:·",
+  "    \\ ● /",
+  "     \\ /",
+  "      '",
+];
+
+// figlet "Tieline" (Standard font), wordmark rows pair with MARK rows 1-5.
+const WORDMARK = [
+  " _____ _      _ _",
+  "|_   _(_) ___| (_)_ __   ___",
+  "  | | | |/ _ \\ | | '_ \\ / _ \\",
+  "  | | | |  __/ | | | | |  __/",
+  "  |_| |_|\\___|_|_|_| |_|\\___|",
+];
+
+const MARK_COLUMN_WIDTH = 13;
+
+export function renderBanner(ui: Palette): string {
+  return MARK.map((line, row) => {
+    const word = row >= 1 && row <= 5 ? WORDMARK[row - 1]! : "";
+    if (!word) return ui.cyan(line);
+    return `${ui.cyan(line.padEnd(MARK_COLUMN_WIDTH))}${ui.bold(word)}`;
+  }).join("\n");
+}
+
+/**
+ * Ask for a single value with a default. Uses a Clack prompt on an
+ * interactive terminal and falls back to the injected io.question
+ * elsewhere (tests, pipes, agents).
+ */
+export async function ask(
+  io: TielineCliIO,
+  message: string,
+  defaultValue: string
+): Promise<string> {
+  if (io.interactive) {
+    const clack = await import("@clack/prompts");
+    const value = await clack.text({
+      message,
+      placeholder: defaultValue,
+      defaultValue,
+    });
+    if (clack.isCancel(value)) {
+      clack.cancel("Cancelled.");
+      throw new Error("Cancelled.");
+    }
+    return value.trim() || defaultValue;
+  }
+  return (
+    (await io.question(`${message} [${defaultValue}]: `)).trim() ||
+    defaultValue
+  );
+}
+
+export async function intro(
+  io: TielineCliIO,
+  title: string
+): Promise<void> {
+  if (!io.interactive) return;
+  const clack = await import("@clack/prompts");
+  clack.intro(pc.bgCyan(pc.black(` ${title} `)));
+}
+
+export async function outro(
+  io: TielineCliIO,
+  message: string
+): Promise<void> {
+  if (!io.interactive) return;
+  const clack = await import("@clack/prompts");
+  clack.outro(message);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,12 +1,23 @@
 #!/usr/bin/env node
 
 import "./loadEnv.js";
-import { realpathSync } from "node:fs";
-import { basename, resolve } from "node:path";
+import { readFileSync, realpathSync } from "node:fs";
+import { basename, dirname, resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
+import type { Interface } from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 import { fileURLToPath } from "node:url";
+import { Command, CommanderError, Option } from "commander";
 import type { EmbeddingProvider } from "./config.js";
+import {
+  ask,
+  createPalette,
+  intro,
+  outro,
+  paletteFor,
+  renderBanner,
+} from "./cli-ui.js";
+import type { Palette } from "./cli-ui.js";
 import {
   detectProductName,
   detectSourceRoots,
@@ -41,7 +52,18 @@ export interface TielineCliIO {
   write(message: string): void;
   error(message: string): void;
   question(message: string): Promise<string>;
+  /** True when attached to a real terminal; enables Clack prompts and color. */
+  interactive?: boolean;
 }
+
+const packageVersion = (
+  JSON.parse(
+    readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), "../package.json"),
+      "utf8"
+    )
+  ) as { version: string }
+).version;
 
 async function reloadRuntimeConfig(
   env: NodeJS.ProcessEnv
@@ -67,116 +89,6 @@ interface InitOptions {
   installLocalEmbedder: boolean;
 }
 
-function optionValue(args: string[], index: number, name: string): string {
-  const value = args[index + 1];
-  if (!value || value.startsWith("--")) {
-    throw new Error(`--${name} requires a value.`);
-  }
-  return value;
-}
-
-function parseInit(
-  args: string[],
-  env: NodeJS.ProcessEnv
-): InitOptions {
-  let target: string | undefined;
-  let product: string | undefined;
-  let repoName: string | undefined;
-  let description: string | undefined;
-  let database: DatabaseMode = "offline";
-  let databaseExplicit = false;
-  let embedding = resolveEmbeddingProvider(env);
-  let embeddingExplicit = false;
-  const context: string[] = [];
-  const sourceRoots: string[] = [];
-  const ignore: string[] = [];
-  let yes = false;
-  let skipMigrate = false;
-  let installLocalEmbedder = false;
-  for (let index = 0; index < args.length; index++) {
-    const arg = args[index]!;
-    if (!arg.startsWith("--")) {
-      if (target) throw new Error("tieline init accepts one repository path.");
-      target = arg;
-      continue;
-    }
-    if (arg === "--yes") {
-      yes = true;
-      continue;
-    }
-    if (arg === "--offline") {
-      database = "offline";
-      databaseExplicit = true;
-      continue;
-    }
-    if (arg === "--skip-migrate") {
-      skipMigrate = true;
-      continue;
-    }
-    if (arg === "--install-local-embedder") {
-      installLocalEmbedder = true;
-      continue;
-    }
-    const [name, inline] = arg.slice(2).split("=", 2);
-    if (
-      ![
-        "product",
-        "repo-name",
-        "description",
-        "context",
-        "source-root",
-        "ignore",
-        "database",
-        "embedding",
-      ].includes(name)
-    ) {
-      throw new Error(`Unknown init option: --${name}`);
-    }
-    const value = inline ?? optionValue(args, index, name);
-    if (inline === undefined) index++;
-    if (name === "product") product = value;
-    if (name === "repo-name") repoName = value;
-    if (name === "description") description = value;
-    if (name === "context") context.push(value);
-    if (name === "source-root") sourceRoots.push(value);
-    if (name === "ignore") ignore.push(value);
-    if (name === "database") {
-      if (!["local", "existing", "offline"].includes(value)) {
-        throw new Error("--database must be local, existing, or offline.");
-      }
-      database = value as DatabaseMode;
-      databaseExplicit = true;
-    }
-    if (name === "embedding") {
-      if (
-        !["local", "openai", "supabase-edge", "hash"].includes(value)
-      ) {
-        throw new Error(
-          "--embedding must be local, openai, supabase-edge, or hash."
-        );
-      }
-      embedding = value as EmbeddingProvider;
-      embeddingExplicit = true;
-    }
-  }
-  return {
-    target: resolve(target ?? process.cwd()),
-    product,
-    repoName,
-    description,
-    context,
-    sourceRoots,
-    ignore,
-    database,
-    databaseExplicit,
-    embedding,
-    embeddingExplicit,
-    yes,
-    skipMigrate,
-    installLocalEmbedder,
-  };
-}
-
 function withoutDatabaseEnvironment(
   env: NodeJS.ProcessEnv
 ): NodeJS.ProcessEnv {
@@ -187,15 +99,17 @@ function withoutDatabaseEnvironment(
   return isolated;
 }
 
-function renderStatus(status: TielineStatus): string {
+function renderStatus(status: TielineStatus, ui: Palette): string {
+  const state = (ok: boolean, good: string, bad: string): string =>
+    ok ? ui.green(good) : ui.yellow(bad);
   return [
-    `Tieline: ${status.product} (${status.repo})`,
+    ui.bold(`Tieline: ${status.product} (${status.repo})`),
     `  root: ${status.root}`,
-    `  runtime: profile=${status.runtime.profile_present ? "present" : "missing"}, database=${status.runtime.database_mode}, embedding=${status.runtime.embedding_provider}, setup=${status.runtime.setup_complete ? "complete" : "incomplete"}`,
-    `  capabilities: semantic_matching=${status.capabilities.semantic_matching_configured ? "configured" : "unconfigured"}, planning_writes=${status.capabilities.planning_writes_configured ? "configured" : "unconfigured"}`,
-    `  integration: mcp_template=${status.integration.mcp_template_present ? "present" : "missing"}`,
-    `  contract: ${status.contract.stories} Stories, ${status.contract.acceptance_criteria} ACs, manifest=${status.contract.manifest_exists ? "present" : "missing"}`,
-    `Next: ${status.next_action}`,
+    `  runtime: profile=${state(status.runtime.profile_present, "present", "missing")}, database=${status.runtime.database_mode}, embedding=${status.runtime.embedding_provider}, setup=${state(status.runtime.setup_complete, "complete", "incomplete")}`,
+    `  capabilities: semantic_matching=${state(status.capabilities.semantic_matching_configured, "configured", "unconfigured")}, planning_writes=${state(status.capabilities.planning_writes_configured, "configured", "unconfigured")}`,
+    `  integration: mcp_template=${state(status.integration.mcp_template_present, "present", "missing")}`,
+    `  contract: ${status.contract.stories} Stories, ${status.contract.acceptance_criteria} ACs, manifest=${state(status.contract.manifest_exists, "present", "missing")}`,
+    `${ui.cyan("Next:")} ${status.next_action}`,
   ].join("\n");
 }
 
@@ -205,6 +119,7 @@ function renderInitSummary(
   io: TielineCliIO,
   env: NodeJS.ProcessEnv
 ): void {
+  const ui = paletteFor(io);
   io.write(
     `Source scope: ${workspace.config.repository.source_roots.join(", ")}\n`
   );
@@ -213,13 +128,15 @@ function renderInitSummary(
     workspace.config.repository.source_roots[0] === "."
   ) {
     io.write(
-      "Warning [source_scope]: no conventional source directory was detected; review repository.source_roots before claiming coverage.\n"
+      ui.yellow(
+        "Warning [source_scope]: no conventional source directory was detected; review repository.source_roots before claiming coverage.\n"
+      )
     );
   }
   for (const check of preflight.filter(
     (candidate) => candidate.status === "warning"
   )) {
-    io.write(`Warning [${check.key}]: ${check.message}\n`);
+    io.write(ui.yellow(`Warning [${check.key}]: ${check.message}\n`));
   }
   const status = getTielineStatus(workspace, env);
   if (status.contract.stories === 0) {
@@ -231,25 +148,8 @@ function renderInitSummary(
     "MCP template: register `.tieline/mcp.json` with your host and ensure its `tieline` command resolves this package.\n"
   );
   io.write(
-    "Next: invoke MCP prompt `tieline_author` (or the bundled /tieline-author skill) to onboard or reconcile behavior.\n"
+    `${ui.cyan("Next:")} invoke MCP prompt \`tieline_author\` (or the bundled /tieline-author skill) to onboard or reconcile behavior.\n`
   );
-}
-
-function printHelp(io: TielineCliIO): void {
-  io.write(`Tieline living-contract CLI
-
-Usage:
-  tieline init [repository] [options]
-  tieline status [repository] [--json]
-  tieline contract <validate|review|compile|coverage|sync> [repository] [options]
-  tieline check --base <ref> [repository] [--json]
-  tieline profile <list|put> [options]
-  tieline migrate [--verify]
-  tieline import-help <articles.json|articles.jsonl> [--batch-size 50]
-  tieline serve [--http|--stdio]
-
-Use /tieline-author for planning Story/AC writes, implementation, and branch reconciliation.
-`);
 }
 
 function firstPositional(
@@ -318,11 +218,10 @@ export function workspaceStartForCommand(
 }
 
 async function runInit(
-  args: string[],
+  parsed: InitOptions,
   io: TielineCliIO,
   env: NodeJS.ProcessEnv
 ): Promise<number> {
-  const parsed = parseInit(args, env);
   const existing = findTielineWorkspace(parsed.target);
   if (existing) {
     const stored = readWorkspaceProfile(existing, env);
@@ -368,25 +267,32 @@ async function runInit(
       return 0;
     }
     io.write(
-      `Tieline is already initialized at ${existing.directory}.\n${renderStatus(getTielineStatus(existing, env))}\n`
+      `Tieline is already initialized at ${existing.directory}.\n${renderStatus(getTielineStatus(existing, env), paletteFor(io))}\n`
     );
     return 0;
   }
+  const willPrompt =
+    !parsed.yes && (!parsed.product || !parsed.repoName);
+  if (willPrompt && io.interactive) {
+    io.write(`${renderBanner(paletteFor(io))}\n\n`);
+  }
+  if (willPrompt) await intro(io, "tieline init");
   const detectedProduct = detectProductName(parsed.target);
   const product =
     parsed.product ??
     (parsed.yes
       ? detectedProduct
-      : (await io.question(`Company/product name [${detectedProduct}]: `)).trim() ||
-        detectedProduct);
+      : await ask(io, "Company/product name", detectedProduct));
   const detectedRepo = slugifyRepoName(basename(parsed.target));
   const repoName = slugifyRepoName(
     parsed.repoName ??
       (parsed.yes
         ? detectedRepo
-        : (await io.question(`Stable repository name [${detectedRepo}]: `)).trim() ||
-          detectedRepo)
+        : await ask(io, "Stable repository name", detectedRepo))
   );
+  if (willPrompt) {
+    await outro(io, `Creating workspace for ${product} (${repoName})`);
+  }
   env.EMBEDDING_PROVIDER = parsed.embedding;
   const initEnv =
     parsed.database === "offline"
@@ -423,22 +329,255 @@ async function runInit(
   return 0;
 }
 
-function parseStatusArgs(args: string[]): {
-  path: string;
-  json: boolean;
-} {
-  const positionals = args.filter((arg) => !arg.startsWith("--"));
-  if (positionals.length > 1) {
-    throw new Error("tieline status accepts one repository path.");
-  }
-  const unknown = args.filter(
-    (arg) => arg.startsWith("--") && arg !== "--json"
-  );
-  if (unknown[0]) throw new Error(`Unknown status option: ${unknown[0]}`);
-  return {
-    path: positionals[0] ?? process.cwd(),
-    json: args.includes("--json"),
+function collect(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
+interface ContractActionOptions {
+  repo?: string;
+  commit?: string;
+  output?: string;
+  spec?: string;
+  expectedPreviousCommit?: string;
+  json?: boolean;
+}
+
+function buildProgram(
+  io: TielineCliIO,
+  env: NodeJS.ProcessEnv,
+  setExit: (code: number) => void,
+  writeErr: (message: string) => void
+): Command {
+  const program = new Command("tieline");
+  program
+    .description("Tieline living-contract CLI")
+    .version(packageVersion)
+    .exitOverride()
+    .configureOutput({
+      writeOut: (message) => io.write(message),
+      writeErr,
+    })
+    .addHelpText("before", () => `${renderBanner(paletteFor(io))}\n\n`)
+    .addHelpText(
+      "after",
+      "\nUse /tieline-author for planning Story/AC writes, implementation, and branch reconciliation."
+    );
+
+  program
+    .command("init")
+    .description("Create a Tieline workspace or resume runtime setup")
+    .argument("[repository]", "repository path", process.cwd())
+    .option("--product <name>", "company/product name")
+    .option("--repo-name <name>", "stable repository name")
+    .option("--description <text>", "product description")
+    .option("--context <location>", "context source (repeatable)", collect, [])
+    .option("--source-root <path>", "source root (repeatable)", collect, [])
+    .option("--ignore <pattern>", "ignore pattern (repeatable)", collect, [])
+    .addOption(
+      new Option("--database <mode>", "database mode").choices([
+        "local",
+        "existing",
+        "offline",
+      ])
+    )
+    .addOption(
+      new Option("--offline", "shorthand for --database offline").conflicts(
+        "database"
+      )
+    )
+    .addOption(
+      new Option("--embedding <provider>", "embedding provider").choices([
+        "local",
+        "openai",
+        "supabase-edge",
+        "hash",
+      ])
+    )
+    .option("--yes", "accept detected defaults without prompting")
+    .option("--skip-migrate", "skip applying database migrations")
+    .option(
+      "--install-local-embedder",
+      "install the optional local embedding runtime"
+    )
+    .action(async (repository: string, opts) => {
+      setExit(
+        await runInit(
+          {
+            target: resolve(repository),
+            product: opts.product,
+            repoName: opts.repoName,
+            description: opts.description,
+            context: opts.context,
+            sourceRoots: opts.sourceRoot,
+            ignore: opts.ignore,
+            database: opts.offline
+              ? "offline"
+              : ((opts.database as DatabaseMode | undefined) ?? "offline"),
+            databaseExplicit: Boolean(opts.offline || opts.database),
+            embedding:
+              (opts.embedding as EmbeddingProvider | undefined) ??
+              resolveEmbeddingProvider(env),
+            embeddingExplicit: Boolean(opts.embedding),
+            yes: Boolean(opts.yes),
+            skipMigrate: Boolean(opts.skipMigrate),
+            installLocalEmbedder: Boolean(opts.installLocalEmbedder),
+          },
+          io,
+          env
+        )
+      );
+    });
+
+  program
+    .command("status")
+    .description("Show workspace, runtime, and contract status")
+    .argument("[repository]", "repository path", process.cwd())
+    .option("--json", "emit machine-readable JSON")
+    .action((repository: string, opts) => {
+      const status = statusFromPath(repository, env);
+      io.write(
+        opts.json
+          ? `${JSON.stringify(status, null, 2)}\n`
+          : `${renderStatus(status, paletteFor(io))}\n`
+      );
+    });
+
+  const contract = program
+    .command("contract")
+    .description("Validate, review, compile, and sync the living contract");
+  const contractAction = (
+    name: string,
+    description: string
+  ): Command => {
+    const sub = contract
+      .command(name)
+      .description(description)
+      .argument("[repository]", "repository path")
+      .option("--repo <key>", "stable repository key")
+      .option("--commit <sha>", "commit recorded in the manifest")
+      .option("--output <path>", "output path")
+      .option("--spec <dir>", "spec directory")
+      .option("--json", "emit machine-readable JSON");
+    sub.action(async (repository: string | undefined, opts) => {
+      const { runContractCommand } = await import("./commands/contract.js");
+      setExit(
+        await runContractCommand(
+          name as
+            | "validate"
+            | "review"
+            | "compile"
+            | "coverage"
+            | "sync",
+          { repository, ...(opts as ContractActionOptions) },
+          io
+        )
+      );
+    });
+    return sub;
   };
+  contractAction("validate", "Validate accepted contract YAML");
+  contractAction("review", "Render a browser review page");
+  contractAction("compile", "Compile the contract manifest");
+  contractAction("coverage", "Report evidence and mapping coverage");
+  contractAction("sync", "Sync the reviewed manifest to the database").option(
+    "--expected-previous-commit <sha>",
+    "guard against concurrent syncs"
+  );
+
+  program
+    .command("check")
+    .description("Evaluate semantic impact of changes against a base ref")
+    .argument("[repository]", "repository path")
+    .requiredOption("--base <ref>", "git base ref to diff against")
+    .option("--repo <key>", "stable repository key")
+    .option("--json", "emit machine-readable JSON")
+    .action(async (repository: string | undefined, opts) => {
+      const { runCheckCommand } = await import("./commands/check.js");
+      setExit(
+        await runCheckCommand(
+          {
+            base: opts.base,
+            repository,
+            repo: opts.repo,
+            json: Boolean(opts.json),
+          },
+          io
+        )
+      );
+    });
+
+  const profile = program
+    .command("profile")
+    .description("Manage stored search profiles");
+  profile
+    .command("list")
+    .description("List stored profiles")
+    .option("--json", "emit machine-readable JSON")
+    .action(async (opts) => {
+      const { runProfileListCommand } = await import(
+        "./commands/profile.js"
+      );
+      setExit(await runProfileListCommand({ json: Boolean(opts.json) }, io));
+    });
+  profile
+    .command("put")
+    .description("Store a profile definition")
+    .requiredOption("--key <key>", "profile key")
+    .requiredOption("--file <definition.json>", "profile definition file")
+    .requiredOption("--created-by <actor>", "actor recorded on the profile")
+    .action(async (opts) => {
+      const { runProfilePutCommand } = await import(
+        "./commands/profile.js"
+      );
+      setExit(
+        await runProfilePutCommand(
+          { key: opts.key, file: opts.file, createdBy: opts.createdBy },
+          io
+        )
+      );
+    });
+
+  program
+    .command("migrate")
+    .description("Apply or verify packaged database migrations")
+    .option("--verify", "verify without applying")
+    .action(async (opts) => {
+      const { runMigrateCommand } = await import("./commands/migrate.js");
+      setExit(await runMigrateCommand({ verify: Boolean(opts.verify) }));
+    });
+
+  program
+    .command("import-help")
+    .description("Import help articles from JSON or JSONL")
+    .argument("<input>", "articles.json or articles.jsonl")
+    .option("--batch-size <n>", "articles per batch (1-200)", "50")
+    .action(async (inputPath: string, opts) => {
+      const { runImportHelpCommand } = await import(
+        "./commands/import-help.js"
+      );
+      setExit(
+        await runImportHelpCommand(inputPath, {
+          batchSize: Number(opts.batchSize),
+        })
+      );
+    });
+
+  program
+    .command("serve")
+    .description("Run the Tieline MCP server")
+    .addOption(new Option("--http", "serve over HTTP").conflicts("stdio"))
+    .option("--stdio", "serve over stdio")
+    .action(async (opts) => {
+      const { runServeCommand } = await import("./commands/serve.js");
+      setExit(
+        await runServeCommand({
+          http: Boolean(opts.http),
+          stdio: Boolean(opts.stdio),
+        })
+      );
+    });
+
+  return program;
 }
 
 export async function runCli(
@@ -446,6 +585,18 @@ export async function runCli(
   io: TielineCliIO,
   env: NodeJS.ProcessEnv = process.env
 ): Promise<number> {
+  let exitCode = 0;
+  let commanderErr = "";
+  const program = buildProgram(
+    io,
+    env,
+    (code) => {
+      exitCode = code;
+    },
+    (message) => {
+      commanderErr += message;
+    }
+  );
   const [command, ...args] = argv;
   if (
     !command ||
@@ -453,7 +604,7 @@ export async function runCli(
     command === "--help" ||
     command === "-h"
   ) {
-    printHelp(io);
+    program.outputHelp();
     return 0;
   }
   loadWorkspaceProfileForCommand(
@@ -462,63 +613,100 @@ export async function runCli(
     env
   );
   await reloadRuntimeConfig(env);
+  try {
+    await program.parseAsync(argv, { from: "user" });
+    return exitCode;
+  } catch (error) {
+    if (error instanceof CommanderError) {
+      if (error.exitCode === 0) return 0;
+      if (error.code === "commander.help") {
+        io.error(commanderErr);
+        return error.exitCode || 1;
+      }
+      throw new Error(
+        (commanderErr.trim() || error.message).replace(/^error: /, "")
+      );
+    }
+    throw error;
+  }
+}
 
-  if (command === "init") return runInit(args, io, env);
-  if (command === "status") {
-    const parsed = parseStatusArgs(args);
-    const status = statusFromPath(parsed.path, env);
-    io.write(
-      parsed.json
-        ? `${JSON.stringify(status, null, 2)}\n`
-        : `${renderStatus(status)}\n`
+/**
+ * Buffers input lines so answers piped through stdin survive the gap
+ * between questions, and rejects (instead of letting the process exit
+ * silently) when input ends before an answer arrives.
+ */
+function createQuestioner(): {
+  question(message: string): Promise<string>;
+  close(): void;
+} {
+  let readline: Interface | undefined;
+  const buffered: string[] = [];
+  let waiter:
+    | { resolve: (line: string) => void; reject: (error: Error) => void }
+    | undefined;
+  let closed = false;
+  const endedEarly = () =>
+    new Error(
+      "Input ended before a response was received; pass flags or --yes for non-interactive runs."
     );
-    return 0;
-  }
-  if (command === "contract") {
-    const { runContractCommand } = await import("./commands/contract.js");
-    return runContractCommand(args, io);
-  }
-  if (command === "check") {
-    const { runCheckCommand } = await import("./commands/check.js");
-    return runCheckCommand(args, io);
-  }
-  if (command === "profile") {
-    const { runProfileCommand } = await import("./commands/profile.js");
-    return runProfileCommand(args, io);
-  }
-  if (command === "migrate") {
-    const { runMigrateCommand } = await import("./commands/migrate.js");
-    return runMigrateCommand(args);
-  }
-  if (command === "import-help") {
-    const { runImportHelpCommand } = await import(
-      "./commands/import-help.js"
-    );
-    return runImportHelpCommand(args);
-  }
-  if (command === "serve") {
-    const { runServeCommand } = await import("./commands/serve.js");
-    return runServeCommand(args);
-  }
-  throw new Error(`Unknown command '${command}'. Run \`tieline --help\`.`);
+  const ensure = (): void => {
+    if (readline) return;
+    readline = createInterface({ input, output });
+    readline.on("line", (line) => {
+      if (waiter) {
+        const current = waiter;
+        waiter = undefined;
+        current.resolve(line);
+      } else {
+        buffered.push(line);
+      }
+    });
+    readline.on("close", () => {
+      closed = true;
+      if (waiter) {
+        const current = waiter;
+        waiter = undefined;
+        current.reject(endedEarly());
+      }
+    });
+  };
+  return {
+    question(message) {
+      ensure();
+      output.write(message);
+      const line = buffered.shift();
+      if (line !== undefined) return Promise.resolve(line);
+      if (closed) return Promise.reject(endedEarly());
+      return new Promise((resolve, reject) => {
+        waiter = { resolve, reject };
+      });
+    },
+    close() {
+      readline?.close();
+    },
+  };
 }
 
 async function main(): Promise<void> {
-  const readline = createInterface({ input, output });
+  const interactive = Boolean(process.stdin.isTTY && process.stdout.isTTY);
+  const questioner = createQuestioner();
   const io: TielineCliIO = {
     write: (message) => process.stdout.write(message),
     error: (message) => process.stderr.write(message),
-    question: (message) => readline.question(message),
+    question: (message) => questioner.question(message),
+    interactive,
   };
   try {
     process.exitCode = await runCli(process.argv.slice(2), io);
   } catch (error) {
+    const ui = createPalette(interactive);
     io.error(
-      `Tieline error: ${error instanceof Error ? error.message : String(error)}\n`
+      `${ui.red("Tieline error:")} ${error instanceof Error ? error.message : String(error)}\n`
     );
     process.exitCode = 1;
   } finally {
-    readline.close();
+    questioner.close();
   }
 }
 

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -15,43 +15,23 @@ interface CheckIO {
   write(message: string): void;
 }
 
-function option(args: string[], name: string): string | undefined {
-  const inline = args.find((arg) => arg.startsWith(`--${name}=`));
-  if (inline) return inline.slice(name.length + 3);
-  const index = args.indexOf(`--${name}`);
-  return index >= 0 ? args[index + 1] : undefined;
-}
-
-function repositoryPath(args: string[]): string {
-  const valueOptions = new Set(["base", "repo"]);
-  for (let index = 0; index < args.length; index++) {
-    const arg = args[index]!;
-    if (!arg.startsWith("--")) {
-      if (index > 0 && valueOptions.has(args[index - 1]!.slice(2))) {
-        continue;
-      }
-      return arg;
-    }
-    if (!arg.includes("=") && valueOptions.has(arg.slice(2))) index++;
-  }
-  return process.cwd();
+export interface CheckCommandOptions {
+  base: string;
+  repository?: string;
+  repo?: string;
+  json?: boolean;
 }
 
 export async function runCheckCommand(
-  args: string[],
+  options: CheckCommandOptions,
   io: CheckIO
 ): Promise<number> {
-  const base = option(args, "base");
-  if (!base) {
-    throw new Error(
-      "Usage: tieline check --base <ref> [repository] [--json]"
-    );
-  }
-  const requestedRoot = resolve(repositoryPath(args));
+  const base = options.base;
+  const requestedRoot = resolve(options.repository ?? process.cwd());
   const workspace = findTielineWorkspace(requestedRoot);
   const root = workspace?.root ?? requestedRoot;
   const repositoryKey =
-    option(args, "repo") ??
+    options.repo ??
     workspace?.config.product.repo_name ??
     basename(root);
   const manifestPath =
@@ -108,7 +88,7 @@ export async function runCheckCommand(
         ),
     ],
   };
-  if (args.includes("--json")) {
+  if (options.json) {
     io.write(`${JSON.stringify(result, null, 2)}\n`);
   } else {
     io.write(

--- a/src/commands/contract.ts
+++ b/src/commands/contract.ts
@@ -30,8 +30,25 @@ interface ContractCommandIO {
   write(message: string): void;
 }
 
+export type ContractAction =
+  | "validate"
+  | "review"
+  | "compile"
+  | "coverage"
+  | "sync";
+
+export interface ContractCommandOptions {
+  repository?: string;
+  repo?: string;
+  commit?: string;
+  output?: string;
+  spec?: string;
+  expectedPreviousCommit?: string;
+  json?: boolean;
+}
+
 interface ParsedContractCommand {
-  action: "validate" | "review" | "compile" | "coverage" | "sync";
+  action: ContractAction;
   repositoryRoot: string;
   repositoryKey: string;
   commit?: string;
@@ -41,14 +58,6 @@ interface ParsedContractCommand {
   ignore: string[];
   expectedPreviousCommit?: string;
   json: boolean;
-}
-
-function valueAfter(args: string[], index: number, name: string): string {
-  const value = args[index + 1];
-  if (!value || value.startsWith("--")) {
-    throw new Error(`--${name} requires a value.`);
-  }
-  return value;
 }
 
 function gitCommit(repositoryRoot: string): string {
@@ -65,74 +74,26 @@ function gitCommit(repositoryRoot: string): string {
   }
 }
 
-function parseContractCommand(args: string[]): ParsedContractCommand {
-  const action = args[0];
-  if (
-    action !== "validate" &&
-    action !== "review" &&
-    action !== "compile" &&
-    action !== "coverage" &&
-    action !== "sync"
-  ) {
-    throw new Error(
-      "Usage: tieline contract <validate|review|compile|coverage|sync> [repository] [options]"
-    );
-  }
-
-  let repositoryPath: string | undefined;
-  let repositoryKey: string | undefined;
-  let commit: string | undefined;
-  let outputPath: string | undefined;
-  let specDirectory: string | undefined;
-  let expectedPreviousCommit: string | undefined;
-  let json = false;
-
-  for (let index = 1; index < args.length; index++) {
-    const arg = args[index]!;
-    if (arg === "--json") {
-      json = true;
-      continue;
-    }
-    if (!arg.startsWith("--")) {
-      if (repositoryPath) {
-        throw new Error("contract commands accept at most one repository path.");
-      }
-      repositoryPath = arg;
-      continue;
-    }
-    const [rawName, inlineValue] = arg.slice(2).split("=", 2);
-    const name = rawName;
-    if (
-      name !== "repo" &&
-      name !== "commit" &&
-      name !== "output" &&
-      name !== "spec" &&
-      name !== "expected-previous-commit"
-    ) {
-      throw new Error(`Unknown contract option: --${name}`);
-    }
-    const value = inlineValue ?? valueAfter(args, index, name);
-    if (inlineValue === undefined) index++;
-    if (name === "repo") repositoryKey = value;
-    if (name === "commit") commit = value;
-    if (name === "output") outputPath = value;
-    if (name === "spec") specDirectory = value;
-    if (name === "expected-previous-commit") expectedPreviousCommit = value;
-  }
-
-  const requestedRoot = resolve(repositoryPath ?? process.cwd());
+function resolveContractCommand(
+  action: ContractAction,
+  options: ContractCommandOptions
+): ParsedContractCommand {
+  const requestedRoot = resolve(options.repository ?? process.cwd());
   const workspace = findTielineWorkspace(requestedRoot);
   const repositoryRoot = workspace?.root ?? requestedRoot;
-  repositoryKey ??= workspace?.config.product.repo_name ?? basename(repositoryRoot);
-  specDirectory ??= workspace
-    ? workspace.config.files.spec_directory.startsWith(".tieline/")
-      ? workspace.config.files.spec_directory
-      : `.tieline/${workspace.config.files.spec_directory}`
-    : ".tieline/spec";
-  const resolvedOutput = outputPath
-    ? isAbsolute(outputPath)
-      ? outputPath
-      : resolve(repositoryRoot, outputPath)
+  const repositoryKey =
+    options.repo ?? workspace?.config.product.repo_name ?? basename(repositoryRoot);
+  const specDirectory =
+    options.spec ??
+    (workspace
+      ? workspace.config.files.spec_directory.startsWith(".tieline/")
+        ? workspace.config.files.spec_directory
+        : `.tieline/${workspace.config.files.spec_directory}`
+      : ".tieline/spec");
+  const resolvedOutput = options.output
+    ? isAbsolute(options.output)
+      ? options.output
+      : resolve(repositoryRoot, options.output)
     : resolve(
         repositoryRoot,
         action === "review" ? ".tieline/review.html" : ".tieline/manifest.json"
@@ -141,13 +102,13 @@ function parseContractCommand(args: string[]): ParsedContractCommand {
     action,
     repositoryRoot,
     repositoryKey,
-    commit,
+    commit: options.commit,
     outputPath: resolvedOutput,
     specDirectory,
     sourceRoots: workspace?.config.repository.source_roots ?? ["src"],
     ignore: workspace?.config.repository.ignore ?? [],
-    expectedPreviousCommit,
-    json,
+    expectedPreviousCommit: options.expectedPreviousCommit,
+    json: options.json === true,
   };
 }
 
@@ -176,10 +137,11 @@ function coverage(manifest: ContractManifest): {
 }
 
 export async function runContractCommand(
-  args: string[],
+  action: ContractAction,
+  options: ContractCommandOptions,
   io: ContractCommandIO
 ): Promise<number> {
-  const parsed = parseContractCommand(args);
+  const parsed = resolveContractCommand(action, options);
   if (parsed.action === "validate") {
     const result = loadAcceptedContract(parsed.repositoryRoot, parsed.specDirectory);
     const response = {

--- a/src/commands/import-help.ts
+++ b/src/commands/import-help.ts
@@ -25,17 +25,13 @@ function parseInput(path: string): ReturnType<typeof helpArticleImportPayloadSch
   return helpArticleImportPayloadSchema.parse(JSON.parse(body));
 }
 
-export async function runImportHelpCommand(args: string[]): Promise<number> {
-  const batchIndex = args.indexOf("--batch-size");
-  const batchSize = batchIndex >= 0 ? Number(args[batchIndex + 1]) : 50;
+export async function runImportHelpCommand(
+  input: string,
+  options: { batchSize: number }
+): Promise<number> {
+  const batchSize = options.batchSize;
   if (!Number.isInteger(batchSize) || batchSize < 1 || batchSize > 200) {
     throw new Error("--batch-size must be an integer from 1 to 200.");
-  }
-  const input = args.find(
-    (arg, index) => !arg.startsWith("--") && args[index - 1] !== "--batch-size"
-  );
-  if (!input) {
-    throw new Error("Usage: tieline import-help path/to/articles.json[|jsonl] [--batch-size 50]");
   }
   const path = resolve(process.cwd(), input);
   if (!existsSync(path)) throw new Error(`Not found: ${path}`);

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -94,16 +94,14 @@ export async function migrateDatabase(dbUrl: string, verifyOnly = false): Promis
   }
 }
 
-export async function runMigrateCommand(args: string[]): Promise<number> {
-  const unknown = args.filter((arg) => arg !== "--verify");
-  if (unknown.length > 0) {
-    throw new Error(`Unknown migrate option '${unknown[0]}'. Usage: tieline migrate [--verify]`);
-  }
+export async function runMigrateCommand(options: {
+  verify?: boolean;
+}): Promise<number> {
   if (!config.dbAdminUrl) {
     throw new Error(
       "Set DATABASE_URL_ADMIN to the database owner used for DDL; the MCP server never loads this connection."
     );
   }
-  await migrateDatabase(config.dbAdminUrl, args.includes("--verify"));
+  await migrateDatabase(config.dbAdminUrl, options.verify === true);
   return 0;
 }

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -7,56 +7,44 @@ interface ProfileIO {
   write(message: string): void;
 }
 
-function value(args: string[], name: string): string | undefined {
-  const inline = args.find((arg) => arg.startsWith(`--${name}=`));
-  if (inline) return inline.slice(name.length + 3);
-  const index = args.indexOf(`--${name}`);
-  return index >= 0 ? args[index + 1] : undefined;
-}
-
-export async function runProfileCommand(
-  args: string[],
+export async function runProfileListCommand(
+  options: { json?: boolean },
   io: ProfileIO
 ): Promise<number> {
-  const action = args[0];
   const repository = new PostgresProfileRepository();
   try {
-    if (action === "list") {
-      const profiles = await repository.listProfiles();
-      if (args.includes("--json")) {
-        io.write(`${JSON.stringify({ profiles }, null, 2)}\n`);
-      } else {
-        for (const profile of profiles) {
-          io.write(
-            `${profile.key}@${profile.version}${profile.active ? " active" : ""} (${profile.created_by})\n`
-          );
-        }
-      }
-      return 0;
-    }
-    if (action === "put") {
-      const key = value(args, "key");
-      const file = value(args, "file");
-      const createdBy = value(args, "created-by");
-      if (!key || !file || !createdBy) {
-        throw new Error(
-          "Usage: tieline profile put --key <key> --file <definition.json> --created-by <actor>"
+    const profiles = await repository.listProfiles();
+    if (options.json) {
+      io.write(`${JSON.stringify({ profiles }, null, 2)}\n`);
+    } else {
+      for (const profile of profiles) {
+        io.write(
+          `${profile.key}@${profile.version}${profile.active ? " active" : ""} (${profile.created_by})\n`
         );
       }
-      const definition = JSON.parse(
-        readFileSync(resolve(file), "utf8")
-      ) as unknown;
-      const profile = await repository.putProfile({
-        key,
-        definition,
-        created_by: createdBy,
-      });
-      io.write(`${JSON.stringify({ profile }, null, 2)}\n`);
-      return 0;
     }
-    throw new Error(
-      "Usage: tieline profile <list|put> [options]"
-    );
+    return 0;
+  } finally {
+    await closeConnections();
+  }
+}
+
+export async function runProfilePutCommand(
+  options: { key: string; file: string; createdBy: string },
+  io: ProfileIO
+): Promise<number> {
+  const repository = new PostgresProfileRepository();
+  try {
+    const definition = JSON.parse(
+      readFileSync(resolve(options.file), "utf8")
+    ) as unknown;
+    const profile = await repository.putProfile({
+      key: options.key,
+      definition,
+      created_by: options.createdBy,
+    });
+    io.write(`${JSON.stringify({ profile }, null, 2)}\n`);
+    return 0;
   } finally {
     await closeConnections();
   }

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -2,14 +2,13 @@ import { config } from "../config.js";
 import { runHttp } from "../http.js";
 import { runStdio } from "../stdio.js";
 
-export async function runServeCommand(args: string[]): Promise<number> {
-  const unknown = args.filter((arg) => arg !== "--http" && arg !== "--stdio");
-  if (unknown.length > 0 || (args.includes("--http") && args.includes("--stdio"))) {
-    throw new Error("Usage: tieline serve [--http|--stdio]");
-  }
-  const transport = args.includes("--http")
+export async function runServeCommand(options: {
+  http?: boolean;
+  stdio?: boolean;
+}): Promise<number> {
+  const transport = options.http
     ? "http"
-    : args.includes("--stdio")
+    : options.stdio
       ? "stdio"
       : config.transport;
   if (transport === "http") await runHttp();


### PR DESCRIPTION
## Why

The CLI's onboarding/maintenance UX was bare: hand-rolled argv loops in every command module, plain `readline` prompts, a single monolithic help screen, and no color or interactive affordances. It also had a real bug: answers piped to `tieline init` could be dropped between questions, making the process **exit 0 silently without creating anything**.

## What

- **commander v14 migration** — all dispatch/parsing moves to declared commands: options with `choices`/`conflicts`/`requiredOption`, per-command `--help`, global `--version`. Command modules (`check`, `contract`, `profile`, `migrate`, `import-help`, `serve`) now take typed options objects instead of raw argv. `runCli(argv, io, env)` and `workspaceStartForCommand` keep their exact signatures for the test harness.
- **@clack/prompts + picocolors** — interactive `tieline init` gets styled prompts with detected defaults; `status`/warnings/errors get TTY-only color. Everything is gated on a real terminal: piped, CI, agent, and MCP output stays byte-identical to before (`--json` untouched), and `NO_COLOR` is respected.
- **ASCII logo banner** — diamond mark + dotted band + figlet wordmark echoing the Tieline logo, shown on root help and interactive init only (subcommand help stays scannable; `serve` never prints it).
- **stdin questioner fix** — line-buffering questioner replaces `readline/promises.question`: piped answers arriving between questions are preserved, and EOF before an answer exits 1 with `Input ended before a response was received` instead of silently exiting 0.
- **Clean group-command errors** — bare `tieline contract`/`tieline profile` now print usage on stderr (exit 1) rather than a `Tieline error:`-prefixed help dump.
- **engines `>=18` -> `>=20.12`** — forced by `@clack/core`; Node 18 has been EOL since April 2025. README updated. Worth a version bump before the next npm publish.

## Verification

- `test:tieline`, `test:contract` (contract/manifest/contract-command), `test:impact`, `test:smoke` all pass.
- New spawn-based tests cover the questioner (piped answers land in config; EOF exits 1 with the message) and bare-group help output.
- Manually exercised: root/subcommand help, `--version`, piped and `--yes` init, empty-stdin init, pseudo-TTY Clack rendering, conflict/missing-option/unknown-command error paths.
- Reviewed by a 5-agent code review (correctness, testing, maintainability, api-contract, adversarial on Opus) plus an independent cross-model Codex adversarial pass (0 findings); both validated findings are fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)