### PR TITLE
fix(matching): require absolute signal magnitude, not just rank, to suggest a link

### DIFF
--- a/.tieline/manifest/MATCHING.json
+++ b/.tieline/manifest/MATCHING.json
@@ -103,7 +103,7 @@
               },
               {
                 "relation": "implements",
-                "reviewed_content_hash": "06ea56c365cd5877eada9ce04c4bd27f5d937761191d1877e12db3eeb4df23f0",
+                "reviewed_content_hash": "5ced89ffc9675ef3210532f5cf0d72c768b64abe9f6c9d2b5c6d1a2d0f1f5a64",
                 "target": {
                   "kind": "code",
                   "path": "src/ranking.ts",
@@ -170,7 +170,7 @@
               },
               {
                 "relation": "tests",
-                "reviewed_content_hash": "d9598f35ac9949ba63c23e4d08f21610913fe623e316a622aabadf2c8f10f956",
+                "reviewed_content_hash": "f73ab70075032befa93734f30d0cbb2834d38752e9ce695436059ad22ddd0f97",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -217,7 +217,7 @@
               },
               {
                 "relation": "implements",
-                "reviewed_content_hash": "a3232c928628b3f599efa5e2d9a9e8d3bbeeeb9aff50e947da957b3a5dca1428",
+                "reviewed_content_hash": "adf23ebbe927ba6534bae791fd0de53a72a7996b8062a0bc647f00d699425595",
                 "target": {
                   "kind": "code",
                   "path": "src/semantic-matching.ts",
@@ -257,6 +257,62 @@
             ],
             "stable_id": "MATCHING-001-AC3",
             "supersedes": null
+          },
+          {
+            "aliases": [],
+            "applies_to": null,
+            "contract_hash": "b82f958e58880eb820901e76e205817a8f3a7c2b2d306dd5ca4cf4900582f6e9",
+            "criterion": "Tieline must withhold a semantic candidate whose vector, lexical, and alias signals all fall below an absolute magnitude floor, even when its blended rank-fusion score clears the presentation cutoff.",
+            "links": [
+              {
+                "relation": "implements",
+                "reviewed_content_hash": "5ced89ffc9675ef3210532f5cf0d72c768b64abe9f6c9d2b5c6d1a2d0f1f5a64",
+                "target": {
+                  "kind": "code",
+                  "path": "src/ranking.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "relation": "implements",
+                "reviewed_content_hash": "adf23ebbe927ba6534bae791fd0de53a72a7996b8062a0bc647f00d699425595",
+                "target": {
+                  "kind": "code",
+                  "path": "src/semantic-matching.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "relation": "tests",
+                "reviewed_content_hash": "f73ab70075032befa93734f30d0cbb2834d38752e9ce695436059ad22ddd0f97",
+                "target": {
+                  "framework_hint": "custom-script",
+                  "kind": "test",
+                  "path": "scripts/test-ranking.ts",
+                  "repository": "tieline"
+                }
+              }
+            ],
+            "position": 3,
+            "rationale": "The blended score is mostly reciprocal rank fusion, which measures a candidate's position inside the returned set rather than how well it matches, so the best member of a weak set scores almost exactly what the best member of a strong set scores. Only a floor on the raw comparable signals stops the least wrong available option from reading as a good match to a caller acting without human review.",
+            "scenarios": [
+              {
+                "given": "the only retrieved candidate carries 0.30 vector similarity and 0.20 lexical similarity",
+                "position": 0,
+                "stable_id": "MATCHING-001-AC4-S1",
+                "then": "the candidate must be withheld even though its blended score clears the presentation cutoff",
+                "when": "Tieline assembles Observation match candidates or planning-create advice"
+              },
+              {
+                "given": "a candidate matches a recorded alias exactly but carries low vector and lexical similarity",
+                "position": 1,
+                "stable_id": "MATCHING-001-AC4-S2",
+                "then": "the candidate must be retained because an exact alias match is a deterministic identifier match rather than a fuzzy one",
+                "when": "Tieline applies the magnitude floor"
+              }
+            ],
+            "stable_id": "MATCHING-001-AC4",
+            "supersedes": null
           }
         ],
         "actor": "author",
@@ -281,6 +337,6 @@
   },
   "input": {
     "path": ".tieline/spec/matching.yaml",
-    "sha256": "70b8d8159d3aff9ac9aa164bfd03aeb4f32a47ec0a7aa7451cb18007f119a5df"
+    "sha256": "ca88d8f9307dffa5ec09541786bca9923c3f8bf60c4c2163f629df7b3bd2d576"
   }
 }

