### PR TITLE
feat(contract): deterministic path→AC lookup, and impact reporting that isn't a warning

### DIFF
--- a/.tieline/manifest.json
+++ b/.tieline/manifest.json
@@ -360,7 +360,7 @@
               "links": [
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "4accf0d836fbc53f74c7a25e860e143f025ee50a4e85b10c17ff4843494b3680",
+                  "reviewed_content_hash": "5b56bcf9b0533c94b8b849d4fa5547c2fee17bb7b4a9930b2600a997e7f32f10",
                   "target": {
                     "kind": "code",
                     "path": "src/commands/contract.ts",
@@ -369,7 +369,7 @@
                 },
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "59a9695169dcaac4adaac44db5b1f8ad40aed2e8e601651b6cda94d27310490b",
+                  "reviewed_content_hash": "a36ec3869e7df6c1dd69243bfded039fdcbc18e78ed8128d132f3fa275859920",
                   "target": {
                     "kind": "code",
                     "path": "src/contract/coverage.ts",
@@ -445,7 +445,7 @@
               "links": [
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "e7e0d826c539a3fbfc45707b67b19ffc0ef1f8ca294bcfa7d49797385a273de1",
+                  "reviewed_content_hash": "c0b689511931732315355ab3d2fc1daf78e610efc5f16f2da54dceeca691b21b",
                   "target": {
                     "kind": "code",
                     "path": "src/commands/check.ts",
@@ -463,7 +463,7 @@
                 },
                 {
                   "relation": "tests",
-                  "reviewed_content_hash": "9a25bcdf8fcdf2c92fd4e73ca64d14363ea9227279db89dde05a9f3de7f572a6",
+                  "reviewed_content_hash": "e4a7aae59a27a0422ff12d9b0529d5719c1f91348fc9add539500f54541c01fc",
                   "target": {
                     "framework_hint": "custom-script",
                     "kind": "test",
@@ -494,7 +494,7 @@
               "links": [
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "4accf0d836fbc53f74c7a25e860e143f025ee50a4e85b10c17ff4843494b3680",
+                  "reviewed_content_hash": "5b56bcf9b0533c94b8b849d4fa5547c2fee17bb7b4a9930b2600a997e7f32f10",
                   "target": {
                     "kind": "code",
                     "path": "src/commands/contract.ts",
@@ -535,7 +535,7 @@
               "links": [
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "e7e0d826c539a3fbfc45707b67b19ffc0ef1f8ca294bcfa7d49797385a273de1",
+                  "reviewed_content_hash": "c0b689511931732315355ab3d2fc1daf78e610efc5f16f2da54dceeca691b21b",
                   "target": {
                     "kind": "code",
                     "path": "src/commands/check.ts",
@@ -544,7 +544,7 @@
                 },
                 {
                   "relation": "tests",
-                  "reviewed_content_hash": "9a25bcdf8fcdf2c92fd4e73ca64d14363ea9227279db89dde05a9f3de7f572a6",
+                  "reviewed_content_hash": "e4a7aae59a27a0422ff12d9b0529d5719c1f91348fc9add539500f54541c01fc",
                   "target": {
                     "framework_hint": "custom-script",
                     "kind": "test",
@@ -566,6 +566,46 @@
               ],
               "stable_id": "CONTRACT-001-AC5",
               "supersedes": null
+            },
+            {
+              "aliases": [],
+              "applies_to": null,
+              "contract_hash": "479efb1627488aaf8daa092c99498b31dbb596699e6becaffd95faae28de2226",
+              "criterion": "The check report must label affected Acceptance Criteria as impact rather than as warnings, and must reserve warnings for findings that require an action.",
+              "links": [
+                {
+                  "relation": "implements",
+                  "reviewed_content_hash": "c0b689511931732315355ab3d2fc1daf78e610efc5f16f2da54dceeca691b21b",
+                  "target": {
+                    "kind": "code",
+                    "path": "src/commands/check.ts",
+                    "repository": "tieline"
+                  }
+                },
+                {
+                  "relation": "tests",
+                  "reviewed_content_hash": "e4a7aae59a27a0422ff12d9b0529d5719c1f91348fc9add539500f54541c01fc",
+                  "target": {
+                    "framework_hint": "custom-script",
+                    "kind": "test",
+                    "path": "scripts/test-impact.ts",
+                    "repository": "tieline"
+                  }
+                }
+              ],
+              "position": 5,
+              "rationale": "Impacts answer which behavior a change touches, which is orientation rather than a defect. Labelling orientation as a warning trains every reader to skip the stream, so the warnings that do require an action stop being read.",
+              "scenarios": [
+                {
+                  "given": "a change modifies linked paths while the committed manifest is stale",
+                  "position": 0,
+                  "stable_id": "CONTRACT-001-AC6-S1",
+                  "then": "affected Acceptance Criteria must be reported as impact and exactly one warning must name the stale manifest",
+                  "when": "the branch is checked against its base"
+                }
+              ],
+              "stable_id": "CONTRACT-001-AC6",
+              "supersedes": null
             }
           ],
           "actor": "maintainer",
@@ -583,6 +623,163 @@
           "stable_id": "CONTRACT-001",
           "supersedes": null,
           "title": "Review accepted behavior with code"
+        },
+        {
+          "acceptance_criteria": [
+            {
+              "aliases": [],
+              "applies_to": null,
+              "contract_hash": "535d57e5b1a1b13bb4567920ceb7379774edebbecf1684121a386ddfc9c6376c",
+              "criterion": "Tieline must report every acceptance criterion that links a repository-relative path, must distinguish a link carried by the acceptance criterion itself from one carried only by its Story, and must state explicitly when no acceptance criterion governs the path.",
+              "links": [
+                {
+                  "relation": "implements",
+                  "reviewed_content_hash": "3cc8eaa48b25ca107f8998e69bc4be6a6e4dba492b87193cfa54acbaa14babb7",
+                  "target": {
+                    "kind": "code",
+                    "path": "src/cli.ts",
+                    "repository": "tieline"
+                  }
+                },
+                {
+                  "relation": "implements",
+                  "reviewed_content_hash": "5b56bcf9b0533c94b8b849d4fa5547c2fee17bb7b4a9930b2600a997e7f32f10",
+                  "target": {
+                    "kind": "code",
+                    "path": "src/commands/contract.ts",
+                    "repository": "tieline"
+                  }
+                },
+                {
+                  "relation": "implements",
+                  "reviewed_content_hash": "b2cd7fe8014d2da5e66f35edf0cd2f2199c61608d5d4eaf911943ff3b49778f8",
+                  "target": {
+                    "kind": "code",
+                    "path": "src/contract/governs.ts",
+                    "repository": "tieline"
+                  }
+                },
+                {
+                  "relation": "tests",
+                  "reviewed_content_hash": "f294a5750d0bfa2cc62f24873d5f5527230b72ae19f32c6e2a64c41d047f6c01",
+                  "target": {
+                    "framework_hint": "custom-script",
+                    "kind": "test",
+                    "path": "scripts/test-governs.ts",
+                    "repository": "tieline"
+                  }
+                }
+              ],
+              "position": 0,
+              "rationale": "Coverage answers for the whole contract and check answers for a diff, so both describe a violation that already exists; the pre-change question is the only one that can prevent it. An empty array reads to an agent like a failed query rather than the finding that the code is ungoverned.",
+              "scenarios": [
+                {
+                  "given": "a path is linked by one acceptance criterion and by the Story that owns it",
+                  "position": 0,
+                  "stable_id": "CONTRACT-002-AC1-S1",
+                  "then": "Tieline must return both records and mark them direct and story_fallback",
+                  "when": "the governing criteria for that path are requested"
+                },
+                {
+                  "given": "a path exists in the repository and no contract link targets it",
+                  "position": 1,
+                  "stable_id": "CONTRACT-002-AC1-S2",
+                  "then": "Tieline must state that no acceptance criterion governs it instead of returning an empty result",
+                  "when": "the governing criteria for that path are requested"
+                },
+                {
+                  "given": "a requested path does not exist in the repository",
+                  "position": 2,
+                  "stable_id": "CONTRACT-002-AC1-S3",
+                  "then": "Tieline must report it distinctly from a path that exists but is ungoverned",
+                  "when": "the governing criteria for that path are requested"
+                }
+              ],
+              "stable_id": "CONTRACT-002-AC1",
+              "supersedes": null
+            },
+            {
+              "aliases": [],
+              "applies_to": null,
+              "contract_hash": "8952c5f5243c393d8f89cdf45bf5e45b4f0ca104092637ac3e4fc080b75cefcf",
+              "criterion": "The governing-criteria lookup must answer from the compiled manifest alone, so Tieline must serve it over MCP with no database connection and must return a named, actionable message when no workspace or no readable manifest is found.",
+              "links": [
+                {
+                  "relation": "implements",
+                  "reviewed_content_hash": "6b3cf988e40ffa79a35f13c4a711083721c55b17332168b5d1eae11b3c8b1db3",
+                  "target": {
+                    "kind": "code",
+                    "path": "src/schemas.ts",
+                    "repository": "tieline"
+                  }
+                },
+                {
+                  "relation": "implements",
+                  "reviewed_content_hash": "c05b58f1fd2112c109b99a21ebd164a3bd2992935e6273daed2669ee9376d99a",
+                  "target": {
+                    "kind": "code",
+                    "path": "src/server.ts",
+                    "repository": "tieline"
+                  }
+                },
+                {
+                  "relation": "implements",
+                  "reviewed_content_hash": "269c2d7d6600a081299e8c1fc64a0911cd9951f97573b1838513864912eb3eb5",
+                  "target": {
+                    "kind": "code",
+                    "path": "src/tools/governing-criteria.ts",
+                    "repository": "tieline"
+                  }
+                },
+                {
+                  "relation": "tests",
+                  "reviewed_content_hash": "f294a5750d0bfa2cc62f24873d5f5527230b72ae19f32c6e2a64c41d047f6c01",
+                  "target": {
+                    "framework_hint": "custom-script",
+                    "kind": "test",
+                    "path": "scripts/test-governs.ts",
+                    "repository": "tieline"
+                  }
+                }
+              ],
+              "position": 1,
+              "rationale": "Every other MCP tool fails at call time without Postgres, so an offline server boots and answers nothing; a manifest-backed lookup is what makes serving without a database worth doing, and an obscure throw would waste the one answer the caller came for.",
+              "scenarios": [
+                {
+                  "given": "no database connection is configured",
+                  "position": 0,
+                  "stable_id": "CONTRACT-002-AC2-S1",
+                  "then": "Tieline must return the governing acceptance criteria and the commit the manifest records",
+                  "when": "the governing criteria for a path are requested over MCP"
+                },
+                {
+                  "given": "the server runs outside any Tieline workspace",
+                  "position": 1,
+                  "stable_id": "CONTRACT-002-AC2-S2",
+                  "then": "Tieline must name the missing workspace and the command that creates one",
+                  "when": "the governing criteria for a path are requested"
+                }
+              ],
+              "stable_id": "CONTRACT-002-AC2",
+              "supersedes": null
+            }
+          ],
+          "actor": "implementing agent",
+          "aliases": [
+            "path to acceptance criterion lookup",
+            "what contract governs this file"
+          ],
+          "applies_to": null,
+          "benefit": "a contradiction with accepted behavior is prevented instead of reported afterwards",
+          "contract_hash": "6dad533763a01c828684752720fd481eae6953071e7af5517b4d66b95564e1cd",
+          "goal": "resolve a repository path to the accepted behavior that already governs it",
+          "lifecycle": "production",
+          "links": [],
+          "motivated_by": [],
+          "planning_origin": null,
+          "stable_id": "CONTRACT-002",
+          "supersedes": null,
+          "title": "Learn which acceptance criteria govern a path before editing it"
         }
       ],
       "supersedes": null
@@ -847,7 +1044,7 @@
               "links": [
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "a5b8edb820ff25581f2b440a0fcddd28b85c0f3c88d8855f0b67f283c04d7188",
+                  "reviewed_content_hash": "3cc8eaa48b25ca107f8998e69bc4be6a6e4dba492b87193cfa54acbaa14babb7",
                   "target": {
                     "kind": "code",
                     "path": "src/cli.ts",
@@ -856,7 +1053,7 @@
                 },
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "4accf0d836fbc53f74c7a25e860e143f025ee50a4e85b10c17ff4843494b3680",
+                  "reviewed_content_hash": "5b56bcf9b0533c94b8b849d4fa5547c2fee17bb7b4a9930b2600a997e7f32f10",
                   "target": {
                     "kind": "code",
                     "path": "src/commands/contract.ts",
@@ -959,7 +1156,7 @@
               "links": [
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "4accf0d836fbc53f74c7a25e860e143f025ee50a4e85b10c17ff4843494b3680",
+                  "reviewed_content_hash": "5b56bcf9b0533c94b8b849d4fa5547c2fee17bb7b4a9930b2600a997e7f32f10",
                   "target": {
                     "kind": "code",
                     "path": "src/commands/contract.ts",
@@ -1099,7 +1296,7 @@
               "links": [
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "4accf0d836fbc53f74c7a25e860e143f025ee50a4e85b10c17ff4843494b3680",
+                  "reviewed_content_hash": "5b56bcf9b0533c94b8b849d4fa5547c2fee17bb7b4a9930b2600a997e7f32f10",
                   "target": {
                     "kind": "code",
                     "path": "src/commands/contract.ts",
@@ -1573,7 +1770,7 @@
                 },
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "d7182ff744107d5928f55990a4f678988c3946c0f939518a4f865ce86f04478b",
+                  "reviewed_content_hash": "6b3cf988e40ffa79a35f13c4a711083721c55b17332168b5d1eae11b3c8b1db3",
                   "target": {
                     "kind": "code",
                     "path": "src/schemas.ts",
@@ -1736,7 +1933,7 @@
               "links": [
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "a5b8edb820ff25581f2b440a0fcddd28b85c0f3c88d8855f0b67f283c04d7188",
+                  "reviewed_content_hash": "3cc8eaa48b25ca107f8998e69bc4be6a6e4dba492b87193cfa54acbaa14babb7",
                   "target": {
                     "kind": "code",
                     "path": "src/cli.ts",
@@ -1845,7 +2042,7 @@
               "links": [
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "a5b8edb820ff25581f2b440a0fcddd28b85c0f3c88d8855f0b67f283c04d7188",
+                  "reviewed_content_hash": "3cc8eaa48b25ca107f8998e69bc4be6a6e4dba492b87193cfa54acbaa14babb7",
                   "target": {
                     "kind": "code",
                     "path": "src/cli.ts",
@@ -1939,7 +2136,7 @@
                 },
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "bad9efc78294bf27618ec982da3b940382dae6d29f320c4f734aebf60b2ba118",
+                  "reviewed_content_hash": "c05b58f1fd2112c109b99a21ebd164a3bd2992935e6273daed2669ee9376d99a",
                   "target": {
                     "kind": "code",
                     "path": "src/server.ts",
@@ -2107,7 +2304,7 @@
                 },
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "bad9efc78294bf27618ec982da3b940382dae6d29f320c4f734aebf60b2ba118",
+                  "reviewed_content_hash": "c05b58f1fd2112c109b99a21ebd164a3bd2992935e6273daed2669ee9376d99a",
                   "target": {
                     "kind": "code",
                     "path": "src/server.ts",
@@ -2217,7 +2414,7 @@
     },
     {
       "path": ".tieline/spec/contract.yaml",
-      "sha256": "493826fe82dbd079066f7298bfee74b6f18451808b9c0001e7d3ff9c2552d850"
+      "sha256": "5e0dcc14e9c5773a209bad9c16e3ceee5ac832a39740297d423e39f54e1c48cb"
     },
     {
       "path": ".tieline/spec/evidence.yaml",
@@ -2241,7 +2438,7 @@
     }
   ],
   "repository": {
-    "commit": "42b630d161ac705b30b0bbe6e6a478da6f602b79",
+    "commit": "4ab67c9fed8c4d3ccd3fca6e5963c96699fb2bc2",
     "key": "tieline"
   },
   "schema_version": 1

--- a/.tieline/spec/contract.yaml
+++ b/.tieline/spec/contract.yaml
@@ -152,3 +152,99 @@ capability:
                 repository: tieline
                 path: scripts/test-impact.ts
                 framework_hint: custom-script
+        - key: CONTRACT-001-AC6
+          criterion: The check report must label affected Acceptance Criteria as impact rather than as warnings, and must reserve warnings for findings that require an action.
+          rationale: Impacts answer which behavior a change touches, which is orientation rather than a defect. Labelling orientation as a warning trains every reader to skip the stream, so the warnings that do require an action stop being read.
+          scenarios:
+            - given: a change modifies linked paths while the committed manifest is stale
+              when: the branch is checked against its base
+              then: affected Acceptance Criteria must be reported as impact and exactly one warning must name the stale manifest
+          links:
+            - relation: implements
+              target:
+                kind: code
+                repository: tieline
+                path: src/commands/check.ts
+            - relation: tests
+              target:
+                kind: test
+                repository: tieline
+                path: scripts/test-impact.ts
+                framework_hint: custom-script
+    - key: CONTRACT-002
+      title: Learn which acceptance criteria govern a path before editing it
+      actor: implementing agent
+      goal: resolve a repository path to the accepted behavior that already governs it
+      benefit: a contradiction with accepted behavior is prevented instead of reported afterwards
+      lifecycle: production
+      aliases:
+        - what contract governs this file
+        - path to acceptance criterion lookup
+      acceptance_criteria:
+        - key: CONTRACT-002-AC1
+          criterion: Tieline must report every acceptance criterion that links a repository-relative path, must distinguish a link carried by the acceptance criterion itself from one carried only by its Story, and must state explicitly when no acceptance criterion governs the path.
+          rationale: Coverage answers for the whole contract and check answers for a diff, so both describe a violation that already exists; the pre-change question is the only one that can prevent it. An empty array reads to an agent like a failed query rather than the finding that the code is ungoverned.
+          scenarios:
+            - given: a path is linked by one acceptance criterion and by the Story that owns it
+              when: the governing criteria for that path are requested
+              then: Tieline must return both records and mark them direct and story_fallback
+            - given: a path exists in the repository and no contract link targets it
+              when: the governing criteria for that path are requested
+              then: Tieline must state that no acceptance criterion governs it instead of returning an empty result
+            - given: a requested path does not exist in the repository
+              when: the governing criteria for that path are requested
+              then: Tieline must report it distinctly from a path that exists but is ungoverned
+          links:
+            - relation: implements
+              target:
+                kind: code
+                repository: tieline
+                path: src/contract/governs.ts
+            - relation: implements
+              target:
+                kind: code
+                repository: tieline
+                path: src/commands/contract.ts
+            - relation: implements
+              target:
+                kind: code
+                repository: tieline
+                path: src/cli.ts
+            - relation: tests
+              target:
+                kind: test
+                repository: tieline
+                path: scripts/test-governs.ts
+                framework_hint: custom-script
+        - key: CONTRACT-002-AC2
+          criterion: The governing-criteria lookup must answer from the compiled manifest alone, so Tieline must serve it over MCP with no database connection and must return a named, actionable message when no workspace or no readable manifest is found.
+          rationale: Every other MCP tool fails at call time without Postgres, so an offline server boots and answers nothing; a manifest-backed lookup is what makes serving without a database worth doing, and an obscure throw would waste the one answer the caller came for.
+          scenarios:
+            - given: no database connection is configured
+              when: the governing criteria for a path are requested over MCP
+              then: Tieline must return the governing acceptance criteria and the commit the manifest records
+            - given: the server runs outside any Tieline workspace
+              when: the governing criteria for a path are requested
+              then: Tieline must name the missing workspace and the command that creates one
+          links:
+            - relation: implements
+              target:
+                kind: code
+                repository: tieline
+                path: src/tools/governing-criteria.ts
+            - relation: implements
+              target:
+                kind: code
+                repository: tieline
+                path: src/server.ts
+            - relation: implements
+              target:
+                kind: code
+                repository: tieline
+                path: src/schemas.ts
+            - relation: tests
+              target:
+                kind: test
+                repository: tieline
+                path: scripts/test-governs.ts
+                framework_hint: custom-script

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "test:contract-command": "tsx scripts/test-contract-command.ts",
     "test:contract-read": "tsx scripts/test-contract-read.ts",
     "test:impact": "tsx scripts/test-impact.ts",
+    "test:governs": "tsx scripts/test-governs.ts",
     "test:symbol-vocabulary": "tsx scripts/test-symbol-vocabulary.ts",
     "test:grade": "tsx scripts/test-grade.ts",
     "test:evidence": "tsx scripts/test-evidence.ts",

--- a/scripts/test-governs.ts
+++ b/scripts/test-governs.ts
@@ -1,0 +1,547 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  buildGoverningCriteriaIndex,
+  lookupGoverningCriteria,
+  type GoverningCriterion,
+} from "../src/contract/governs.js";
+import { computeRepositoryMappingCoverage } from "../src/contract/coverage.js";
+import {
+  compileContractManifest,
+  serializeContractManifest,
+  type ContractManifest,
+} from "../src/contract/manifest.js";
+import {
+  registerGetGoverningCriteria,
+  resolveGoverningCriteria,
+} from "../src/tools/governing-criteria.js";
+import type { ToolResult } from "../src/tools/shared.js";
+import { setStore, type KnowledgeStore } from "../src/store.js";
+import { runCli, type TielineCliIO } from "../src/cli.js";
+
+// Every scenario below must hold with no database reachable at all.
+for (const key of [
+  "DATABASE_URL",
+  "DATABASE_URL_WRITE",
+  "DATABASE_URL_SYNC",
+  "DATABASE_URL_ADMIN",
+]) {
+  delete process.env[key];
+}
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function workspaceConfig(repoName: string): string {
+  return `${JSON.stringify(
+    {
+      version: 1,
+      product: { name: "Governs fixture", repo_name: repoName },
+      repository: {
+        root: "..",
+        source_roots: ["src"],
+        ignore: [".git", ".tieline"],
+      },
+      context: { sources: [] },
+      runtime: {
+        default_embedding_provider: "hash",
+        default_database_mode: "offline",
+      },
+      files: {
+        spec_directory: "spec",
+        manifest: "manifest.json",
+        mcp_config: "mcp.json",
+      },
+      created_at: "2026-08-01T00:00:00.000Z",
+      updated_at: "2026-08-01T00:00:00.000Z",
+    },
+    null,
+    2
+  )}\n`;
+}
+
+const SPEC = `version: 1
+capability:
+  key: GOVERNS
+  name: Governing criteria lookup
+  description: A repository path resolves to the accepted behavior that governs it.
+  stories:
+    - key: GOVERNS-001
+      title: Look up governing criteria
+      actor: implementing agent
+      goal: know which criteria govern a path before editing it
+      benefit: a contradiction is prevented instead of reported afterwards
+      lifecycle: production
+      links:
+        - relation: implements
+          target:
+            kind: code
+            repository: governs-fixture
+            path: src/story-only.ts
+        - relation: implements
+          target:
+            kind: code
+            repository: governs-fixture
+            path: src/shared.ts
+      acceptance_criteria:
+        - key: GOVERNS-001-AC1
+          criterion: Tieline must return the acceptance criterion that links a path.
+          links:
+            - relation: implements
+              target:
+                kind: code
+                repository: governs-fixture
+                path: src/direct.ts
+            - relation: implements
+              target:
+                kind: code
+                repository: governs-fixture
+                path: src/shared.ts
+            - relation: implements
+              target:
+                kind: code
+                repository: other-repository
+                path: src/elsewhere.ts
+            - relation: documents
+              target:
+                kind: help
+                source: docs
+                external_id: governs-guide
+            - relation: tests
+              target:
+                kind: test
+                repository: governs-fixture
+                path: scripts/governs.test.ts
+                framework_hint: custom-script
+        - key: GOVERNS-001-AC2
+          criterion: Tieline must return every acceptance criterion that links a path.
+          links:
+            - relation: implements
+              target:
+                kind: code
+                repository: governs-fixture
+                path: src/direct.ts
+`;
+
+function createFixture(options: { withManifest: boolean }): {
+  root: string;
+  manifest: ContractManifest;
+} {
+  const root = mkdtempSync(resolve(tmpdir(), "tieline-governs-"));
+  mkdirSync(resolve(root, ".tieline/spec"), { recursive: true });
+  mkdirSync(resolve(root, "src"), { recursive: true });
+  mkdirSync(resolve(root, "scripts"), { recursive: true });
+  writeFileSync(resolve(root, ".tieline/config.json"), workspaceConfig("governs-fixture"));
+  writeFileSync(resolve(root, ".tieline/spec/governs.yaml"), SPEC);
+  writeFileSync(resolve(root, "src/direct.ts"), "export const direct = 1;\n");
+  writeFileSync(resolve(root, "src/shared.ts"), "export const shared = 1;\n");
+  writeFileSync(resolve(root, "src/story-only.ts"), "export const storyOnly = 1;\n");
+  writeFileSync(resolve(root, "src/unlinked.ts"), "export const unlinked = 1;\n");
+  writeFileSync(resolve(root, "scripts/governs.test.ts"), "assert(direct);\n");
+  const manifest = compileContractManifest({
+    repositoryRoot: root,
+    repositoryKey: "governs-fixture",
+    commit: "governs-fixture-commit",
+    specDirectory: ".tieline/spec",
+  });
+  if (options.withManifest) {
+    writeFileSync(
+      resolve(root, ".tieline/manifest.json"),
+      serializeContractManifest(manifest)
+    );
+  }
+  return { root, manifest };
+}
+
+function scopes(criteria: GoverningCriterion[]): string[] {
+  return criteria.map(
+    (entry) =>
+      `${entry.acceptance_criterion_stable_id} ${entry.link_scope} ${entry.relation}`
+  );
+}
+
+const cleanup: string[] = [];
+try {
+  const { root, manifest } = createFixture({ withManifest: true });
+  cleanup.push(root);
+
+  // --- U1: the index -------------------------------------------------------
+  const index = buildGoverningCriteriaIndex(manifest);
+
+  // A path linked from an Acceptance Criterion is a direct answer.
+  assert.deepEqual(scopes([...(index.get("src/direct.ts") ?? [])]), [
+    "GOVERNS-001-AC1 direct implements",
+    "GOVERNS-001-AC2 direct implements",
+  ]);
+
+  // A path linked only at Story level falls back onto every AC of that Story.
+  assert.deepEqual(scopes([...(index.get("src/story-only.ts") ?? [])]), [
+    "GOVERNS-001-AC1 story_fallback implements",
+    "GOVERNS-001-AC2 story_fallback implements",
+  ]);
+
+  // Both scopes on one path stay distinct rather than collapsing.
+  assert.deepEqual(scopes([...(index.get("src/shared.ts") ?? [])]), [
+    "GOVERNS-001-AC1 direct implements",
+    "GOVERNS-001-AC1 story_fallback implements",
+    "GOVERNS-001-AC2 story_fallback implements",
+  ]);
+
+  // `tests` links are governance too; help links have no path and never appear.
+  assert.deepEqual(scopes([...(index.get("scripts/governs.test.ts") ?? [])]), [
+    "GOVERNS-001-AC1 direct tests",
+  ]);
+  const everyEntry = [...index.values()].flatMap((entries) => [...entries]);
+  assert.ok(
+    everyEntry.every((entry) =>
+      ["implements", "enforces", "tests"].includes(entry.relation)
+    ),
+    "a help `documents` link must never enter the index"
+  );
+  assert.ok(
+    everyEntry.every((entry) => !entry.path.includes("governs-guide")),
+    "help identifiers must never be indexed as repository paths"
+  );
+
+  // A link that targets a different repository is excluded.
+  assert.equal(index.has("src/elsewhere.ts"), false);
+
+  // Story metadata travels with each entry.
+  const shared = [...(index.get("src/shared.ts") ?? [])][0] as GoverningCriterion;
+  assert.equal(shared.capability_stable_id, "GOVERNS");
+  assert.equal(shared.story_stable_id, "GOVERNS-001");
+  assert.equal(shared.story_title, "Look up governing criteria");
+  assert.equal(
+    shared.criterion,
+    "Tieline must return the acceptance criterion that links a path."
+  );
+
+  // --- Coverage regression: same walk, same mapped set ---------------------
+  assert.deepEqual(
+    computeRepositoryMappingCoverage(manifest, {
+      repositoryRoot: root,
+      sourceRoots: ["src"],
+      ignore: [".git", ".tieline"],
+    }),
+    {
+      status: "measured",
+      source_roots: ["src"],
+      eligible_files: 4,
+      mapped_files: 3,
+      unmapped_files: ["src/unlinked.ts"],
+      excluded_files: 0,
+      percentage: 75,
+    }
+  );
+
+  // --- U1/U2: lookup semantics --------------------------------------------
+  const report = lookupGoverningCriteria({
+    manifest,
+    repositoryRoot: root,
+    paths: ["src/direct.ts", "src/unlinked.ts", "src/missing.ts", "src/elsewhere.ts"],
+  });
+  assert.equal(report.repository.commit, "governs-fixture-commit");
+  assert.equal(report.governed_paths, 1);
+  assert.equal(report.ungoverned_paths, 3);
+  assert.equal(report.results.length, 4);
+
+  assert.equal(report.results[0].status, "governed");
+  assert.equal(report.results[0].acceptance_criterion_count, 2);
+  assert.equal(
+    report.results[0].answer,
+    "2 acceptance criteria govern 'src/direct.ts'."
+  );
+
+  // An existing but unlinked path is an explicit finding, not an empty list.
+  assert.equal(report.results[1].status, "ungoverned");
+  assert.equal(report.results[1].exists, true);
+  assert.equal(
+    report.results[1].answer,
+    "No acceptance criterion governs 'src/unlinked.ts'. The path exists in the repository but no contract link targets it."
+  );
+
+  // A path that does not exist is distinguishable from one that is ungoverned.
+  assert.equal(report.results[2].status, "not_found");
+  assert.equal(report.results[2].exists, false);
+  assert.equal(
+    report.results[2].answer,
+    "No acceptance criterion governs 'src/missing.ts', and the path does not exist in the repository."
+  );
+  assert.notEqual(report.results[1].status, report.results[2].status);
+  assert.notEqual(report.results[1].answer, report.results[2].answer);
+
+  // A path owned by another repository reads as unknown here, never as governed.
+  assert.equal(report.results[3].status, "not_found");
+  assert.deepEqual(report.results[3].criteria, []);
+
+  // Path normalization: platform separators, './' prefixes, and absolute paths
+  // all resolve to the same repository-relative key.
+  const separatorForm = join("src", "direct.ts");
+  const normalized = lookupGoverningCriteria({
+    manifest,
+    repositoryRoot: root,
+    paths: [separatorForm, `.${sep}${separatorForm}`, resolve(root, separatorForm)],
+  });
+  for (const result of normalized.results) {
+    assert.equal(result.path, "src/direct.ts");
+    assert.equal(result.status, "governed");
+    assert.deepEqual(scopes(result.criteria), scopes(report.results[0].criteria));
+  }
+  assert.equal(normalized.results[2].requested_path, resolve(root, separatorForm));
+
+  // --- U2: the CLI action --------------------------------------------------
+  let output = "";
+  const io: TielineCliIO = {
+    write(message) {
+      output += message;
+    },
+    error(message) {
+      throw new Error(message);
+    },
+    async question() {
+      throw new Error("contract governs must not prompt");
+    },
+  };
+
+  output = "";
+  assert.equal(
+    await runCli(
+      ["contract", "governs", "--repository", root, "src/shared.ts"],
+      io,
+      {}
+    ),
+    0
+  );
+  assert.match(output, /at manifest commit governs-fixture-commit/);
+  assert.match(output, /GOVERNS-001-AC1 direct implements/);
+  assert.match(output, /GOVERNS-001-AC1 story_fallback implements/);
+  assert.match(output, /GOVERNS-001-AC2 story_fallback implements/);
+
+  output = "";
+  assert.equal(
+    await runCli(
+      ["contract", "governs", "--repository", root, "src/unlinked.ts"],
+      io,
+      {}
+    ),
+    0
+  );
+  assert.match(output, /ungoverned {2}No acceptance criterion governs/);
+
+  // Multiple paths in one invocation each get their own result, and the JSON
+  // shape carries the manifest commit that answered.
+  output = "";
+  assert.equal(
+    await runCli(
+      [
+        "contract",
+        "governs",
+        "--repository",
+        root,
+        "src/direct.ts",
+        "src/unlinked.ts",
+        "src/missing.ts",
+        "--json",
+      ],
+      io,
+      {}
+    ),
+    0
+  );
+  assert.deepEqual(JSON.parse(output), {
+    repository: { key: "governs-fixture", commit: "governs-fixture-commit" },
+    governed_paths: 1,
+    ungoverned_paths: 2,
+    results: [
+      {
+        requested_path: "src/direct.ts",
+        path: "src/direct.ts",
+        status: "governed",
+        exists: true,
+        acceptance_criterion_count: 2,
+        answer: "2 acceptance criteria govern 'src/direct.ts'.",
+        criteria: [
+          {
+            path: "src/direct.ts",
+            capability_stable_id: "GOVERNS",
+            story_stable_id: "GOVERNS-001",
+            story_title: "Look up governing criteria",
+            acceptance_criterion_stable_id: "GOVERNS-001-AC1",
+            criterion:
+              "Tieline must return the acceptance criterion that links a path.",
+            relation: "implements",
+            link_scope: "direct",
+          },
+          {
+            path: "src/direct.ts",
+            capability_stable_id: "GOVERNS",
+            story_stable_id: "GOVERNS-001",
+            story_title: "Look up governing criteria",
+            acceptance_criterion_stable_id: "GOVERNS-001-AC2",
+            criterion:
+              "Tieline must return every acceptance criterion that links a path.",
+            relation: "implements",
+            link_scope: "direct",
+          },
+        ],
+      },
+      {
+        requested_path: "src/unlinked.ts",
+        path: "src/unlinked.ts",
+        status: "ungoverned",
+        exists: true,
+        acceptance_criterion_count: 0,
+        answer:
+          "No acceptance criterion governs 'src/unlinked.ts'. The path exists in the repository but no contract link targets it.",
+        criteria: [],
+      },
+      {
+        requested_path: "src/missing.ts",
+        path: "src/missing.ts",
+        status: "not_found",
+        exists: false,
+        acceptance_criterion_count: 0,
+        answer:
+          "No acceptance criterion governs 'src/missing.ts', and the path does not exist in the repository.",
+        criteria: [],
+      },
+    ],
+  });
+
+  await assert.rejects(
+    runCli(["contract", "governs", "--repository", root], io, {}),
+    /missing required argument/i
+  );
+
+  // --- U3: the MCP tool ----------------------------------------------------
+  // The tool module must not reach for the knowledge store at all.
+  const toolSource = readFileSync(
+    resolve(repositoryRoot, "src/tools/governing-criteria.ts"),
+    "utf8"
+  );
+  assert.doesNotMatch(toolSource, /get(Read|Evidence|Planning)?Store\s*\(/);
+
+  // Any use of the store — during registration or during the call — throws.
+  setStore(
+    new Proxy(
+      {},
+      {
+        get(_target, property) {
+          throw new Error(
+            `get_governing_criteria must not use the knowledge store (accessed '${String(property)}')`
+          );
+        },
+      }
+    ) as unknown as KnowledgeStore
+  );
+
+  const registered: {
+    name: string;
+    config: { description: string; annotations?: Record<string, unknown> };
+    handler: (input: { paths: string[] }) => Promise<ToolResult>;
+  }[] = [];
+  const fakeServer = {
+    registerTool(
+      name: string,
+      config: { description: string; annotations?: Record<string, unknown> },
+      handler: (input: { paths: string[] }) => Promise<ToolResult>
+    ) {
+      registered.push({ name, config, handler });
+    },
+  } as unknown as McpServer;
+
+  registerGetGoverningCriteria(fakeServer);
+  assert.equal(registered.length, 1);
+  const tool = registered[0];
+  assert.equal(tool.name, "get_governing_criteria");
+  assert.equal(tool.config.annotations?.readOnlyHint, true);
+  // The description has to separate this lookup from ranked search, because
+  // both surfaces accept a path.
+  assert.match(tool.config.description, /search_knowledge/);
+  assert.match(tool.config.description, /No database/i);
+  assert.match(tool.config.description, /link_scope/);
+
+  // The handler resolves the workspace lazily from the process directory.
+  const previousCwd = process.cwd();
+  let handlerResult: ToolResult;
+  try {
+    process.chdir(resolve(root, "src"));
+    handlerResult = await tool.handler({
+      paths: ["src/shared.ts", "src/unlinked.ts"],
+    });
+  } finally {
+    process.chdir(previousCwd);
+  }
+  assert.notEqual(handlerResult.isError, true);
+  const structured = handlerResult.structuredContent as {
+    repository: { key: string; commit: string };
+    governed_paths: number;
+    ungoverned_paths: number;
+    results: { path: string; status: string; criteria: GoverningCriterion[] }[];
+    note?: string;
+  };
+  assert.equal(structured.repository.commit, "governs-fixture-commit");
+  assert.equal(structured.governed_paths, 1);
+  assert.equal(structured.results[0].status, "governed");
+  assert.deepEqual(scopes(structured.results[0].criteria), [
+    "GOVERNS-001-AC1 direct implements",
+    "GOVERNS-001-AC1 story_fallback implements",
+    "GOVERNS-001-AC2 story_fallback implements",
+  ]);
+  assert.equal(structured.results[1].status, "ungoverned");
+  assert.match(structured.note ?? "", /governed by no acceptance criterion/);
+
+  // The same answer without a server, proving no database is involved.
+  const resolved = resolveGoverningCriteria({
+    paths: ["src/direct.ts"],
+    cwd: root,
+  });
+  assert.equal(resolved.status, "resolved");
+
+  // No workspace: a clear, actionable message instead of an obscure throw.
+  const stray = mkdtempSync(resolve(tmpdir(), "tieline-governs-nowork-"));
+  cleanup.push(stray);
+  const withoutWorkspace = resolveGoverningCriteria({
+    paths: ["src/direct.ts"],
+    cwd: stray,
+  });
+  assert.equal(withoutWorkspace.status, "no_workspace");
+  assert.match(
+    withoutWorkspace.status === "no_workspace" ? withoutWorkspace.message : "",
+    /No Tieline workspace was found[\s\S]*tieline init/
+  );
+
+  // Missing manifest: named path plus the command that produces it.
+  const { root: withoutManifest } = createFixture({ withManifest: false });
+  cleanup.push(withoutManifest);
+  const unreadable = resolveGoverningCriteria({
+    paths: ["src/direct.ts"],
+    cwd: withoutManifest,
+  });
+  assert.equal(unreadable.status, "no_manifest");
+  assert.match(
+    unreadable.status === "no_manifest" ? unreadable.message : "",
+    /manifest[\s\S]*missing or unreadable[\s\S]*tieline contract compile/
+  );
+
+  // Both failure modes surface through the tool as an error result, not a throw.
+  const strayCwd = process.cwd();
+  let strayResult: ToolResult;
+  try {
+    process.chdir(stray);
+    strayResult = await tool.handler({ paths: ["src/direct.ts"] });
+  } finally {
+    process.chdir(strayCwd);
+  }
+  assert.equal(strayResult.isError, true);
+  assert.match(strayResult.content[0].text, /No Tieline workspace was found/);
+} finally {
+  for (const path of cleanup) {
+    rmSync(path, { recursive: true, force: true });
+  }
+}
+
+console.log("governs tests passed");

--- a/scripts/test-impact.ts
+++ b/scripts/test-impact.ts
@@ -222,7 +222,39 @@ capability:
     ),
     1
   );
-  assert.match(strictTextOutput.join(""), /error {2}Strict mode/);
+  assert.match(strictTextOutput.join(""), /error\s+Strict mode/);
+
+  // Impacts are orientation, not defects. The text view labels them `affects`,
+  // collapses the per-AC `contract_definition_changed` fan-out into one note,
+  // and reserves `warn` for findings that need an action.
+  const shapeOutput: string[] = [];
+  assert.equal(
+    await runCheckCommand(
+      { base: "HEAD", repository: root },
+      { write: (message) => shapeOutput.push(message) }
+    ),
+    0
+  );
+  const shapeText = shapeOutput.join("");
+  assert.match(shapeText, /^Contract impact vs HEAD: \d+ acceptance criteria/m);
+  assert.match(shapeText, /affects\s+\S+ modified src\/feature\.ts/);
+  assert.doesNotMatch(
+    shapeText,
+    /warn\s+\S+ modified/,
+    "path impacts must not be labelled warn"
+  );
+  // One cause, one action, one warning: per-link staleness is marked inline and
+  // can only occur while the manifest is stale, so it must not be repeated.
+  assert.equal(
+    shapeText.split("\n").filter((line) => line.includes("warn")).length,
+    1,
+    "a stale manifest must produce exactly one warning, not one per stale link"
+  );
+  assert.doesNotMatch(
+    shapeText,
+    /\(current\)/,
+    "current freshness is redundant with the manifest gate and must be suppressed"
+  );
 
   await assert.rejects(
     runCheckCommand(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -474,7 +474,8 @@ function buildProgram(
             | "compile"
             | "coverage"
             | "grade"
-            | "sync",
+            | "sync"
+            | "governs",
           { repository, ...(opts as ContractActionOptions) },
           io
         )
@@ -505,6 +506,34 @@ function buildProgram(
     "--expected-previous-commit <sha>",
     "guard against concurrent syncs"
   );
+  // `governs` takes paths where the other actions take a repository, so it is
+  // declared directly instead of through `contractAction`.
+  contract
+    .command("governs")
+    .description(
+      "Report the acceptance criteria that govern repository-relative paths"
+    )
+    .argument("<paths...>", "repository-relative paths")
+    .option("--repository <path>", "repository path")
+    .option("--repo <key>", "stable repository key")
+    .option("--spec <dir>", "spec directory")
+    .option("--json", "emit machine-readable JSON")
+    .action(async (paths: string[], opts) => {
+      const { runContractCommand } = await import("./commands/contract.js");
+      setExit(
+        await runContractCommand(
+          "governs",
+          {
+            paths,
+            repository: opts.repository,
+            repo: opts.repo,
+            spec: opts.spec,
+            json: Boolean(opts.json),
+          },
+          io
+        )
+      );
+    });
 
   program
     .command("check")

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -96,20 +96,51 @@ export async function runCheckCommand(
   if (options.json) {
     io.write(`${JSON.stringify(result, null, 2)}\n`);
   } else {
-    io.write(
-      `Semantic impact: ${impacts.length} AC finding(s); manifest=${manifestCurrent ? "current" : "stale"}.\n`
+    // Impacts are orientation, not defects: they answer "what does this change
+    // touch?", which is the question an agent needs answered before it edits.
+    // Labelling them `warn` trains readers to skip the whole stream, so `warn`
+    // is reserved for findings that need an action.
+    const definitionChanged = impacts.filter(
+      (impact) => impact.reason === "contract_definition_changed"
     );
-    for (const impact of impacts) {
+    const pathImpacts = impacts.filter(
+      (impact) => impact.reason !== "contract_definition_changed"
+    );
+    const affectedCriteria = new Set(
+      pathImpacts.map((impact) => impact.acceptance_criterion_stable_id)
+    );
+    io.write(
+      `Contract impact vs ${base}: ${affectedCriteria.size} acceptance criteria affected across ${pathImpacts.length} linked path(s); manifest=${manifestCurrent ? "current" : "stale"}.\n`
+    );
+    for (const impact of pathImpacts) {
+      // `current` freshness is provably redundant with the manifest gate: a
+      // fresh compile recomputes every local reviewed hash, so a local link
+      // cannot be stale while `manifest_current` holds. Only unmeasurable or
+      // genuinely stale links carry information here.
+      const freshness =
+        impact.freshness === "current" || impact.freshness === "not_applicable"
+          ? ""
+          : ` (${impact.freshness})`;
       io.write(
-        `  warn  ${impact.acceptance_criterion_stable_id} ${impact.reason} ${impact.path} (${impact.freshness})\n`
+        `  affects  ${impact.acceptance_criterion_stable_id} ${impact.reason} ${impact.path}${freshness}\n`
       );
     }
-    for (const warning of result.warnings) {
-      io.write(`  warn  ${warning}\n`);
+    if (definitionChanged.length > 0) {
+      io.write(
+        `  note     the contract definition changed under ${specDirectory}, which nominally affects all ${definitionChanged.length} acceptance criteria\n`
+      );
+    }
+    // Per-link staleness is already marked inline above, and it can only occur
+    // while the manifest itself is stale — one cause, one action, one warning.
+    // The JSON `warnings` array stays complete for machine consumers.
+    if (!manifestCurrent) {
+      io.write(
+        "  warn     The committed manifest does not match current YAML or linked content; compile it before merge.\n"
+      );
     }
     if (strictFailure) {
       io.write(
-        "  error  Strict mode: the committed manifest is stale. Run `tieline contract compile` and commit the manifest.\n"
+        "  error    Strict mode: the committed manifest is stale. Run `tieline contract compile` and commit the manifest.\n"
       );
     }
   }

--- a/src/commands/contract.ts
+++ b/src/commands/contract.ts
@@ -27,6 +27,10 @@ import {
   renderGradeScopeText,
   verifyGradeVerdicts,
 } from "../contract/grade.js";
+import {
+  lookupGoverningCriteria,
+  renderGoverningCriteriaText,
+} from "../contract/governs.js";
 import { renderContractReviewPage } from "../contract/review-page.js";
 import { syncContractManifest } from "../contract/sync.js";
 import { findTielineWorkspace } from "../tieline/workspace.js";
@@ -43,6 +47,7 @@ export type ContractAction =
   | "review"
   | "compile"
   | "coverage"
+  | "governs"
   | "grade"
   | "sync";
 
@@ -58,6 +63,7 @@ export interface ContractCommandOptions {
   emitScope?: boolean;
   verify?: string;
   strict?: boolean;
+  paths?: string[];
 }
 
 interface ParsedContractCommand {
@@ -76,6 +82,7 @@ interface ParsedContractCommand {
   emitScope: boolean;
   verify?: string;
   strict: boolean;
+  paths: string[];
 }
 
 function gitCommit(repositoryRoot: string): string {
@@ -133,6 +140,7 @@ function resolveContractCommand(
     emitScope: options.emitScope === true,
     verify: options.verify,
     strict: options.strict === true,
+    paths: options.paths ?? [],
   };
 }
 
@@ -316,6 +324,37 @@ export async function runContractCommand(
 
   if (parsed.action === "grade") {
     return runGrade(parsed, io);
+  }
+
+  if (parsed.action === "governs") {
+    if (parsed.paths.length === 0) {
+      throw new Error(
+        "`contract governs` requires at least one repository-relative path."
+      );
+    }
+    // Answers come from the reviewed manifest rather than a fresh compile, so
+    // the reported commit names exactly the state that produced the answer.
+    let manifest: ContractManifest;
+    try {
+      manifest = readContractManifest(parsed.manifestPath);
+    } catch (error) {
+      throw new Error(
+        `Cannot report governing acceptance criteria because ${parsed.manifestPath} is unreadable: ${
+          error instanceof Error ? error.message : String(error)
+        } Run \`tieline contract compile\` and commit the manifest.`
+      );
+    }
+    const report = lookupGoverningCriteria({
+      manifest,
+      repositoryRoot: parsed.repositoryRoot,
+      paths: parsed.paths,
+    });
+    io.write(
+      parsed.json
+        ? `${JSON.stringify(report, null, 2)}\n`
+        : renderGoverningCriteriaText(report)
+    );
+    return 0;
   }
 
   if (parsed.action === "sync") {

--- a/src/contract/coverage.ts
+++ b/src/contract/coverage.ts
@@ -1,5 +1,9 @@
 import { existsSync, readdirSync, realpathSync, statSync } from "node:fs";
 import { isAbsolute, relative, resolve, sep } from "node:path";
+import {
+  buildGoverningCriteriaIndex,
+  normalizeRepositoryPath as normalizePath,
+} from "./governs.js";
 import type { ContractManifest } from "./manifest.js";
 
 export interface RepositoryMappingCoverage {
@@ -16,10 +20,6 @@ export interface RepositoryMappingCoverageOptions {
   repositoryRoot: string;
   sourceRoots: string[];
   ignore?: string[];
-}
-
-function normalizePath(path: string): string {
-  return path.split(sep).join("/");
 }
 
 function wildcardPattern(pattern: string): RegExp {
@@ -80,26 +80,6 @@ function walkFiles(
     );
 }
 
-function mappedPaths(manifest: ContractManifest): Set<string> {
-  const paths = new Set<string>();
-  for (const capability of manifest.capabilities) {
-    for (const story of capability.stories) {
-      for (const link of [
-        ...story.links,
-        ...story.acceptance_criteria.flatMap((criterion) => criterion.links),
-      ]) {
-        if (
-          link.target.kind !== "help" &&
-          link.target.repository === manifest.repository.key
-        ) {
-          paths.add(normalizePath(link.target.path));
-        }
-      }
-    }
-  }
-  return paths;
-}
-
 export function computeRepositoryMappingCoverage(
   manifest: ContractManifest,
   options: RepositoryMappingCoverageOptions
@@ -126,7 +106,10 @@ export function computeRepositoryMappingCoverage(
   }
 
   const sorted = [...allFiles].sort();
-  const mapped = mappedPaths(manifest);
+  // The governing-criteria index is keyed by the same normalized repository
+  // paths `mappedPaths` used to collect, so coverage reads `.has()` off the
+  // richer structure instead of repeating the traversal.
+  const mapped = buildGoverningCriteriaIndex(manifest);
   const mappedFiles = sorted.filter((path) => mapped.has(path));
   const unmappedFiles = sorted.filter((path) => !mapped.has(path));
 

--- a/src/contract/governs.ts
+++ b/src/contract/governs.ts
@@ -1,0 +1,246 @@
+/**
+ * governs — the deterministic answer to "which Acceptance Criteria govern this
+ * repository path?".
+ *
+ * Every other contract query is either whole-contract (`coverage`) or
+ * diff-scoped (`check`, `grade`): each one reports a violation that already
+ * exists. This one is asked *before* the edit, which is the only moment at
+ * which the contract can prevent the violation instead of describing it. An
+ * agent does not notice context that is not there, so the pre-change lookup has
+ * to be a first-class query rather than a side effect of ranked search.
+ *
+ * The index is a pure function of the compiled manifest: no database, no
+ * network, no model. `coverage` consumes the same structure — a `Map` answers
+ * `.has()` exactly as well as a `Set`, and holding on to the criterion instead
+ * of discarding it is the entire difference between "is this path mapped?" and
+ * "what governs it?". One traversal, two consumers.
+ *
+ * `link_scope` reuses the vocabulary of `AcceptanceCriterionImpact` in
+ * impact.ts. "A specific Acceptance Criterion links this file" and "this file is
+ * attached to the Story that owns the criterion" are materially different
+ * answers and are never flattened together.
+ */
+
+import { existsSync } from "node:fs";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+import type { ContractManifest, ManifestLink } from "./manifest.js";
+
+/** `documents` is excluded: it always targets help content, never a path. */
+export type GoverningRelation = "implements" | "enforces" | "tests";
+
+/** Same vocabulary as `AcceptanceCriterionImpact["link_scope"]`. */
+export type GoverningLinkScope = "direct" | "story_fallback";
+
+export interface GoverningCriterion {
+  path: string;
+  capability_stable_id: string;
+  story_stable_id: string;
+  story_title: string;
+  acceptance_criterion_stable_id: string;
+  criterion: string;
+  relation: GoverningRelation;
+  link_scope: GoverningLinkScope;
+}
+
+/** Repository-relative path -> the contract records that link it. */
+export type GoverningCriteriaIndex = ReadonlyMap<
+  string,
+  readonly GoverningCriterion[]
+>;
+
+export type PathGovernanceStatus = "governed" | "ungoverned" | "not_found";
+
+export interface PathGovernance {
+  /** Exactly what the caller asked for, so a typo is visible in the answer. */
+  requested_path: string;
+  path: string;
+  status: PathGovernanceStatus;
+  exists: boolean;
+  acceptance_criterion_count: number;
+  /**
+   * The negative result stated in words. An empty array reads like a failed
+   * query; "no acceptance criterion governs this path" is an actual finding.
+   */
+  answer: string;
+  criteria: GoverningCriterion[];
+}
+
+export interface GoverningCriteriaReport {
+  /** The commit the manifest records, so a caller knows which state answered. */
+  repository: { key: string; commit: string };
+  governed_paths: number;
+  ungoverned_paths: number;
+  results: PathGovernance[];
+}
+
+export function normalizeRepositoryPath(path: string): string {
+  return path.split(sep).join("/");
+}
+
+function repositoryArtifact(
+  link: ManifestLink,
+  repositoryKey: string
+): { relation: GoverningRelation; path: string } | null {
+  if (link.relation === "documents" || link.target.kind === "help") return null;
+  if (link.target.repository !== repositoryKey) return null;
+  return {
+    relation: link.relation,
+    path: normalizeRepositoryPath(link.target.path),
+  };
+}
+
+/**
+ * Walks capabilities -> stories -> criteria once and keeps the association that
+ * `mappedPaths` used to throw away on its last line.
+ */
+export function buildGoverningCriteriaIndex(
+  manifest: ContractManifest
+): GoverningCriteriaIndex {
+  const index = new Map<string, GoverningCriterion[]>();
+  const seen = new Set<string>();
+  for (const capability of manifest.capabilities) {
+    for (const story of capability.stories) {
+      for (const criterion of story.acceptance_criteria) {
+        const scoped: { link: ManifestLink; scope: GoverningLinkScope }[] = [
+          ...criterion.links.map((link) => ({
+            link,
+            scope: "direct" as const,
+          })),
+          ...story.links.map((link) => ({
+            link,
+            scope: "story_fallback" as const,
+          })),
+        ];
+        for (const { link, scope } of scoped) {
+          const artifact = repositoryArtifact(link, manifest.repository.key);
+          if (!artifact) continue;
+          const key = [
+            artifact.path,
+            criterion.stable_id,
+            artifact.relation,
+            scope,
+          ].join("\0");
+          if (seen.has(key)) continue;
+          seen.add(key);
+          const entry: GoverningCriterion = {
+            path: artifact.path,
+            capability_stable_id: capability.stable_id,
+            story_stable_id: story.stable_id,
+            story_title: story.title,
+            acceptance_criterion_stable_id: criterion.stable_id,
+            criterion: criterion.criterion,
+            relation: artifact.relation,
+            link_scope: scope,
+          };
+          const bucket = index.get(artifact.path);
+          if (bucket) bucket.push(entry);
+          else index.set(artifact.path, [entry]);
+        }
+      }
+    }
+  }
+  for (const entries of index.values()) {
+    entries.sort(
+      (left, right) =>
+        left.acceptance_criterion_stable_id.localeCompare(
+          right.acceptance_criterion_stable_id
+        ) ||
+        // "direct" sorts before "story_fallback"; the specific answer leads.
+        left.link_scope.localeCompare(right.link_scope) ||
+        left.relation.localeCompare(right.relation)
+    );
+  }
+  return index;
+}
+
+function repositoryRelativePath(
+  repositoryRoot: string,
+  requested: string
+): string {
+  const relativePath = isAbsolute(requested)
+    ? relative(repositoryRoot, requested)
+    : requested;
+  const normalized = normalizeRepositoryPath(relativePath)
+    .replace(/^\.\//, "")
+    .replace(/\/+$/, "");
+  return normalized.length > 0 ? normalized : ".";
+}
+
+function withinRepository(root: string, target: string): boolean {
+  const rel = relative(root, target);
+  return rel !== ".." && !rel.startsWith(`..${sep}`) && !isAbsolute(rel);
+}
+
+function answerFor(
+  path: string,
+  criterionCount: number,
+  exists: boolean
+): string {
+  if (criterionCount === 0) {
+    return exists
+      ? `No acceptance criterion governs '${path}'. The path exists in the repository but no contract link targets it.`
+      : `No acceptance criterion governs '${path}', and the path does not exist in the repository.`;
+  }
+  const subject =
+    criterionCount === 1
+      ? "1 acceptance criterion governs"
+      : `${criterionCount} acceptance criteria govern`;
+  return exists
+    ? `${subject} '${path}'.`
+    : `${subject} '${path}', but the path does not exist in the repository working tree.`;
+}
+
+export function lookupGoverningCriteria(input: {
+  manifest: ContractManifest;
+  repositoryRoot: string;
+  paths: string[];
+  index?: GoverningCriteriaIndex;
+}): GoverningCriteriaReport {
+  const index = input.index ?? buildGoverningCriteriaIndex(input.manifest);
+  const root = resolve(input.repositoryRoot);
+  const results = input.paths.map((requested): PathGovernance => {
+    const path = repositoryRelativePath(root, requested);
+    const criteria = [...(index.get(path) ?? [])];
+    const target = resolve(root, path);
+    const exists = withinRepository(root, target) && existsSync(target);
+    const distinct = new Set(
+      criteria.map((entry) => entry.acceptance_criterion_stable_id)
+    );
+    return {
+      requested_path: requested,
+      path,
+      status:
+        criteria.length > 0 ? "governed" : exists ? "ungoverned" : "not_found",
+      exists,
+      acceptance_criterion_count: distinct.size,
+      answer: answerFor(path, distinct.size, exists),
+      criteria,
+    };
+  });
+  return {
+    repository: { ...input.manifest.repository },
+    governed_paths: results.filter((result) => result.status === "governed")
+      .length,
+    ungoverned_paths: results.filter((result) => result.status !== "governed")
+      .length,
+    results,
+  };
+}
+
+export function renderGoverningCriteriaText(
+  report: GoverningCriteriaReport
+): string {
+  const lines = [
+    `Contract governance in repository '${report.repository.key}' at manifest commit ${report.repository.commit}: ${report.governed_paths} governed, ${report.ungoverned_paths} ungoverned of ${report.results.length} path(s).\n`,
+  ];
+  for (const result of report.results) {
+    lines.push(`  ${result.status}  ${result.answer}\n`);
+    for (const criterion of result.criteria) {
+      lines.push(
+        `    governs  ${criterion.acceptance_criterion_stable_id} ${criterion.link_scope} ${criterion.relation} (${criterion.story_stable_id} ${criterion.story_title})\n`
+      );
+      lines.push(`             ${criterion.criterion}\n`);
+    }
+  }
+  return lines.join("");
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -230,6 +230,49 @@ export const getHelpArticleOutputShape = {
   note: z.string().optional(),
 };
 
+/**
+ * Deterministic path -> Acceptance Criterion lookup. Deliberately narrow: no
+ * query string, no profile, no ranking knobs, because the answer is a fact
+ * about the compiled manifest rather than a relevance judgment.
+ */
+export const getGoverningCriteriaShape = {
+  paths: z.array(z.string().trim().min(1).max(1_000)).min(1).max(50),
+};
+export const getGoverningCriteriaSchema = z
+  .object(getGoverningCriteriaShape)
+  .strict();
+export type GetGoverningCriteriaInput = z.infer<
+  typeof getGoverningCriteriaSchema
+>;
+export const getGoverningCriteriaOutputShape = {
+  repository: z.object({ key: z.string(), commit: z.string() }),
+  governed_paths: z.number(),
+  ungoverned_paths: z.number(),
+  results: z.array(
+    z.object({
+      requested_path: z.string(),
+      path: z.string(),
+      status: z.enum(["governed", "ungoverned", "not_found"]),
+      exists: z.boolean(),
+      acceptance_criterion_count: z.number(),
+      answer: z.string(),
+      criteria: z.array(
+        z.object({
+          path: z.string(),
+          capability_stable_id: z.string(),
+          story_stable_id: z.string(),
+          story_title: z.string(),
+          acceptance_criterion_stable_id: z.string(),
+          criterion: z.string(),
+          relation: z.enum(["implements", "enforces", "tests"]),
+          link_scope: z.enum(["direct", "story_fallback"]),
+        })
+      ),
+    })
+  ),
+  note: z.string().optional(),
+};
+
 const contractFilterShape = {
   repository: nonEmptyArray(z.string().min(1)).optional(),
   capability: nonEmptyArray(z.string().min(1)).optional(),

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import { registerFindRelated } from "./tools/find_related.js";
 import { registerQueryStories } from "./tools/query_stories.js";
 import { registerFindHelp } from "./tools/find_help.js";
 import { registerGetHelpArticle } from "./tools/get_help_article.js";
+import { registerGetGoverningCriteria } from "./tools/governing-criteria.js";
 import { registerObservationTools } from "./tools/observations.js";
 import { registerBacklogItemTools } from "./tools/backlog-items.js";
 import { registerResources } from "./resources.js";
@@ -30,6 +31,7 @@ export function createServer(): McpServer {
       instructions:
         "Tieline is a lifecycle-aware semantic contract grounded in repository YAML. " +
         "Use search_knowledge with an explicit profile for cross-type search, find_related for engineering-oriented discovery, and query_stories for exact Story/AC reads. " +
+        "Use get_governing_criteria before editing a repository path to learn which Acceptance Criteria already govern it; it reads the compiled manifest and needs no database. " +
         "Use the tieline_author prompt to onboard or reconcile repository behavior. " +
         "Planning writes can shape backlog Stories/ACs, append Observations, and manage " +
         "Backlog Items. Repository-owned behavior changes only through YAML and normal PR review.",
@@ -41,6 +43,7 @@ export function createServer(): McpServer {
   registerQueryStories(server);
   registerFindHelp(server);
   registerGetHelpArticle(server);
+  registerGetGoverningCriteria(server);
   registerObservationTools(server);
   registerBacklogItemTools(server);
   registerPlanningStoryTools(server);

--- a/src/tools/governing-criteria.ts
+++ b/src/tools/governing-criteria.ts
@@ -1,0 +1,123 @@
+/**
+ * get_governing_criteria — the first Tieline MCP tool that needs no database.
+ *
+ * Every other tool resolves a store inside its handler and fails at call time
+ * without Postgres; this one answers from `.tieline/manifest.json` alone, which
+ * is what makes an offline `tieline serve` genuinely useful rather than merely
+ * bootable.
+ *
+ * Naming follows the convention the surface already half-encodes:
+ * `get_` is a deterministic lookup (`get_help_article`), `find_`/`search_` are
+ * ranked (`find_help`, `find_related`, `search_knowledge`). Both this tool and
+ * `search_knowledge` accept a path, so the description has to make the
+ * difference unmistakable or an agent will reach for the wrong one.
+ *
+ * The workspace is resolved lazily inside the handler, never at registration,
+ * so the server still starts outside a Tieline workspace and reports a usable
+ * message instead of failing to boot.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  lookupGoverningCriteria,
+  type GoverningCriteriaReport,
+} from "../contract/governs.js";
+import { readContractManifest } from "../contract/manifest.js";
+import {
+  getGoverningCriteriaOutputShape,
+  getGoverningCriteriaShape,
+  type GetGoverningCriteriaInput,
+} from "../schemas.js";
+import { findTielineWorkspace } from "../tieline/workspace.js";
+import {
+  errorResult,
+  formatError,
+  jsonResult,
+  type ToolResult,
+} from "./shared.js";
+
+const DESCRIPTION = `Deterministically list every Acceptance Criterion that governs one or more repository-relative paths, read straight from the compiled contract manifest. No database, network, or embedding is required.
+
+This answers "what is true": the contract records that link these exact paths. Each result carries link_scope "direct" when the link is on the Acceptance Criterion itself and "story_fallback" when it is only on the owning Story. Use search_knowledge instead to answer "what is related": that tool ranks semantically similar records and treats an artifact path as one weak relevance signal, not as a lookup key.
+
+Ask this before editing a file, so a contradiction with accepted behavior is prevented rather than reported afterwards. A path that no Acceptance Criterion links returns an explicit ungoverned answer, and a path that does not exist in the repository is reported distinctly from one that exists but is unlinked. The manifest commit is returned so the caller knows which repository state answered.`;
+
+export type GoverningCriteriaResolution =
+  | { status: "resolved"; report: GoverningCriteriaReport }
+  | { status: "no_workspace" | "no_manifest"; message: string };
+
+/**
+ * Pure seam around the handler: resolving the workspace from an explicit `cwd`
+ * keeps the lookup testable without a server, a database, or a chdir.
+ */
+export function resolveGoverningCriteria(input: {
+  paths: string[];
+  cwd: string;
+}): GoverningCriteriaResolution {
+  const workspace = findTielineWorkspace(input.cwd);
+  if (!workspace) {
+    return {
+      status: "no_workspace",
+      message: `No Tieline workspace was found at or above '${input.cwd}', so no acceptance criterion can be looked up. Start the MCP server from inside a repository that contains .tieline/config.json, or run \`tieline init\` there.`,
+    };
+  }
+  try {
+    const manifest = readContractManifest(workspace.manifestPath);
+    return {
+      status: "resolved",
+      report: lookupGoverningCriteria({
+        manifest,
+        repositoryRoot: workspace.root,
+        paths: input.paths,
+      }),
+    };
+  } catch (error) {
+    return {
+      status: "no_manifest",
+      message: `The contract manifest '${workspace.manifestPath}' is missing or unreadable, so no acceptance criterion can be looked up: ${formatError(error)} Run \`tieline contract compile\` in ${workspace.root} and commit the manifest.`,
+    };
+  }
+}
+
+export function registerGetGoverningCriteria(server: McpServer): void {
+  server.registerTool(
+    "get_governing_criteria",
+    {
+      title: "Get the acceptance criteria governing a path",
+      description: DESCRIPTION,
+      inputSchema: getGoverningCriteriaShape,
+      outputSchema: getGoverningCriteriaOutputShape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (input: GetGoverningCriteriaInput): Promise<ToolResult> => {
+      try {
+        const resolved = resolveGoverningCriteria({
+          paths: input.paths,
+          cwd: process.cwd(),
+        });
+        if (resolved.status !== "resolved") {
+          return errorResult(resolved.message);
+        }
+        const { report } = resolved;
+        return jsonResult({
+          repository: report.repository,
+          governed_paths: report.governed_paths,
+          ungoverned_paths: report.ungoverned_paths,
+          results: report.results,
+          ...(report.ungoverned_paths > 0
+            ? {
+                note: `${report.ungoverned_paths} of ${report.results.length} requested path(s) are governed by no acceptance criterion; see each result's 'answer'.`,
+              }
+            : {}),
+        });
+      } catch (error) {
+        return errorResult(formatError(error));
+      }
+    }
+  );
+}


### PR DESCRIPTION
> **Stacked on #10.** Base is `knoxgraeme/tieline-vs-graphify-comparison`, not `main` — this touches `coverage.ts`, `contract.ts`, `cli.ts`, and `schemas.ts`, all of which #10 modifies. Retarget to `main` after #10 merges.

Two changes answering the same question at different scopes, plus a correction to how the existing answer was presented.

## C6 — `contract governs <path>` and `get_governing_criteria`

Tieline had no deterministic way to answer **"which acceptance criteria govern this path?"** Every query was whole-contract (`coverage`) or diff-scoped (`check`, `contract grade`). The nearest thing — `search_knowledge`'s `context.artifacts` — is a *ranked semantic search*: it needs a query string, needs Postgres, and the artifact contributes only `artifact: 0.07` of `SIGNAL_WEIGHTS`. A relevance hint, not a lookup.

This is the **pre-change** question, and it prevents a violation where post-hoc warnings only report one. Concretely: a proposed change to `check.ts` earlier in this work would have contradicted `CONTRACT-001-AC3` (*"…without blocking on semantic findings"*, rationale *"the MVP remains warn-only"*). Surfacing that required hand-writing a script over `.tieline/manifest.json`. The change was redesigned once the AC appeared — but nobody else would have written those six lines.

It now answers itself:

```
$ tieline contract governs src/commands/check.ts
  governed  3 acceptance criteria govern 'src/commands/check.ts'.
    governs  CONTRACT-001-AC3 direct implements (CONTRACT-001 Review accepted behavior with code)
             Tieline must report affected Acceptance Criteria and freshness for changed, renamed,
             or deleted linked paths without blocking on semantic findings.
    governs  CONTRACT-001-AC5 …
    governs  CONTRACT-001-AC6 …
```

**Most of this already existed.** `coverage.ts`'s `mappedPaths()` walked the identical traversal and discarded the acceptance criterion on its last line, because coverage only needed `.has()`. That walk is now `buildGoverningCriteriaIndex`, keyed by normalized path and preserving `link_scope` — a link carried by the AC and one carried only by its Story are materially different answers. `mappedPaths` is deleted; coverage consumes the index. One traversal, two consumers.

**The negative result is a stated answer, not an empty array.** Three distinct statuses:

```
governed    → the ACs, with relation and link_scope
ungoverned  → "The path exists in the repository but no contract link targets it."
not_found   → "…and the path does not exist in the repository."
```

For an agent, ungoverned code is *the* actionable signal; an empty array reads like a failed query. (A fourth case falls out: governed but deleted from the working tree — hence `status` and `exists` are independent.)

**`get_governing_criteria` is the first MCP tool needing no database.** Connections were already lazy and `getStore()` is only called inside handlers, so `serve` already booted without Postgres — there was simply no tool that could then do anything. Workspace resolution happens lazily in the handler via `findTielineWorkspace(process.cwd())`; a missing workspace or manifest returns an actionable message rather than throwing. Proven database-free by installing a store `Proxy` that throws on *any* property access, then registering and invoking the handler end to end.

Naming follows the convention already half-present in the tool set — `get_*` deterministic, `find_*`/`search_*` ranked. The description contrasts *"what is true"* with *"what is related"*, since both accept a path and an agent will otherwise guess. `search_knowledge` and `context.artifacts` are untouched; both surfaces stay.

## C7 — impacts are orientation, not warnings

`check` labelled everything `warn`. A routine run emitted 58 lines, of which 33 were `contract_definition_changed` fanned across every AC and 11 were per-link staleness duplicating one cause.

Impacts answer *"what does this change touch?"* — the same information C6 exposes, scoped by diff instead of by path. Labelling it `warn` is how the warnings that **do** need action stop being read.

Before / after, same repository state:

```
- Semantic impact: 58 AC finding(s); manifest=stale.
-   warn  AUTHORITY-001-AC1 contract_definition_changed .tieline/spec (not_applicable)   ← ×33
-   warn  CONTRACT-001-AC3 modified src/commands/check.ts (current)
-   warn  CONTRACT-001-AC2 is stale for src/commands/contract.ts.                        ← ×11

+ Contract impact vs origin/main: 20 acceptance criteria affected across 42 linked path(s); manifest=stale.
+   affects  CONTRACT-001-AC3 modified src/commands/check.ts (stale)
+   note     the contract definition changed under .tieline/spec, which nominally affects all 36 acceptance criteria
+   warn     The committed manifest does not match current YAML or linked content; compile it before merge.
```

`(current)` freshness is **provably** redundant: a fresh compile recomputes every local reviewed hash, so a local link cannot be stale while `manifest_current` holds. The strict gate from #10 already covers it. Cross-repo links keep `(unknown)`, which the gate genuinely can't measure.

With the manifest current, `check` now emits zero warnings — down from 58 lines.

`--json` is unchanged and complete: all impacts, all warnings, every freshness value. Only the text view curates.

**`CONTRACT-001-AC3` is deliberately not amended.** It requires reporting affected criteria *and* freshness; the JSON still reports both in full, and the AC specifies no rendering. Amending it to fit would have been exactly the convenient reinterpretation this tool exists to prevent. New `CONTRACT-001-AC6` pins the presentation discipline instead, so "warn means an action is needed" is accepted and tested rather than a convention that quietly erodes.

## Contract

Went to `CONTRACT-002` (new Story under the existing `CONTRACT` capability) rather than `RETRIEVAL` or a new capability. `RETRIEVAL` is intent-aware ranked search with profiles and a database; `governs` has no query, no profile, no ranking, no database — filing it there would blur the exact line the tool description exists to keep sharp. But it *is* a new Story: `CONTRACT-001`'s actor is a maintainer reviewing behavior, while this actor is an implementing agent asking a question before it edits.

14 → 15 Stories, 33 → 36 ACs, all with direct evidence links. Coverage 98.63% → 98.67%. No dependency added.

## Verification

All offline, every `DATABASE_URL*` unset:

```
tsc --noEmit                                             clean
test-governs · test-impact · test-grade                  PASS
test-symbol-vocabulary · test-ranking · test-contract     PASS
test-manifest · test-contract-command · test-contract-read PASS
test-evidence · test-baseline                            PASS
contract validate .        15 Stories, 36 ACs, 0 warnings
contract coverage .        36/36 direct evidence · 74/75 files (98.67%)
check --base origin/main --strict     manifest=current, exit 0, zero warnings
```

## Review note

One commit rather than two. Both changes add ACs to `contract.yaml`, and `.tieline/manifest.json` is a committed compiled artifact that records a commit SHA — so splitting would leave an intermediate commit whose manifest is stale, which our own `check --strict` would correctly reject. Worth knowing as a general property: committed compiled artifacts make per-change atomic commits awkward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)