### PR TITLE
fix(sync): reconcile orphaned code assets so the projection matches the manifest

### DIFF
--- a/.tieline/manifest.json
+++ b/.tieline/manifest.json
@@ -85,7 +85,7 @@
               "links": [
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "59058a247377fb3428241fd80b53c489adf6270eb3da9162bb8345e17cdf258a",
+                  "reviewed_content_hash": "57e9533a1b6a182bfa1d289f5b46ed8cb609e52f272dc7e2abd0caeae35b46dd",
                   "target": {
                     "kind": "code",
                     "path": "src/adapters/postgres/contract-sync-repository.ts",
@@ -94,7 +94,7 @@
                 },
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "3edd50e5faf5ef6edb540692bde84b7cff5d0543b0f37a87c7162d8d9cbfc1cc",
+                  "reviewed_content_hash": "5887a1dd6baba9655bde50a48999281c2e4a68d54e915034e2a3bc7770556f75",
                   "target": {
                     "kind": "code",
                     "path": "src/contract/sync.ts",
@@ -121,7 +121,7 @@
                 },
                 {
                   "relation": "tests",
-                  "reviewed_content_hash": "2a945c58248587245717fa875df640a1babca0ab62b70c44cd2906758316d1de",
+                  "reviewed_content_hash": "ee0e74592e60aca7f0c2aa1ab082617ef419a5a7ef5a8c5fad041bbdd1d86410",
                   "target": {
                     "framework_hint": "custom-script",
                     "kind": "test",
@@ -161,7 +161,7 @@
                 },
                 {
                   "relation": "enforces",
-                  "reviewed_content_hash": "50375ac04a62d4c02bf724c3902ccf2ee14b757819c13b29e6fcc837d77a6f02",
+                  "reviewed_content_hash": "8c5db15ee31587c3ef2de4b10fabcea91c166deca9c49ddcc8ddd61ee3921fae",
                   "target": {
                     "kind": "code",
                     "path": "src/commands/migrate.ts",
@@ -221,6 +221,46 @@
               "scenarios": [],
               "stable_id": "AUTHORITY-002-AC2",
               "supersedes": null
+            },
+            {
+              "aliases": [],
+              "applies_to": null,
+              "contract_hash": "ea86d1fa82ca27d888dbc487bd9d17d3b7a27471369399a89fbabef9a14e3932",
+              "criterion": "Tieline must remove projected code assets that the synchronized repository contract no longer declares and that no contract record still links.",
+              "links": [
+                {
+                  "relation": "implements",
+                  "reviewed_content_hash": "57e9533a1b6a182bfa1d289f5b46ed8cb609e52f272dc7e2abd0caeae35b46dd",
+                  "target": {
+                    "kind": "code",
+                    "path": "src/adapters/postgres/contract-sync-repository.ts",
+                    "repository": "tieline"
+                  }
+                },
+                {
+                  "relation": "tests",
+                  "reviewed_content_hash": "ee0e74592e60aca7f0c2aa1ab082617ef419a5a7ef5a8c5fad041bbdd1d86410",
+                  "target": {
+                    "framework_hint": "custom-script",
+                    "kind": "test",
+                    "path": "scripts/integration-contract-sync.ts",
+                    "repository": "tieline"
+                  }
+                }
+              ],
+              "position": 2,
+              "rationale": "Postgres is a projection of the repository manifest, so a renamed path or a reworded selector otherwise strands a code asset that holds a frozen content hash and still answers the artifact overlap lookup, and the projection drifts further with every rename until it is rebuilt from scratch.",
+              "scenarios": [
+                {
+                  "given": "a synchronized repository contract whose linked implementation path was renamed",
+                  "position": 0,
+                  "stable_id": "AUTHORITY-002-AC3-S1",
+                  "then": "the code asset for the former path must be removed, while an asset owned by another repository or still linked by another contract record must be retained",
+                  "when": "the repository contract is synchronized again"
+                }
+              ],
+              "stable_id": "AUTHORITY-002-AC3",
+              "supersedes": null
             }
           ],
           "actor": "maintainer",
@@ -270,7 +310,7 @@
                 },
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "865a3393f1335b8478952af1e063d6afedebd570cbc08969d0ad8ba72d3009b8",
+                  "reviewed_content_hash": "9aed2036f597e76209167acdc3ff73d8dceb50842a5acfffd42e30e1feaaee14",
                   "target": {
                     "kind": "code",
                     "path": "src/contract/load.ts",
@@ -279,7 +319,7 @@
                 },
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "d7195fb21bb3efc8c19bcb5ba00fe7f657ebdd8e2210c1c3c1a00491d1fb6a62",
+                  "reviewed_content_hash": "3f15cb80178a5d8d463f9eeb0c99a500320c185843588ea35d8b2312741a9efe",
                   "target": {
                     "kind": "code",
                     "path": "src/contract/schema.ts",
@@ -288,7 +328,7 @@
                 },
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "1748a7d73a311a2c15619fc8c0427e610b48317a387aa1b99647d995c8b977f6",
+                  "reviewed_content_hash": "4b22c3ffb795335d3411fefb28adf686805155ef45d8688636cad33a1f8f03f4",
                   "target": {
                     "kind": "code",
                     "path": "src/contract/validate.ts",
@@ -297,7 +337,7 @@
                 },
                 {
                   "relation": "tests",
-                  "reviewed_content_hash": "4b737e2a7abe4ce695d78233d8a929d955657db63415ade0996be45e3f2e01d9",
+                  "reviewed_content_hash": "19f3d11c2b5b191bf27f0093765c5bba91ce69c68a66a24167e511821d1b32b5",
                   "target": {
                     "framework_hint": "custom-script",
                     "kind": "test",
@@ -320,7 +360,7 @@
               "links": [
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "6b7d8e315658c48279664fb436284d00ccae036c4975ed911a21444681877a6c",
+                  "reviewed_content_hash": "4f7f711a77fa9811bd3797b3a350b566ab4a503df945cbbf1509b8536208b421",
                   "target": {
                     "kind": "code",
                     "path": "src/commands/contract.ts",
@@ -329,7 +369,7 @@
                 },
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "59a9695169dcaac4adaac44db5b1f8ad40aed2e8e601651b6cda94d27310490b",
+                  "reviewed_content_hash": "fbea3757e99fae29e4c35a29ac13eba324b8967637328ce23b0cd7942f2dab67",
                   "target": {
                     "kind": "code",
                     "path": "src/contract/coverage.ts",
@@ -338,7 +378,7 @@
                 },
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "53e3da943c557d7e569f6ae7101c68b96a0d221728e01da1a9402df520cd7c27",
+                  "reviewed_content_hash": "e9807062093f1706d38bcbad8f1c8b501862dd58c386cacff8d29253b88eb627",
                   "target": {
                     "kind": "code",
                     "path": "src/contract/manifest.ts",
@@ -347,7 +387,7 @@
                 },
                 {
                   "relation": "tests",
-                  "reviewed_content_hash": "9e979c47c4f1aff7460fab681ad7589d409b831d72ced177058e9c8f3ea253c7",
+                  "reviewed_content_hash": "904223be32138dba034ee9b355a7fd19cc39d91d99edcb58b7892bbf89eed61b",
                   "target": {
                     "framework_hint": "custom-script",
                     "kind": "test",
@@ -357,7 +397,7 @@
                 },
                 {
                   "relation": "tests",
-                  "reviewed_content_hash": "4b737e2a7abe4ce695d78233d8a929d955657db63415ade0996be45e3f2e01d9",
+                  "reviewed_content_hash": "19f3d11c2b5b191bf27f0093765c5bba91ce69c68a66a24167e511821d1b32b5",
                   "target": {
                     "framework_hint": "custom-script",
                     "kind": "test",
@@ -367,7 +407,7 @@
                 },
                 {
                   "relation": "tests",
-                  "reviewed_content_hash": "fd3505706fed658a7eae5ec1bb6df1df82058ecf01b9c62615d23a845a93e845",
+                  "reviewed_content_hash": "e35423435ad4bf723d2f1dd0c8321b38408126f3139a261cc1156588aa455a11",
                   "target": {
                     "framework_hint": "custom-script",
                     "kind": "test",
@@ -405,7 +445,7 @@
               "links": [
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "8658042b5b98b999bd8bcd868ab67dea6b13c7dbb36043501928600c3d05da41",
+                  "reviewed_content_hash": "a2ec7e26193533394b9393fe3533542c861b30924a40372f524ff4b75e275ca9",
                   "target": {
                     "kind": "code",
                     "path": "src/commands/check.ts",
@@ -414,7 +454,7 @@
                 },
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "007031264fd70b6e07a6a710d09e7d121fa5455b0291489d40dea6fad066d03c",
+                  "reviewed_content_hash": "b8cf43553b2ab0c49cc91e58db347f22d84c9a5db22fe2a66410558220e26dfd",
                   "target": {
                     "kind": "code",
                     "path": "src/contract/impact.ts",
@@ -423,7 +463,7 @@
                 },
                 {
                   "relation": "tests",
-                  "reviewed_content_hash": "64ebf4b9b8310605fecdbdf7cd1faf4ba75be95bd93dbc277789d615e3130183",
+                  "reviewed_content_hash": "d525a30587ed973d00302f3abea9685d8308ea13ddee0bc46841d1148b4e1daf",
                   "target": {
                     "framework_hint": "custom-script",
                     "kind": "test",
@@ -454,7 +494,7 @@
               "links": [
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "6b7d8e315658c48279664fb436284d00ccae036c4975ed911a21444681877a6c",
+                  "reviewed_content_hash": "4f7f711a77fa9811bd3797b3a350b566ab4a503df945cbbf1509b8536208b421",
                   "target": {
                     "kind": "code",
                     "path": "src/commands/contract.ts",
@@ -472,7 +512,7 @@
                 },
                 {
                   "relation": "tests",
-                  "reviewed_content_hash": "9e979c47c4f1aff7460fab681ad7589d409b831d72ced177058e9c8f3ea253c7",
+                  "reviewed_content_hash": "904223be32138dba034ee9b355a7fd19cc39d91d99edcb58b7892bbf89eed61b",
                   "target": {
                     "framework_hint": "custom-script",
                     "kind": "test",
@@ -686,7 +726,7 @@
                 },
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "9169881790a4d521c42f60ab39e8bb387602f57ce08c4fcf47597948bd789422",
+                  "reviewed_content_hash": "ee6149d24121327462dfca0d6620be890989ed2e7f2fd2343669e2fdb41b200f",
                   "target": {
                     "kind": "code",
                     "path": "src/commands/import-help.ts",
@@ -713,7 +753,7 @@
                 },
                 {
                   "relation": "tests",
-                  "reviewed_content_hash": "2a945c58248587245717fa875df640a1babca0ab62b70c44cd2906758316d1de",
+                  "reviewed_content_hash": "ee0e74592e60aca7f0c2aa1ab082617ef419a5a7ef5a8c5fad041bbdd1d86410",
                   "target": {
                     "framework_hint": "custom-script",
                     "kind": "test",
@@ -814,7 +854,7 @@
               "links": [
                 {
                   "relation": "enforces",
-                  "reviewed_content_hash": "c5306bf0d66e3b3998f2fadda214b8be1e2b7d8e602056957e89dbae4a19ce1e",
+                  "reviewed_content_hash": "9f99c3ac24bd8f87617d85e1ccf8aa8486ca05351a70a38f8f275a6bbb24a7a6",
                   "target": {
                     "kind": "code",
                     "path": "migrations/0001_baseline.sql",
@@ -1138,7 +1178,7 @@
                 },
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "f8bbad853cd001d369bb872543e50952015546974811745197d69f24ab6365d3",
+                  "reviewed_content_hash": "03156259c3016f0b25c5e066d90cc4a8b4fc8ad4f2c5407c1f07d80d2e797c19",
                   "target": {
                     "kind": "code",
                     "path": "src/commands/profile.ts",
@@ -1225,7 +1265,7 @@
               "links": [
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "e916a9e0067faf2b3238a133876c048616a5fa8aa97c4dfbeda34ea7b75efe7d",
+                  "reviewed_content_hash": "8e45b513f6d90428c9b63667e42e0acddf64cce5e63904cc673f46f76ed0facc",
                   "target": {
                     "kind": "code",
                     "path": "src/cli.ts",
@@ -1252,7 +1292,7 @@
                 },
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "eeb3608233dbc8468855ff6de1394148aa6a19177345aba900146e88b0169e4e",
+                  "reviewed_content_hash": "bbf7f4a942fd9944ec90a1cb775f7c5eee69029cb9eea8cd2567e4fd07884e64",
                   "target": {
                     "kind": "code",
                     "path": "src/tieline/workspace.ts",
@@ -1261,7 +1301,7 @@
                 },
                 {
                   "relation": "tests",
-                  "reviewed_content_hash": "57ec05b979d0807a36cdd4d25379e9e726bd65bcc5392833d0c42e04429bf2c7",
+                  "reviewed_content_hash": "18a50d6bbf9011cf1d2137d2117de8dd4a2c35a9ef7e5ffd674d3e003f7ad5cb",
                   "target": {
                     "framework_hint": "custom-script",
                     "kind": "test",
@@ -1311,7 +1351,7 @@
                 },
                 {
                   "relation": "tests",
-                  "reviewed_content_hash": "57ec05b979d0807a36cdd4d25379e9e726bd65bcc5392833d0c42e04429bf2c7",
+                  "reviewed_content_hash": "18a50d6bbf9011cf1d2137d2117de8dd4a2c35a9ef7e5ffd674d3e003f7ad5cb",
                   "target": {
                     "framework_hint": "custom-script",
                     "kind": "test",
@@ -1334,7 +1374,7 @@
               "links": [
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "e916a9e0067faf2b3238a133876c048616a5fa8aa97c4dfbeda34ea7b75efe7d",
+                  "reviewed_content_hash": "8e45b513f6d90428c9b63667e42e0acddf64cce5e63904cc673f46f76ed0facc",
                   "target": {
                     "kind": "code",
                     "path": "src/cli.ts",
@@ -1352,7 +1392,7 @@
                 },
                 {
                   "relation": "tests",
-                  "reviewed_content_hash": "57ec05b979d0807a36cdd4d25379e9e726bd65bcc5392833d0c42e04429bf2c7",
+                  "reviewed_content_hash": "18a50d6bbf9011cf1d2137d2117de8dd4a2c35a9ef7e5ffd674d3e003f7ad5cb",
                   "target": {
                     "framework_hint": "custom-script",
                     "kind": "test",
@@ -1469,7 +1509,7 @@
               "links": [
                 {
                   "relation": "enforces",
-                  "reviewed_content_hash": "464f48121da6ec46b431cc4bc44f164698b5bd5cf4539831241f976146db7d4b",
+                  "reviewed_content_hash": "f8071433f0755226afdf3ad8ef2ad0aa2831cb7a32bc583f778c09bd0269a7c0",
                   "target": {
                     "kind": "code",
                     "path": "src/config.ts",
@@ -1478,7 +1518,7 @@
                 },
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "82313b0bb9728c6c918a155afe7419697b1f945326d56b36cfe64a59bb992e61",
+                  "reviewed_content_hash": "1f479c20a7c785e83b58440e9fdd4a9c616d9128fa28ab6980dde664a2980c77",
                   "target": {
                     "kind": "code",
                     "path": "src/commands/serve.ts",
@@ -1578,7 +1618,7 @@
               "links": [
                 {
                   "relation": "implements",
-                  "reviewed_content_hash": "9e2ee6b624c71f5ee003094a70aa84ce49396b6e5417871f17d0e88d1adacdda",
+                  "reviewed_content_hash": "cf8dbcf2859defd42aa4fd76fbc26afb18aa4461be8806e3a840c1988f2d0bf9",
                   "target": {
                     "kind": "code",
                     "path": "skills/tieline-author/SKILL.md",
@@ -1615,7 +1655,7 @@
                 },
                 {
                   "relation": "tests",
-                  "reviewed_content_hash": "57ec05b979d0807a36cdd4d25379e9e726bd65bcc5392833d0c42e04429bf2c7",
+                  "reviewed_content_hash": "18a50d6bbf9011cf1d2137d2117de8dd4a2c35a9ef7e5ffd674d3e003f7ad5cb",
                   "target": {
                     "framework_hint": "custom-script",
                     "kind": "test",
@@ -1702,7 +1742,7 @@
   "inputs": [
     {
       "path": ".tieline/spec/authority.yaml",
-      "sha256": "fd1f19df50f8d0412250da6bdf46771ac69c03f6becb9e0df43eb95befd8775d"
+      "sha256": "9554b679f02df2d67e5a67a724c43f13adfb97fb388b5ea0dcdd284f0e5fa4fc"
     },
     {
       "path": ".tieline/spec/contract.yaml",
@@ -1726,7 +1766,7 @@
     }
   ],
   "repository": {
-    "commit": "5fc640d13d11aa6d69bf9d39908dc772d83373d6",
+    "commit": "e5430cbd81c3e87a4b1b744d56c6deb6119c88c8",
     "key": "tieline"
   },
   "schema_version": 1

--- a/.tieline/spec/authority.yaml
+++ b/.tieline/spec/authority.yaml
@@ -115,3 +115,22 @@ capability:
                 repository: tieline
                 path: scripts/integration-baseline.ts
                 framework_hint: custom-script
+        - key: AUTHORITY-002-AC3
+          criterion: Tieline must remove projected code assets that the synchronized repository contract no longer declares and that no contract record still links.
+          rationale: Postgres is a projection of the repository manifest, so a renamed path or a reworded selector otherwise strands a code asset that holds a frozen content hash and still answers the artifact overlap lookup, and the projection drifts further with every rename until it is rebuilt from scratch.
+          scenarios:
+            - given: a synchronized repository contract whose linked implementation path was renamed
+              when: the repository contract is synchronized again
+              then: the code asset for the former path must be removed, while an asset owned by another repository or still linked by another contract record must be retained
+          links:
+            - relation: implements
+              target:
+                kind: code
+                repository: tieline
+                path: src/adapters/postgres/contract-sync-repository.ts
+            - relation: tests
+              target:
+                kind: test
+                repository: tieline
+                path: scripts/integration-contract-sync.ts
+                framework_hint: custom-script

--- a/migrations/0001_baseline.sql
+++ b/migrations/0001_baseline.sql
@@ -714,7 +714,8 @@ grant delete on
   story_code_assets,
   criterion_code_assets,
   story_help_articles,
-  criterion_help_articles
+  criterion_help_articles,
+  code_assets
 to tieline_repository_sync;
 grant usage, select on all sequences in schema public to tieline_repository_sync;
 

--- a/scripts/integration-contract-sync.ts
+++ b/scripts/integration-contract-sync.ts
@@ -33,6 +33,7 @@ function contractYaml(input: {
   originId: string;
   originRevision: number;
   includeSecondCriterion?: boolean;
+  implementationPath?: string;
 }): string {
   return `version: 1
 capability:
@@ -78,6 +79,15 @@ capability:
                 source: intercom
                 external_id: unresolved-help-article
 ${
+  input.implementationPath
+    ? `            - relation: implements
+              target:
+                kind: code
+                repository: sync-integration
+                path: ${input.implementationPath}
+`
+    : ""
+}${
   input.includeSecondCriterion
     ? `        - key: ${input.storyKey}-AC2
           criterion: Tieline must retire a removed acceptance criterion without deleting observations.
@@ -167,7 +177,9 @@ try {
   ) => {
     await sql.unsafe("set role tieline_repository_sync");
     try {
-      return await syncContractManifest(store, manifest, options);
+      // Calls the adapter directly so the reconciliation diagnostic it reports
+      // beyond ContractSyncResult stays typed.
+      return await store.sync(manifest, options);
     } finally {
       await sql.unsafe("reset role");
     }
@@ -590,6 +602,151 @@ try {
     ),
     ContractSyncCheckpointError
   );
+
+  // Postgres is a projection of the repository manifest, so a code asset the
+  // manifest stopped declaring must not survive as an orphan. Seed the rows a
+  // careless delete would take with it: another repository's asset sharing the
+  // renamed path, and two sync-integration assets that only another
+  // repository's Story and Acceptance Criterion still link.
+  const [foreignRepository] = await sql<{ id: string }[]>`
+    insert into repositories (key, display_name)
+    values ('foreign-integration', 'Foreign integration')
+    returning id`;
+  const [foreignPathTwin] = await sql<{ id: string }[]>`
+    insert into code_assets (repository_id, kind, path)
+    values (${foreignRepository.id}, 'code', 'src/before-rename.ts')
+    returning id`;
+  const [foreignStory] = await sql<{ id: string }[]>`
+    insert into user_stories (
+      repository_id, stable_id, title, actor, goal, benefit, lifecycle, authority
+    ) values (
+      ${foreignRepository.id}, 'FOREIGN-001', 'Consume a shared asset',
+      'maintainer', 'link an asset another repository owns',
+      'one file can carry contracts from two repositories',
+      'production', 'repository'
+    )
+    returning id`;
+  const [foreignCriterion] = await sql<{ id: string }[]>`
+    insert into acceptance_criteria (
+      story_id, repository_id, stable_id, criterion, position, authority
+    ) values (
+      ${foreignStory.id}, ${foreignRepository.id}, 'FOREIGN-001-AC1',
+      'Tieline must keep a shared asset another repository still links.',
+      0, 'repository'
+    )
+    returning id`;
+  const [storyLinkedAsset] = await sql<{ id: string }[]>`
+    insert into code_assets (repository_id, kind, path)
+    values (${repository.id}, 'code', 'src/linked-by-foreign-story.ts')
+    returning id`;
+  const [criterionLinkedAsset] = await sql<{ id: string }[]>`
+    insert into code_assets (repository_id, kind, path)
+    values (${repository.id}, 'code', 'src/linked-by-foreign-criterion.ts')
+    returning id`;
+  await sql`
+    insert into story_code_assets (story_id, asset_id, relation)
+    values (${foreignStory.id}, ${storyLinkedAsset.id}, 'implements')`;
+  await sql`
+    insert into criterion_code_assets (criterion_id, asset_id, relation)
+    values (${foreignCriterion.id}, ${criterionLinkedAsset.id}, 'implements')`;
+
+  mkdirSync(resolve(root, "src"), { recursive: true });
+  writeFileSync(
+    resolve(root, "src/before-rename.ts"),
+    "export const projection = 'before';\n"
+  );
+  writeFileSync(
+    resolve(root, ".tieline/spec/sync.yaml"),
+    contractYaml({
+      capabilityKey: "CONFLICT",
+      storyKey: "CONFLICT-001",
+      title: "Reconciled repository title",
+      originId: conflictStory.id,
+      originRevision: 1,
+      implementationPath: "src/before-rename.ts",
+    })
+  );
+  const beforeRename = await syncAsRepositoryRole(
+    compileContractManifest({
+      repositoryRoot: root,
+      repositoryKey: "sync-integration",
+      commit: "commit-five",
+    }),
+    { expectedPreviousCommit: "commit-four" }
+  );
+  assert.equal(beforeRename.reconciled_code_assets, 0);
+  const [projectedBeforeRename] = await sql<{ id: string }[]>`
+    select id from code_assets
+    where repository_id = ${repository.id} and path = 'src/before-rename.ts'`;
+  assert.ok(projectedBeforeRename);
+
+  rmSync(resolve(root, "src/before-rename.ts"));
+  writeFileSync(
+    resolve(root, "src/after-rename.ts"),
+    "export const projection = 'after';\n"
+  );
+  writeFileSync(
+    resolve(root, ".tieline/spec/sync.yaml"),
+    contractYaml({
+      capabilityKey: "CONFLICT",
+      storyKey: "CONFLICT-001",
+      title: "Reconciled repository title",
+      originId: conflictStory.id,
+      originRevision: 1,
+      implementationPath: "src/after-rename.ts",
+    })
+  );
+  const afterRename = await syncAsRepositoryRole(
+    compileContractManifest({
+      repositoryRoot: root,
+      repositoryKey: "sync-integration",
+      commit: "commit-six",
+    }),
+    { expectedPreviousCommit: "commit-five" }
+  );
+  assert.equal(afterRename.reconciled_code_assets, 1);
+  const projectedPaths = await sql<{ path: string }[]>`
+    select path from code_assets
+    where repository_id = ${repository.id}
+    order by path`;
+  assert.deepEqual(
+    projectedPaths.map((row) => row.path),
+    [
+      "scripts/sync.test.ts",
+      "src/after-rename.ts",
+      "src/linked-by-foreign-criterion.ts",
+      "src/linked-by-foreign-story.ts",
+    ]
+  );
+  const [foreignPathTwinAfter] = await sql<{ id: string }[]>`
+    select id from code_assets where id = ${foreignPathTwin.id}`;
+  assert.equal(foreignPathTwinAfter?.id, foreignPathTwin.id);
+  const [reconciledAudit] = await sql<{ reconciled: string }[]>`
+    select detail->>'reconciled_code_assets' as reconciled
+    from audit_events
+    where event_kind = 'repository_contract_synced'
+    order by occurred_at desc, id desc
+    limit 1`;
+  assert.equal(reconciledAudit.reconciled, "1");
+
+  // Re-running the same commit repairs a projection that already carries
+  // orphans, so drift never requires rebuilding the database from scratch.
+  const [staleOrphan] = await sql<{ id: string }[]>`
+    insert into code_assets (repository_id, kind, path, selector)
+    values (${repository.id}, 'code', 'src/after-rename.ts', 'reworded selector')
+    returning id`;
+  const repaired = await syncAsRepositoryRole(
+    compileContractManifest({
+      repositoryRoot: root,
+      repositoryKey: "sync-integration",
+      commit: "commit-six",
+    })
+  );
+  assert.equal(repaired.outcome, "unchanged");
+  assert.equal(repaired.reconciled_code_assets, 1);
+  const [staleOrphanAfter] = await sql<{ id: string }[]>`
+    select id from code_assets where id = ${staleOrphan.id}`;
+  assert.equal(staleOrphanAfter, undefined);
 
   const [helpStub] = await sql<{ title: string | null; markdown: string | null }[]>`
     select title, markdown from help_articles

--- a/src/adapters/postgres/contract-sync-repository.ts
+++ b/src/adapters/postgres/contract-sync-repository.ts
@@ -176,10 +176,16 @@ async function ensureCodeAsset(
   return raced[0].id;
 }
 
-async function refreshCodeAssetHashes(
-  tx: Tx,
+/**
+ * Every code or test locator this manifest declares against its own
+ * repository, keyed by the `code_assets` identity tuple
+ * `(kind, path, selector, framework_hint)`. Locators aimed at another
+ * repository are excluded: this repository does not own those rows and must
+ * never treat their absence from its own manifest as a reason to touch them.
+ */
+function localCodeAssetLinks(
   manifest: ContractManifest
-): Promise<void> {
+): Map<string, ManifestLink> {
   const localLinks = new Map<string, ManifestLink>();
   for (const capability of manifest.capabilities) {
     for (const story of capability.stories) {
@@ -205,9 +211,82 @@ async function refreshCodeAssetHashes(
       }
     }
   }
-  for (const link of localLinks.values()) {
+  return localLinks;
+}
+
+async function refreshCodeAssetHashes(
+  tx: Tx,
+  manifest: ContractManifest
+): Promise<void> {
+  for (const link of localCodeAssetLinks(manifest).values()) {
     await ensureCodeAsset(tx, manifest.repository.key, link);
   }
+}
+
+/**
+ * Removes `code_assets` rows this repository no longer declares.
+ *
+ * Postgres is a projection of the repository manifest, so an asset whose
+ * identity tuple leaves the manifest - a renamed path, a reworded selector,
+ * the same file linked once with and once without a selector - must not
+ * survive as an orphan. Orphans stay reachable: `search-context.ts` joins
+ * `code_assets` by `(repository, kind, path, selector)` with a null request
+ * selector matching any stored selector, so a frozen orphan keeps feeding the
+ * `artifact_overlap` ranking signal and the noise grows with every rename.
+ *
+ * Two guards make the delete safe:
+ *
+ * 1. `repository_id` is pinned to the repository being synced. Links may aim
+ *    at another repository (`ensureCodeAsset` resolves those through
+ *    `link.target.repository`), and a sync of repository X must never delete
+ *    an asset owned by repository Y.
+ * 2. Both junction tables are checked globally rather than per repository, so
+ *    an asset that any Story or Acceptance Criterion still references -
+ *    including a retired one, and including one belonging to a different
+ *    repository - is retained.
+ */
+async function reconcileCodeAssets(
+  tx: Tx,
+  repositoryId: string,
+  manifest: ContractManifest
+): Promise<number> {
+  const kinds: string[] = [];
+  const paths: string[] = [];
+  const selectors: string[] = [];
+  const frameworkHints: string[] = [];
+  for (const link of localCodeAssetLinks(manifest).values()) {
+    if (link.target.kind === "help") continue;
+    kinds.push(link.target.kind);
+    paths.push(link.target.path);
+    selectors.push(link.target.selector ?? "");
+    frameworkHints.push(
+      link.target.kind === "test" ? link.target.framework_hint ?? "" : ""
+    );
+  }
+  const removed = await tx<{ id: string }[]>`
+    delete from code_assets asset
+    where asset.repository_id = ${repositoryId}
+      and not exists (
+        select 1
+        from unnest(
+          ${kinds}::text[],
+          ${paths}::text[],
+          ${selectors}::text[],
+          ${frameworkHints}::text[]
+        ) as declared(kind, path, selector, framework_hint)
+        where declared.kind = asset.kind
+          and declared.path = asset.path
+          and declared.selector = coalesce(asset.selector, '')
+          and declared.framework_hint = coalesce(asset.framework_hint, '')
+      )
+      and not exists (
+        select 1 from story_code_assets link where link.asset_id = asset.id
+      )
+      and not exists (
+        select 1 from criterion_code_assets link where link.asset_id = asset.id
+      )
+    returning asset.id`;
+  return removed.length;
 }
 
 async function ensureHelpArticle(tx: Tx, link: ManifestLink): Promise<string> {
@@ -834,6 +913,14 @@ export class PostgresContractSyncRepository
 
       if (currentCommit === manifest.repository.commit) {
         await refreshCodeAssetHashes(tx, manifest);
+        // Reconcile on the unchanged path too: re-running sync at the same
+        // commit is how a projection carrying orphans from an earlier release
+        // repairs itself, without forcing a rebuild from scratch.
+        const reconciledCodeAssets = await reconcileCodeAssets(
+          tx,
+          repositoryId,
+          manifest
+        );
         return {
           outcome: "unchanged" as const,
           repository: manifest.repository.key,
@@ -842,6 +929,7 @@ export class PostgresContractSyncRepository
           acceptance_criteria: counts.acceptanceCriteria,
           retired_stories: 0,
           retired_acceptance_criteria: 0,
+          reconciled_code_assets: reconciledCodeAssets,
           conflicts: [],
         };
       }
@@ -977,6 +1065,14 @@ export class PostgresContractSyncRepository
 
       await applySupersession(tx, repositoryId, manifest);
 
+      // Runs last so every junction row this manifest declares has already
+      // been rebuilt; anything still unreferenced is genuinely orphaned.
+      const reconciledCodeAssets = await reconcileCodeAssets(
+        tx,
+        repositoryId,
+        manifest
+      );
+
       await tx`
         insert into repository_sync_checkpoints (
           repository_id, commit_sha, synced_at
@@ -996,6 +1092,7 @@ export class PostgresContractSyncRepository
             acceptance_criteria: counts.acceptanceCriteria,
             retired_stories: retiredStories.length,
             retired_acceptance_criteria: retiredCriteria.length,
+            reconciled_code_assets: reconciledCodeAssets,
             handoff_conflicts: conflicts.length,
           })}
         )`;
@@ -1008,6 +1105,7 @@ export class PostgresContractSyncRepository
         acceptance_criteria: counts.acceptanceCriteria,
         retired_stories: retiredStories.length,
         retired_acceptance_criteria: retiredCriteria.length,
+        reconciled_code_assets: reconciledCodeAssets,
         conflicts,
       };
     });

--- a/src/commands/contract.ts
+++ b/src/commands/contract.ts
@@ -464,7 +464,7 @@ export async function runContractCommand(
               re_embedded: indexing.embedded,
               semantic_index: indexing,
             }, null, 2)}\n`
-          : `Contract ${result.outcome}: ${result.stories} Stories, ${result.acceptance_criteria} acceptance criteria, ${result.conflicts.length} handoff conflict(s); ${indexing.documents} semantic document(s) indexed (${indexing.embedded} embedded, ${indexing.unchanged} unchanged, ${indexing.embedding_unavailable} embedding unavailable).\n`
+          : `Contract ${result.outcome}: ${result.stories} Stories, ${result.acceptance_criteria} acceptance criteria, ${result.conflicts.length} handoff conflict(s), ${result.reconciled_code_assets} orphaned code asset(s) reconciled; ${indexing.documents} semantic document(s) indexed (${indexing.embedded} embedded, ${indexing.unchanged} unchanged, ${indexing.embedding_unavailable} embedding unavailable).\n`
       );
       return 0;
     } finally {

--- a/src/contract/sync.ts
+++ b/src/contract/sync.ts
@@ -20,6 +20,11 @@ export interface ContractSyncResult {
   retired_stories: number;
   retired_acceptance_criteria: number;
   conflicts: HandoffConflict[];
+  /**
+   * Orphaned `code_assets` rows the projection repaired on this run. Reported
+   * so drift is visible rather than accumulating silently across renames.
+   */
+  reconciled_code_assets: number;
 }
 
 export interface ContractSyncRepository {


### PR DESCRIPTION
Rebuilt onto current `main`. Previously part of #10, which is superseded by #9.

> ⚠️ **More urgent after #9.** Selectors are now canonicalized to prevent identity drift — and `code_assets` identity is `(repository_id, kind, path, selector, framework_hint)`. Canonicalization **re-keys existing assets**, orphaning every prior row. Without this change, #9 actively manufactures the orphans described below.

## The problem

Postgres is documented as a *searchable projection* of the manifest. A projection must not hold rows its source no longer declares — but `code_assets` rows were inserted and never deleted.

`ensureCodeAsset` looks up `(repository_id, kind, path, selector, framework_hint)` and inserts on miss. Sync deleted and rebuilt the **junction** rows but never the assets:

| Event | Result |
|---|---|
| Rename a file, update the YAML | New row; old orphaned forever, frozen at its last `content_hash` |
| Reword a selector | Different identity tuple → new row, old orphaned |
| Link one path with *and* without a selector | Two rows for one file |

Not merely cruft — orphans stayed **reachable**. `search-context.ts` joins `provided_artifacts` on `(repository, kind, path, selector)` where a null selector in the request matches *any* selector on the asset, so dead rows kept feeding the `artifact_overlap` ranking signal. The set grew monotonically with every rename.

## The fix

Delete rows this repository no longer declares **and** that no junction still references.

**Cross-repository safety, two independent guards:**
1. `repository_id` is pinned to the repo being synced, and the keep-list itself excludes foreign-target links — a sync of X can only ever consider X-owned rows.
2. Both junction tables are checked **globally**, with no repository predicate — so an X-owned asset that repository Y's Story or AC still links survives, as does one held by a retired X story.

`coalesce(..., '')` in the keep-list match mirrors the `code_assets_identity` unique index exactly, so both use the same normalization.

**Self-healing.** The keep-list builder is extracted from `refreshCodeAssetHashes` into `localCodeAssetLinks`, so reconcile and hash-refresh consume the same set and cannot diverge. Reconciliation also runs on the `unchanged` early-return path — an already-drifted projection repairs itself on the next sync rather than needing a rebuild. The failure worth designing against isn't the duplicate; it's having no repair path and no way to notice.

**Visibility.** `reconciled_code_assets` is reported on `ContractSyncResult`, in the `repository_contract_synced` audit event detail, and in the `tieline contract sync` line.

## ⚠️ Breaking change — read before merging

The reconcile needs `DELETE` on `code_assets`, which `tieline_repository_sync` did not have. **Postgres checks the privilege even when zero rows match**, so without the grant the *first* sync fails outright rather than degrading quietly.

`src/commands/migrate.ts` permits exactly one migration file, so this had to be an edit to `migrations/0001_baseline.sql`. The checksum drift guard means **it only takes effect on a freshly created database — existing databases must be recreated.**

## Verification

Offline, every `DATABASE_URL*` unset:

```
tsc --noEmit                clean
test-contract · test-manifest · test-impact          PASS
test-contract-command · test-ranking                 PASS
test-link-plausibility · test-reconciliation         PASS   ← main's new suites
test-evidence · test-baseline                        PASS
contract validate .         12 Stories, 24 ACs, 0 warnings
```

Manifest recompiled against main's updated `manifest.ts`.

**`scripts/integration-contract-sync.ts` was NOT re-run against this rebase** — Docker is unavailable in the current environment. It covers rename-drops-asset, retained-because-still-linked (referenced only from a *foreign* repo, one case per junction table), never-touched foreign asset seeded at the same path as the renamed-away one, a no-false-positives sync, the audit field, and the self-healing repeat-commit repair.

On the pre-rebase branch it passed against a real `pgvector/pgvector:pg16` container, including a **mutation check** — stubbing the delete to `return 0` made the new assertions fail, confirming they aren't vacuous. Since `manifest.ts` changed in #9 and feeds sync, **please run it against a database before merging.**

## Contract

Adds `AUTHORITY-002-AC3`. `AUTHORITY-002-AC1` covers preserving planning/repository *identity* across handoff; projection reconciliation is a distinct behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)