--- a/.tieline/manifest/index.json
+++ b/.tieline/manifest/index.json
@@ -1,6 +1,6 @@
 {
   "repository": {
-    "commit": "2feefc81afda99067a2b31322426a048c2b92ff3",
+    "commit": "5c275b9c19f49cd56e093f80d1f7f507adbb5a3f",
     "key": "tieline"
   },
   "schema_version": 1

--- a/.tieline/spec/matching.yaml
+++ b/.tieline/spec/matching.yaml
@@ -142,3 +142,30 @@ capability:
                 repository: tieline
                 path: scripts/integration-evidence.ts
                 framework_hint: custom-script
+        - key: MATCHING-001-AC4
+          criterion: Tieline must withhold a semantic candidate whose vector, lexical, and alias signals all fall below an absolute magnitude floor, even when its blended rank-fusion score clears the presentation cutoff.
+          rationale: The blended score is mostly reciprocal rank fusion, which measures a candidate's position inside the returned set rather than how well it matches, so the best member of a weak set scores almost exactly what the best member of a strong set scores. Only a floor on the raw comparable signals stops the least wrong available option from reading as a good match to a caller acting without human review.
+          scenarios:
+            - given: the only retrieved candidate carries 0.30 vector similarity and 0.20 lexical similarity
+              when: Tieline assembles Observation match candidates or planning-create advice
+              then: the candidate must be withheld even though its blended score clears the presentation cutoff
+            - given: a candidate matches a recorded alias exactly but carries low vector and lexical similarity
+              when: Tieline applies the magnitude floor
+              then: the candidate must be retained because an exact alias match is a deterministic identifier match rather than a fuzzy one
+          links:
+            - relation: implements
+              target:
+                kind: code
+                repository: tieline
+                path: src/ranking.ts
+            - relation: implements
+              target:
+                kind: code
+                repository: tieline
+                path: src/semantic-matching.ts
+            - relation: tests
+              target:
+                kind: test
+                repository: tieline
+                path: scripts/test-ranking.ts
+                framework_hint: custom-script

--- a/scripts/test-ranking.ts
+++ b/scripts/test-ranking.ts
@@ -1,8 +1,14 @@
 import assert from "node:assert/strict";
 import {
+  SEMANTIC_MAGNITUDE_FLOOR,
+  clearsSemanticMagnitudeFloor,
   groupSemanticHitsAroundAcceptanceCriteria,
   rankSemanticDocuments,
 } from "../src/ranking.js";
+import {
+  SEMANTIC_MATCH_SCORE_FLOOR,
+  isPresentableSemanticMatch,
+} from "../src/semantic-matching.js";
 import { narrowSemanticFilters } from "../src/adapters/postgres/semantic-repository.js";
 import { parseRetrievalProfileDefinition } from "../src/adapters/postgres/profile-repository.js";
 import {
@@ -160,6 +166,186 @@ test("Scenario and AC hits collapse around the same AC", () => {
   );
   assert.equal(grouped.length, 1);
   assert.equal(grouped[0]?.matched_level, "scenario");
+});
+
+test("a weak candidate alone is withheld despite clearing the blended cutoff", () => {
+  const [weak] = rankSemanticDocuments([
+    {
+      document_id: "weak",
+      entity_kind: "acceptance_criterion",
+      entity_id: "ac-weak",
+      canonical_text: "loosely related behavior",
+      matched_level: "acceptance_criterion",
+      acceptance_criterion_id: "ac-weak",
+      vector_score: 0.3,
+      lexical_score: 0.2,
+      metadata: {},
+    },
+  ]);
+  // Rank fusion cannot see that this is the only, and a poor, option.
+  assert.ok((weak?.score ?? 0) >= SEMANTIC_MATCH_SCORE_FLOOR);
+  assert.equal(clearsSemanticMagnitudeFloor(weak!.features), false);
+  assert.equal(isPresentableSemanticMatch(weak!), false);
+});
+
+test("a weak candidate stays withheld when ranked behind stronger ones", () => {
+  const ranked = rankSemanticDocuments([
+    {
+      document_id: "strong-a",
+      entity_kind: "acceptance_criterion",
+      entity_id: "ac-strong-a",
+      canonical_text: "clearly the same behavior",
+      matched_level: "acceptance_criterion",
+      acceptance_criterion_id: "ac-strong-a",
+      vector_score: 0.92,
+      lexical_score: 0.9,
+      metadata: {},
+    },
+    {
+      document_id: "strong-b",
+      entity_kind: "acceptance_criterion",
+      entity_id: "ac-strong-b",
+      canonical_text: "nearly the same behavior",
+      matched_level: "acceptance_criterion",
+      acceptance_criterion_id: "ac-strong-b",
+      vector_score: 0.88,
+      lexical_score: 0.85,
+      metadata: {},
+    },
+    {
+      document_id: "weak",
+      entity_kind: "acceptance_criterion",
+      entity_id: "ac-weak",
+      canonical_text: "loosely related behavior",
+      matched_level: "acceptance_criterion",
+      acceptance_criterion_id: "ac-weak",
+      vector_score: 0.3,
+      lexical_score: 0.2,
+      metadata: {},
+    },
+  ]);
+  const presentable = ranked.filter(isPresentableSemanticMatch);
+  // The blended score barely moves between "only option" and "clearly worst".
+  assert.deepEqual(
+    presentable.map((hit) => hit.document_id),
+    ["strong-a", "strong-b"]
+  );
+  assert.ok(
+    ranked.find((hit) => hit.document_id === "weak")!.score >=
+      SEMANTIC_MATCH_SCORE_FLOOR
+  );
+});
+
+test("a strong candidate clears both admission gates", () => {
+  const [strong] = rankSemanticDocuments([
+    {
+      document_id: "strong",
+      entity_kind: "acceptance_criterion",
+      entity_id: "ac-strong",
+      canonical_text: "the same behavior in other words",
+      matched_level: "acceptance_criterion",
+      acceptance_criterion_id: "ac-strong",
+      vector_score: 0.85,
+      lexical_score: 0.7,
+      metadata: {},
+    },
+  ]);
+  assert.ok(strong!.features.vector >= SEMANTIC_MAGNITUDE_FLOOR.vector);
+  assert.equal(isPresentableSemanticMatch(strong!), true);
+});
+
+test("an exact alias match survives a low similarity score", () => {
+  const ranked = rankSemanticDocuments([
+    {
+      document_id: "strong",
+      entity_kind: "acceptance_criterion",
+      entity_id: "ac-strong",
+      canonical_text: "the same behavior in other words",
+      matched_level: "acceptance_criterion",
+      acceptance_criterion_id: "ac-strong",
+      vector_score: 0.9,
+      lexical_score: 0.85,
+      metadata: {},
+    },
+    {
+      document_id: "alias",
+      entity_kind: "acceptance_criterion",
+      entity_id: "ac-alias",
+      canonical_text: "recorded under an alternate name",
+      matched_level: "acceptance_criterion",
+      acceptance_criterion_id: "ac-alias",
+      vector_score: 0.2,
+      lexical_score: 0.1,
+      alias_match: true,
+      metadata: {},
+    },
+  ]);
+  const alias = ranked.find((hit) => hit.document_id === "alias")!;
+  // Deterministic identifier match, so magnitude never disqualifies it.
+  assert.ok(alias.features.vector < SEMANTIC_MAGNITUDE_FLOOR.vector);
+  assert.ok(alias.features.lexical < SEMANTIC_MAGNITUDE_FLOOR.lexical);
+  assert.equal(isPresentableSemanticMatch(alias), true);
+  assert.match(alias.why.join(" "), /alias/i);
+});
+
+test("the magnitude floor removes candidates without reordering survivors", () => {
+  const ranked = rankSemanticDocuments([
+    {
+      document_id: "weak",
+      entity_kind: "acceptance_criterion",
+      entity_id: "ac-weak",
+      canonical_text: "loosely related behavior",
+      matched_level: "acceptance_criterion",
+      acceptance_criterion_id: "ac-weak",
+      vector_score: 0.3,
+      lexical_score: 0.2,
+      metadata: {},
+    },
+    {
+      document_id: "mid",
+      entity_kind: "acceptance_criterion",
+      entity_id: "ac-mid",
+      canonical_text: "related behavior",
+      matched_level: "acceptance_criterion",
+      acceptance_criterion_id: "ac-mid",
+      vector_score: 0.62,
+      lexical_score: 0.4,
+      metadata: {},
+    },
+    {
+      document_id: "strong",
+      entity_kind: "acceptance_criterion",
+      entity_id: "ac-strong",
+      canonical_text: "the same behavior in other words",
+      matched_level: "acceptance_criterion",
+      acceptance_criterion_id: "ac-strong",
+      vector_score: 0.9,
+      lexical_score: 0.85,
+      metadata: {},
+    },
+    {
+      document_id: "alias",
+      entity_kind: "acceptance_criterion",
+      entity_id: "ac-alias",
+      canonical_text: "recorded under an alternate name",
+      matched_level: "acceptance_criterion",
+      acceptance_criterion_id: "ac-alias",
+      vector_score: 0.2,
+      lexical_score: 0.1,
+      alias_match: true,
+      metadata: {},
+    },
+  ]);
+  const order = ranked.map((hit) => hit.document_id);
+  const presentable = ranked
+    .filter(isPresentableSemanticMatch)
+    .map((hit) => hit.document_id);
+  assert.deepEqual(presentable, ["strong", "mid", "alias"]);
+  // Filtering is a subsequence of the ranked order: nothing is re-sorted.
+  assert.deepEqual(
+    order.filter((id) => presentable.includes(id)),
+    presentable
+  );
 });
 
 test("caller filters can narrow but not broaden a profile", () => {

--- a/src/ranking.ts
+++ b/src/ranking.ts
@@ -143,6 +143,57 @@ export function rankSemanticDocuments(
     );
 }
 
+/**
+ * Minimum RAW signal strength a candidate must reach before it can be presented
+ * as a match.
+ *
+ * `rankSemanticDocuments` blends reciprocal rank fusion (0.65) with the weighted
+ * absolute signals (0.35). RRF is the right tool for FUSING signals whose scales
+ * are not comparable, and the blended score is correct for ORDERING. It is not a
+ * quality measure: RRF awards `weight / (k + rank + 1)`, so it reports where a
+ * candidate sits inside the returned set, not how well it actually matches. The
+ * top of a uniformly terrible set scores nearly what the top of an excellent set
+ * scores, and the gap between rank 1 and rank 4 is a rounding error.
+ *
+ * Measured against this implementation, a candidate with 0.30 vector and 0.20
+ * lexical similarity blends to 0.582 alone and 0.558 when it is plainly the
+ * fourth-best option — 0.024 apart, both comfortably above any cutoff tuned to
+ * admit real matches. So no threshold on the blended score can distinguish "this
+ * is good" from "this was the least wrong thing available".
+ *
+ * These features are absolute similarities on a fixed 0..1 scale, so unlike the
+ * blended score they mean the same thing in every result set. Gating on them is
+ * what keeps a weak candidate from reaching a caller as a suggestion.
+ */
+export const SEMANTIC_MAGNITUDE_FLOOR = {
+  /** Embedding similarity that reads as "the same behavior", not "same topic". */
+  vector: 0.5,
+  /** ts_rank_cd or identifier word-similarity strong enough to stand alone. */
+  lexical: 0.5,
+} as const;
+
+/**
+ * True when a ranked candidate is strong enough on its own terms, independent of
+ * how the rest of the result set happened to score.
+ *
+ * Deliberately conservative: today this filter is the only thing between a weak
+ * match and an agent acting on it, and one strong signal is required rather than
+ * an average, because averaging lets two mediocre signals impersonate one good
+ * one.
+ */
+export function clearsSemanticMagnitudeFloor(
+  features: Pick<SemanticRankingFeatures, "vector" | "lexical" | "alias">
+): boolean {
+  // An exact alias match is a deterministic identifier match, not a fuzzy one.
+  // Someone recorded that phrasing as naming this record, so it always survives
+  // however weak the similarity signals happen to be.
+  if (features.alias === 1) return true;
+  return (
+    features.vector >= SEMANTIC_MAGNITUDE_FLOOR.vector ||
+    features.lexical >= SEMANTIC_MAGNITUDE_FLOOR.lexical
+  );
+}
+
 export function groupSemanticHitsAroundAcceptanceCriteria(
   ranked: RankedSemanticDocument[]
 ): RankedSemanticDocument[] {

--- a/src/semantic-matching.ts
+++ b/src/semantic-matching.ts
@@ -21,8 +21,10 @@ import {
   optionalQueryEmbedding,
 } from "./embeddings.js";
 import {
+  clearsSemanticMagnitudeFloor,
   groupSemanticHitsAroundAcceptanceCriteria,
   rankSemanticDocuments,
+  type RankedSemanticDocument,
   type SemanticRankingFeatures,
 } from "./ranking.js";
 
@@ -69,6 +71,35 @@ function candidateStableId(
     : undefined;
 }
 
+/**
+ * Blended-score cutoff. Kept because the blended score is the correct ORDERING
+ * signal — it is what decides which candidate is better than which.
+ */
+export const SEMANTIC_MATCH_SCORE_FLOOR = 0.45;
+
+/**
+ * Both gates must pass before a candidate is shown to a caller.
+ *
+ * The blended score answers "was this the best available?" — it is 65%
+ * reciprocal rank fusion, which measures rank position rather than match
+ * magnitude, so on its own it cannot tell a good match from the least wrong
+ * option in a bad set (see SEMANTIC_MAGNITUDE_FLOOR). The magnitude floor
+ * answers "was this actually good?" by reading the raw 0..1 similarity features,
+ * which mean the same thing regardless of what else was retrieved.
+ *
+ * These candidates increasingly drive agent behavior rather than human review,
+ * so "best of a bad set" must not reach a caller reading as "good". Prefer
+ * returning nothing over returning a plausible wrong answer.
+ */
+export function isPresentableSemanticMatch(
+  hit: RankedSemanticDocument
+): boolean {
+  return (
+    hit.score >= SEMANTIC_MATCH_SCORE_FLOOR &&
+    clearsSemanticMagnitudeFloor(hit.features)
+  );
+}
+
 export class DefaultSemanticMatcher implements SemanticMatcher {
   constructor(
     private readonly repository = new PostgresSemanticRepository(
@@ -91,9 +122,11 @@ export class DefaultSemanticMatcher implements SemanticMatcher {
       filters,
       limit: 10,
     });
+    // Shared by matchObservation and advisePlanningCreate so both paths apply the
+    // same admission rule.
     return groupSemanticHitsAroundAcceptanceCriteria(
       rankSemanticDocuments(rows)
-    ).filter((hit) => hit.score >= 0.45);
+    ).filter(isPresentableSemanticMatch);
   }
 
   async matchObservation(


### PR DESCRIPTION
Rebuilt onto current `main`. Previously part of #10, which is superseded by #9.

## The problem

`semantic-matching.ts` gated candidates on `hit.score >= 0.45`. That score is rank-fusion-dominated:

```
clamp01((rrf * 0.65 + absolute * 0.35) * applicabilityPenalty)
```

RRF measures **rank position**, not match magnitude, and carries 0.65 of the weight. Since it awards `weight / (60 + rank + 1)`, rank 1 and rank 4 are nearly identical. The gate answered *"best available?"* not *"actually good?"*

Measured against the real implementation:

| case | blended | before | after |
|---|---|---|---|
| weak alone (v .30 / l .20) | 0.582 | admitted | **rejected** |
| same weak, 4th behind three strong | 0.558 | admitted | **rejected** |
| v .49 / l .49 | 0.641 | admitted | **rejected** |
| strong (v .85 / l .70) | 0.729 | admitted | admitted |
| alias match (v .20 / l .10) | 0.611 | admitted | admitted |
| alias buried behind 9 strong | 0.569 | admitted | admitted |

**0.024 of movement** between best-of-set and clearly-fourth-best. When the right acceptance criterion isn't in the candidate set at all, the least-wrong option still clears the bar — and these suggestions increasingly drive agent behaviour rather than human review.

## The fix

`SEMANTIC_MAGNITUDE_FLOOR` + `clearsSemanticMagnitudeFloor` in `ranking.ts`, composed with the existing cutoff as `isPresentableSemanticMatch` in the shared `candidates()` helper — so both `matchObservation` and `advisePlanningCreate` get it.

A candidate must clear **both** gates: the blend (ordering) and an absolute floor on the underlying features (quality).

Disjunction, not a weighted average of features — averaging lets two mediocre signals impersonate one good one, which is the same failure mode being fixed. Exact alias matches short-circuit first: a deterministic identifier match must never be disqualified on magnitude.

`rankSemanticDocuments` is untouched. RRF remains correct for **ordering** — the bug was using a rank-derived value as an absolute quality gate. A test asserts the retained set is a subsequence of the ranked order, so filtering provably never reorders.

## Contract

Adds `MATCHING-001-AC4`. Existing ACs don't cover it — AC2 governs fusion/ranking (unchanged), AC3 governs suggestion *state* after admission, not admission itself.

## Verification

Offline, every `DATABASE_URL*` unset:

```
tsc --noEmit                clean
test-ranking                14 passed, 0 failed
test-contract · test-manifest · test-impact         PASS
test-contract-command · test-evidence               PASS
test-link-plausibility · test-reconciliation        PASS   ← main's new suites
contract validate .         12 Stories, 24 ACs, 0 warnings
contract coverage .         24/24 direct evidence links
```

Manifest recompiled against main's updated `manifest.ts`.

## Note

Pre-existing and untouched: a lexical-only candidate (vector 0) can never clear the blended cutoff — v0/l0.80 blends to 0.186 — so the no-embedding-provider path through `candidates()` already returns nothing today. Possibly in tension with the `MATCHING-001-AC2` scenario about returning full-text matches without an embedding provider. Needs its own decision rather than a patch here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)