### PR TITLE
feat(check): fail on a stale manifest, for the same reason broken links fail

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -1,0 +1,40 @@
+name: Contract
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      # `check` diffs against origin/main, so it needs more than a shallow clone.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      # Every step below runs fully offline: no database, no network, no
+      # credentials. The contract plane is a pure function of the working tree.
+      - name: Validate contract YAML
+        run: npx tsx src/cli.ts contract validate .
+
+      - name: Compile the manifest
+        run: npx tsx src/cli.ts contract compile . --output /tmp/manifest-check
+
+      - name: Evaluate semantic impact
+        run: npx tsx src/cli.ts check . --base origin/main
+
+      - name: Contract tests
+        run: |
+          npx tsx scripts/test-contract.ts
+          npx tsx scripts/test-manifest.ts
+          npx tsx scripts/test-contract-command.ts
+          npx tsx scripts/test-impact.ts

--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -164,7 +164,7 @@
             "links": [
               {
                 "relation": "implements",
-                "reviewed_content_hash": "69abe1df40f916d17fff307a40202a5fd6ad0b2cb3098a4ce873b4c58c248358",
+                "reviewed_content_hash": "ca6eca419f5addb10098798e458d685c46c03455cb861d3203814afd68206985",
                 "target": {
                   "kind": "code",
                   "path": "src/commands/check.ts",
@@ -182,7 +182,7 @@
               },
               {
                 "relation": "tests",
-                "reviewed_content_hash": "49c97579766928bb43c0d8ac9d6c772c7efde0242d1ad305277abb1d9e567dc5",
+                "reviewed_content_hash": "94654903b247afd26da09a78dd05eee0a549eeea91cb2b922e41bbf447d6061c",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -311,6 +311,69 @@
             ],
             "stable_id": "CONTRACT-001-AC5",
             "supersedes": null
+          },
+          {
+            "aliases": [],
+            "applies_to": null,
+            "contract_hash": "4d47026f26b951001e602d934f3a8e6075170bda6e25e4f65e5fc1610a75adea",
+            "criterion": "Tieline must fail the check when the committed manifest differs from the manifest the contract compiles to, unless that gate is explicitly downgraded.",
+            "links": [
+              {
+                "relation": "enforces",
+                "reviewed_content_hash": "ca6eca419f5addb10098798e458d685c46c03455cb861d3203814afd68206985",
+                "target": {
+                  "kind": "code",
+                  "path": "src/commands/check.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "relation": "implements",
+                "reviewed_content_hash": "7fd7cf15c1c11708912cd73e607bbfdf4cec92cbe233060cbe66c8f557632ccf",
+                "target": {
+                  "kind": "code",
+                  "path": "src/cli.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "relation": "tests",
+                "reviewed_content_hash": "94654903b247afd26da09a78dd05eee0a549eeea91cb2b922e41bbf447d6061c",
+                "target": {
+                  "framework_hint": "custom-script",
+                  "kind": "test",
+                  "path": "scripts/test-impact.ts",
+                  "repository": "tieline"
+                }
+              }
+            ],
+            "position": 5,
+            "rationale": "A manifest merged without recompilation records evidence hashes that were never reviewed against the code they name. Comparing the committed manifest with a fresh compilation is a byte diff of a deterministic function, so nothing is being judged, which is the same reason broken links already fail. Findings that do need judgement stay warn-only.",
+            "scenarios": [
+              {
+                "given": "a specification file changed without the manifest being recompiled",
+                "position": 0,
+                "stable_id": "CONTRACT-001-AC6-S1",
+                "then": "Tieline must report the stale manifest as an error and exit non-zero",
+                "when": "the branch is checked against its base"
+              },
+              {
+                "given": "the same stale manifest and an explicit request to downgrade the gate",
+                "position": 1,
+                "stable_id": "CONTRACT-001-AC6-S2",
+                "then": "Tieline must report the stale manifest as a warning and exit zero",
+                "when": "the branch is checked against its base"
+              },
+              {
+                "given": "a manifest that cannot be recompiled at all",
+                "position": 2,
+                "stable_id": "CONTRACT-001-AC6-S3",
+                "then": "Tieline must report the compilation failure once rather than also reporting it as a stale manifest",
+                "when": "the branch is checked against its base"
+              }
+            ],
+            "stable_id": "CONTRACT-001-AC6",
+            "supersedes": null
           }
         ],
         "actor": "maintainer",
@@ -334,6 +397,6 @@
   },
   "input": {
     "path": ".tieline/spec/contract.yaml",
-    "sha256": "6ccb43429d2d5105c341719d80d2906af8a23d2b0a15756d621f40535e6291e1"
+    "sha256": "ce6294eccfd5da8a8c0efb477b6394191f7582a6116685d0002f4c110bdbac91"
   }
 }

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -17,7 +17,7 @@
             "links": [
               {
                 "relation": "implements",
-                "reviewed_content_hash": "9f2abc973c16b6028c603ae32bd01e0e33e7333022ab8df4ce5af811ce8cb05d",
+                "reviewed_content_hash": "7fd7cf15c1c11708912cd73e607bbfdf4cec92cbe233060cbe66c8f557632ccf",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -126,7 +126,7 @@
             "links": [
               {
                 "relation": "implements",
-                "reviewed_content_hash": "9f2abc973c16b6028c603ae32bd01e0e33e7333022ab8df4ce5af811ce8cb05d",
+                "reviewed_content_hash": "7fd7cf15c1c11708912cd73e607bbfdf4cec92cbe233060cbe66c8f557632ccf",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",

--- a/.tieline/manifest/index.json
+++ b/.tieline/manifest/index.json
@@ -1,6 +1,6 @@
 {
   "repository": {
-    "commit": "2feefc81afda99067a2b31322426a048c2b92ff3",
+    "commit": "5c275b9c19f49cd56e093f80d1f7f507adbb5a3f",
     "key": "tieline"
   },
   "schema_version": 1

--- a/.tieline/spec/contract.yaml
+++ b/.tieline/spec/contract.yaml
@@ -166,3 +166,33 @@ capability:
                 repository: tieline
                 path: scripts/test-contract-command.ts
                 framework_hint: custom-script
+        - key: CONTRACT-001-AC6
+          criterion: Tieline must fail the check when the committed manifest differs from the manifest the contract compiles to, unless that gate is explicitly downgraded.
+          rationale: A manifest merged without recompilation records evidence hashes that were never reviewed against the code they name. Comparing the committed manifest with a fresh compilation is a byte diff of a deterministic function, so nothing is being judged, which is the same reason broken links already fail. Findings that do need judgement stay warn-only.
+          scenarios:
+            - given: a specification file changed without the manifest being recompiled
+              when: the branch is checked against its base
+              then: Tieline must report the stale manifest as an error and exit non-zero
+            - given: the same stale manifest and an explicit request to downgrade the gate
+              when: the branch is checked against its base
+              then: Tieline must report the stale manifest as a warning and exit zero
+            - given: a manifest that cannot be recompiled at all
+              when: the branch is checked against its base
+              then: Tieline must report the compilation failure once rather than also reporting it as a stale manifest
+          links:
+            - relation: enforces
+              target:
+                kind: code
+                repository: tieline
+                path: src/commands/check.ts
+            - relation: implements
+              target:
+                kind: code
+                repository: tieline
+                path: src/cli.ts
+            - relation: tests
+              target:
+                kind: test
+                repository: tieline
+                path: scripts/test-impact.ts
+                framework_hint: custom-script

--- a/scripts/test-impact.ts
+++ b/scripts/test-impact.ts
@@ -298,10 +298,18 @@ capability:
     ]
   );
 
+  // This fixture is stale by construction — `src/feature.ts` changed after the
+  // manifest was compiled — so the stale gate is downgraded here to keep these
+  // assertions about impact reporting. The gate itself is covered below.
   const output: string[] = [];
   assert.equal(
     await runCheckCommand(
-      { base: "HEAD", repository: root, json: true },
+      {
+        base: "HEAD",
+        repository: root,
+        json: true,
+        failOnStaleManifest: false,
+      },
       { write: (message) => output.push(message) }
     ),
     0
@@ -327,12 +335,12 @@ capability:
   assert.equal(report.impacts[0].story_title, "Review semantic impact");
   assert.equal(report.broken_links.length, 0);
   assert.equal(report.exit_code, 0);
-  assert.equal(report.exit_reason, "ok");
+  assert.equal(report.exit_reason, "stale_manifest_warn_only");
 
   const humanOutput: string[] = [];
   assert.equal(
     await runCheckCommand(
-      { base: "HEAD", repository: root },
+      { base: "HEAD", repository: root, failOnStaleManifest: false },
       { write: (message) => humanOutput.push(message) }
     ),
     0
@@ -382,7 +390,12 @@ capability:
   const completenessOutput: string[] = [];
   assert.equal(
     await runCheckCommand(
-      { base: "HEAD", repository: root, json: true },
+      {
+        base: "HEAD",
+        repository: root,
+        json: true,
+        failOnStaleManifest: false,
+      },
       { write: (message) => completenessOutput.push(message) }
     ),
     0
@@ -409,9 +422,10 @@ capability:
   );
   assert.equal(completenessReport.unclaimed_changes[0].status, "added");
   assert.equal(completenessReport.unclaimed_change_count, 1);
-  // Unclaimed changes alone never fail the check.
+  // Unclaimed changes alone never fail the check. The reason reflects this
+  // fixture's downgraded stale manifest, not anything unclaimed changes did.
   assert.equal(completenessReport.exit_code, 0);
-  assert.equal(completenessReport.exit_reason, "ok");
+  assert.equal(completenessReport.exit_reason, "stale_manifest_warn_only");
   assert.equal(completenessReport.broken_links.length, 0);
   assert.ok(
     completenessReport.warnings.some((warning) =>
@@ -467,7 +481,7 @@ capability:
   const completenessHumanOutput: string[] = [];
   assert.equal(
     await runCheckCommand(
-      { base: "HEAD", repository: root },
+      { base: "HEAD", repository: root, failOnStaleManifest: false },
       { write: (message) => completenessHumanOutput.push(message) }
     ),
     0
@@ -592,7 +606,96 @@ capability:
   };
   assert.equal(addedReport.manifest_current, false);
   assert.equal(addedReport.manifest_compile_error, null);
+
+  // A manifest that does not match its own recompilation gates by default: the
+  // comparison is a byte diff of a deterministic function, so nothing is judged.
+  const staleGateOutput: string[] = [];
+  assert.equal(
+    await runCheckCommand(
+      { base: "HEAD", repository: root, json: true },
+      { write: (message) => staleGateOutput.push(message) }
+    ),
+    1
+  );
+  const staleGateReport = JSON.parse(staleGateOutput.join("")) as {
+    exit_code: number;
+    exit_reason: string;
+    fail_on_stale_manifest: boolean;
+    errors: string[];
+    warnings: string[];
+  };
+  assert.equal(staleGateReport.exit_code, 1);
+  assert.equal(staleGateReport.exit_reason, "stale_manifest");
+  assert.equal(staleGateReport.fail_on_stale_manifest, true);
+  assert.ok(
+    staleGateReport.errors.some((entry) => /does not match/i.test(entry)),
+    "a gating stale manifest belongs in errors"
+  );
+  assert.ok(
+    !staleGateReport.warnings.some((entry) => /does not match/i.test(entry)),
+    "a gating stale manifest must not also be listed as a warning"
+  );
+
+  const staleDowngradeOutput: string[] = [];
+  assert.equal(
+    await runCheckCommand(
+      {
+        base: "HEAD",
+        repository: root,
+        json: true,
+        failOnStaleManifest: false,
+      },
+      { write: (message) => staleDowngradeOutput.push(message) }
+    ),
+    0
+  );
+  const staleDowngradeReport = JSON.parse(staleDowngradeOutput.join("")) as {
+    exit_code: number;
+    exit_reason: string;
+    errors: string[];
+    warnings: string[];
+  };
+  assert.equal(staleDowngradeReport.exit_code, 0);
+  assert.equal(staleDowngradeReport.exit_reason, "stale_manifest_warn_only");
+  assert.ok(
+    staleDowngradeReport.warnings.some((entry) => /does not match/i.test(entry))
+  );
+  assert.ok(
+    !staleDowngradeReport.errors.some((entry) => /does not match/i.test(entry))
+  );
+
+  const staleTextOutput: string[] = [];
+  await runCheckCommand(
+    { base: "HEAD", repository: root },
+    { write: (message) => staleTextOutput.push(message) }
+  );
+  assert.match(staleTextOutput.join(""), /--no-fail-on-stale-manifest/);
   rmSync(resolve(root, ".tieline/contract/added.yaml"));
+
+  // A manifest that cannot be recompiled at all is one fault, reported once.
+  // Counting it as staleness too would name the same problem twice and let the
+  // stale gate fire for a reason the operator cannot act on as staleness.
+  writeFileSync(
+    resolve(root, ".tieline/contract/broken.yaml"),
+    "version: 1\ncapability: [this is not a capability]\n"
+  );
+  const compileErrorOutput: string[] = [];
+  assert.equal(
+    await runCheckCommand(
+      { base: "HEAD", repository: root, json: true },
+      { write: (message) => compileErrorOutput.push(message) }
+    ),
+    0
+  );
+  const compileErrorReport = JSON.parse(compileErrorOutput.join("")) as {
+    manifest_current: boolean;
+    manifest_compile_error: string | null;
+    exit_reason: string;
+  };
+  assert.equal(compileErrorReport.manifest_current, false);
+  assert.ok(compileErrorReport.manifest_compile_error);
+  assert.equal(compileErrorReport.exit_reason, "ok");
+  rmSync(resolve(root, ".tieline/contract/broken.yaml"));
 
   await assert.rejects(
     runCheckCommand(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -513,6 +513,10 @@ function buildProgram(
       "--no-fail-on-broken",
       "report broken links as warnings instead of failing"
     )
+    .option(
+      "--no-fail-on-stale-manifest",
+      "report a stale manifest as a warning instead of failing"
+    )
     .action(async (repository: string | undefined, opts) => {
       const { runCheckCommand } = await import("./commands/check.js");
       setExit(
@@ -523,6 +527,7 @@ function buildProgram(
             repo: opts.repo,
             json: Boolean(opts.json),
             failOnBroken: opts.failOnBroken !== false,
+            failOnStaleManifest: opts.failOnStaleManifest !== false,
           },
           io
         )

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -30,12 +30,21 @@ export interface CheckCommandOptions {
    * needs no human judgement. Set to `false` to downgrade them to warnings.
    */
   failOnBroken?: boolean;
+  /**
+   * A committed manifest that differs from the one compilation produces fails
+   * for the same reason broken links do: the comparison is a byte diff of a
+   * deterministic function's output, so nothing is being judged. Set to `false`
+   * to downgrade it to a warning.
+   */
+  failOnStaleManifest?: boolean;
 }
 
 export type CheckExitReason =
   | "ok"
   | "broken_links"
-  | "broken_links_warn_only";
+  | "broken_links_warn_only"
+  | "stale_manifest"
+  | "stale_manifest_warn_only";
 
 /**
  * A changed source file that no manifest link names.
@@ -224,6 +233,7 @@ export async function runCheckCommand(
 ): Promise<number> {
   const base = options.base;
   const failOnBroken = options.failOnBroken !== false;
+  const failOnStaleManifest = options.failOnStaleManifest !== false;
   const requestedRoot = resolve(options.repository ?? process.cwd());
   const workspace = findTielineWorkspace(requestedRoot);
   const root = workspace?.root ?? requestedRoot;
@@ -275,12 +285,22 @@ export async function runCheckCommand(
     specDirectory,
   });
   const brokenLinks = impacts.filter(isBrokenImpact);
-  const errors = brokenLinks.map(
-    (impact) =>
-      `${impact.acceptance_criterion_stable_id} links to ${impact.path}, but ${describeBrokenCause(
-        impact.broken_cause ?? "missing"
-      )}.`
-  );
+  // A manifest that does not match its own recompilation is drift, not a
+  // judgement call, so it gates alongside broken links. A compile failure is
+  // deliberately excluded: it is already reported on its own, and counting it
+  // as staleness would report one fault twice.
+  const staleManifest = !manifestCurrent && manifestCompileError === null;
+  const staleManifestMessage =
+    "The committed manifest does not match current YAML or linked content; compile it before merge.";
+  const errors = [
+    ...brokenLinks.map(
+      (impact) =>
+        `${impact.acceptance_criterion_stable_id} links to ${impact.path}, but ${describeBrokenCause(
+          impact.broken_cause ?? "missing"
+        )}.`
+    ),
+    ...(staleManifest && failOnStaleManifest ? [staleManifestMessage] : []),
+  ];
   // Without a workspace there is no configured `source_roots`, and guessing at
   // eligibility would report doc, fixture, and lockfile changes as source work.
   // A missing workspace already falls back elsewhere in this command, so the
@@ -297,13 +317,22 @@ export async function runCheckCommand(
         specDirectory,
       })
     : [];
-  const exitCode = brokenLinks.length > 0 && failOnBroken ? 1 : 0;
+  const brokenLinksFail = brokenLinks.length > 0 && failOnBroken;
+  const staleManifestFails = staleManifest && failOnStaleManifest;
+  const exitCode = brokenLinksFail || staleManifestFails ? 1 : 0;
+  // Broken links outrank a stale manifest when both hold: recorded evidence
+  // that no longer exists is the more severe fault, and the full picture stays
+  // available in `errors`, `warnings`, and `manifest_current`.
   const exitReason: CheckExitReason =
-    brokenLinks.length === 0
-      ? "ok"
-      : failOnBroken
+    brokenLinks.length > 0
+      ? failOnBroken
         ? "broken_links"
-        : "broken_links_warn_only";
+        : "broken_links_warn_only"
+      : staleManifest
+        ? failOnStaleManifest
+          ? "stale_manifest"
+          : "stale_manifest_warn_only"
+        : "ok";
   const result = {
     base,
     repository: repositoryKey,
@@ -316,15 +345,14 @@ export async function runCheckCommand(
     unclaimed_change_count: unclaimed.length,
     unclaimed_changes_status: unclaimedStatus,
     fail_on_broken: failOnBroken,
+    fail_on_stale_manifest: failOnStaleManifest,
     exit_code: exitCode,
     exit_reason: exitReason,
     errors,
     warnings: [
-      ...(!manifestCurrent
-        ? [
-            "The committed manifest does not match current YAML or linked content; compile it before merge.",
-          ]
-        : []),
+      // Reported here only when it is not already an error, so a gating stale
+      // manifest is named once rather than in both lists.
+      ...(staleManifest && !failOnStaleManifest ? [staleManifestMessage] : []),
       ...(manifestCompileError
         ? [`The manifest could not be recompiled: ${manifestCompileError}`]
         : []),
@@ -362,16 +390,23 @@ export async function runCheckCommand(
     for (const warning of result.warnings) {
       io.write(`  warn  ${warning}\n`);
     }
-    if (exitCode !== 0) {
+    if (brokenLinksFail) {
       io.write(
         "  Broken links fail this check. Re-run with --no-fail-on-broken to downgrade them to warnings.\n"
       );
     }
+    if (staleManifestFails) {
+      io.write(
+        "  A stale manifest fails this check. Run `tieline contract compile` and commit the result, or re-run with --no-fail-on-stale-manifest to downgrade it to a warning.\n"
+      );
+    }
   }
-  // Findings that require human judgement (stale, modified, contract
-  // definition changes, changed files no criterion names) stay warn-only:
-  // whether a change is a behavior change or a refactor is exactly the kind of
-  // call a build must not make. Broken links do not: nothing needs to be judged
-  // to know the manifest points at evidence that is not there.
+  // Findings that require human judgement (stale links, modified paths,
+  // contract definition changes, changed files no criterion names) stay
+  // warn-only: whether a change is a behavior change or a refactor is exactly
+  // the kind of call a build must not make. Broken links and a stale manifest
+  // do not. Nothing needs to be judged to know the manifest points at evidence
+  // that is not there, or that the committed manifest is not the one this
+  // contract compiles to.
   return exitCode;
 }


### PR DESCRIPTION
## The line `check` already draws

From its own trailing comment on `main`:

> Findings that require human judgement (stale, modified, contract definition changes, changed files no criterion names) stay warn-only: whether a change is a behavior change or a refactor is exactly the kind of call a build must not make. **Broken links do not: nothing needs to be judged** to know the manifest points at evidence that is not there.

That reasoning is right, and **manifest currency sits on the second side of it**. Comparing the committed manifest against a fresh compilation is a byte diff of a deterministic function's output — no judgement, no false positive available. It was on the first side, reported as a warning, exiting 0.

## Why it matters

PR #8 merged with the manifest recording commit `5fc640d` while `HEAD` was `42b630d`, and 14 link hashes no longer matching their files. `check` exited 0.

A manifest merged without recompilation records `reviewed_content_hash` values that were **never reviewed against the code they name** — which is the single thing the artifact exists to assert.

## Folded in, not bolted on

```
--no-fail-on-stale-manifest       mirrors --no-fail-on-broken
CheckExitReason  += stale_manifest | stale_manifest_warn_only
```

- Broken links **outrank** a stale manifest when both hold — evidence that no longer exists is the more severe fault. The full picture stays in `errors`, `warnings`, and `manifest_current`.
- The message moves between `errors` and `warnings` with the gate, so it's named once rather than in both lists.
- **A manifest that cannot be recompiled is deliberately not treated as stale.** `manifest_compile_error` is already reported on its own; counting it as staleness would name one fault twice and gate on a condition the operator can't act on as staleness. Tested.

## CI

Adds `.github/workflows/contract.yml`: validate → compile → check → contract tests. No services, no secrets — every step is a pure function of the working tree.

This is arguably the more important half. **The warning in #8 was never ignored — it was never printed**, because nothing ran `check`. The gate is unreachable without CI.

## Test changes worth reviewing

Several existing assertions expected exit 0 from fixtures that are **stale by construction** (they modify `src/feature.ts` after compiling the manifest). Handled two ways, deliberately:

- Blocks testing **impact reporting** pass `failOnStaleManifest: false`, so they stay about rendering and don't break when gate policy changes.
- The block asserting *"unclaimed changes alone never fail the check"* keeps `exit_code === 0` — that's the real claim — and updates the incidental `exit_reason` from `"ok"` to `"stale_manifest_warn_only"`, which is what that fixture actually is.

New coverage: default gating with the message in `errors` and not `warnings`; the downgrade path with it in `warnings` and not `errors`; the remediation hint naming the flag; and a compile-failure fixture proving it isn't double-reported as stale.

## Verification

Offline, every `DATABASE_URL*` unset:

```
tsc --noEmit                                         clean
test-impact · test-manifest · test-contract           PASS
test-contract-command · test-ranking                  PASS
test-link-plausibility · test-reconciliation          PASS
test-evidence · test-baseline · test-contract-read    PASS
contract validate .    12 Stories, 26 ACs, 0 warnings
contract coverage .    26/26 direct evidence · 70/74 files (94.59%)
check --base origin/main    manifest=current, exit 0
```

Observed live during development: editing a spec file without recompiling produced `exit=1` with the error and remediation hint; `--no-fail-on-stale-manifest` on the same tree produced `exit=0`.

## Contract

Adds `CONTRACT-001-AC6`. `CONTRACT-001-AC3` is untouched and still holds — it governs reporting affected criteria and freshness without blocking on **semantic findings**, and a stale manifest is a build-integrity fact, not a semantic finding. That's the same distinction #9 relied on when it gated broken links while AC3 stood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)