### PR TITLE
feat(contract): preserve link provenance

### DIFF
--- a/.tieline/manifest/AUTHORITY.json
+++ b/.tieline/manifest/AUTHORITY.json
@@ -12,10 +12,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "f8f6ffe7b965e443b4fa75c787e032a001f975b8f3c0fc5d50c10bcad6be4dee",
+            "contract_hash": "cd1ca73c7f076574f55045479d543132b20b1664ea4dfd3698c9365e171b7b28",
             "criterion": "Tieline must allow planning writers to create and revise only backlog Stories and their Acceptance Criteria.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "8221d8c529fd0230342fb253ef76ef6499319e6e0eeea537d774987e54c05dbf",
                 "target": {
@@ -25,6 +26,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "9d01ce74028da22ff09e5a6f222524bc5e84ad87a405405434ed3b7c500ea138",
                 "target": {
@@ -34,6 +36,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "e1f7384c95aafeae36d9378ba9647c8e8d8e59467e26f3d74fb9b858eed8457c",
                 "target": {
@@ -43,6 +46,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
                 "reviewed_content_hash": "c8be46a2a078683df069c428779f8e99aa4ed461de66bd2400bb3b4aeff1246b",
                 "target": {
@@ -79,12 +83,13 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "c1677542d6335b6e9d1748a6c88d7cb4255e6471562c082c9a00260f4351afc6",
+            "contract_hash": "73063136f0f591ff1ddaa47106495eab634a216fb6f49bf38c80b4d72fac00e3",
             "criterion": "Tieline must preserve matching planning Story and Acceptance Criterion identities when a repository contract is synchronized.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "57e9533a1b6a182bfa1d289f5b46ed8cb609e52f272dc7e2abd0caeae35b46dd",
+                "reviewed_content_hash": "15910de6c8fc05fecec96615d20b26f36be85288adb6ec2d0c32a5dfbd3f77cf",
                 "target": {
                   "kind": "code",
                   "path": "src/adapters/postgres/contract-sync-repository.ts",
@@ -92,6 +97,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "5887a1dd6baba9655bde50a48999281c2e4a68d54e915034e2a3bc7770556f75",
                 "target": {
@@ -101,6 +107,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "32de0cf0779ef97953f99d631af747645ed95e21b0c26f48d0de46306f86adbd",
                 "target": {
@@ -110,6 +117,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "3639ad52d813cf476830db4184619b6a1e24aa96353ff11622266f5b19684a32",
                 "target": {
@@ -119,8 +127,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "ee0e74592e60aca7f0c2aa1ab082617ef419a5a7ef5a8c5fad041bbdd1d86410",
+                "reviewed_content_hash": "5e36b65da676de069e31bc8f60fd3a94e58dc63a559152c26ee1e0a904a0d65a",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -146,10 +155,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "0dc7cf77d78c41ea400bc3c827967b185e32397ce48135de1ecf91ebc27d52dd",
+            "contract_hash": "5f6b11c2364a86b95b7d82753beb0fa48fb3a81aa1d5e8b726868a6c4dd7a723",
             "criterion": "Tieline must keep read, planning-write, repository-sync, and offline-admin database responsibilities separate.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "enforces",
                 "reviewed_content_hash": "4abf6bbf188298016dfa55ed799f6f2c315ad72b766aed6a26ba8f96cf848d57",
                 "target": {
@@ -159,6 +169,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "enforces",
                 "reviewed_content_hash": "8c5db15ee31587c3ef2de4b10fabcea91c166deca9c49ddcc8ddd61ee3921fae",
                 "target": {
@@ -168,6 +179,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "enforces",
                 "reviewed_content_hash": "6884626bd717f3d1b60d323d32f77365d887a0a0026e7274281a876072a373dd",
                 "target": {
@@ -177,6 +189,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "enforces",
                 "reviewed_content_hash": "6453abe79100aad8774a580b49d3684b890a9e03d14851e0e7814458bd6d5b9f",
                 "target": {
@@ -186,6 +199,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "enforces",
                 "reviewed_content_hash": "8124daf81c62a307a05f0b381795e92d8493fe4f637848192aaab37f8b377cc3",
                 "target": {
@@ -195,6 +209,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
                 "reviewed_content_hash": "7a8667501e1cce7be148e33939b7e34e462a326ebe727b183286dcfc685d8238",
                 "target": {
@@ -205,6 +220,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
                 "reviewed_content_hash": "185b17f4ae9053750201363f4a6189361108ca5cdf876d6bc67ea5d6816a3fc7",
                 "target": {
@@ -224,12 +240,13 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "ea86d1fa82ca27d888dbc487bd9d17d3b7a27471369399a89fbabef9a14e3932",
+            "contract_hash": "dc896ede89e5e9a2ca16e3752395a3a0cfbca333bdd52bae74c0e60d97cd2396",
             "criterion": "Tieline must remove projected code assets that the synchronized repository contract no longer declares and that no contract record still links.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "57e9533a1b6a182bfa1d289f5b46ed8cb609e52f272dc7e2abd0caeae35b46dd",
+                "reviewed_content_hash": "15910de6c8fc05fecec96615d20b26f36be85288adb6ec2d0c32a5dfbd3f77cf",
                 "target": {
                   "kind": "code",
                   "path": "src/adapters/postgres/contract-sync-repository.ts",
@@ -237,8 +254,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "ee0e74592e60aca7f0c2aa1ab082617ef419a5a7ef5a8c5fad041bbdd1d86410",
+                "reviewed_content_hash": "5e36b65da676de069e31bc8f60fd3a94e58dc63a559152c26ee1e0a904a0d65a",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -281,6 +299,6 @@
   },
   "input": {
     "path": ".tieline/spec/authority.yaml",
-    "sha256": "9554b679f02df2d67e5a67a724c43f13adfb97fb388b5ea0dcdd284f0e5fa4fc"
+    "sha256": "d7995bd2145a316b7b841a5644627d1880a9e37500596f697472a7b488f6cd1f"
   }
 }

--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -15,10 +15,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "0ca5565e8ee4f6a6606f1aa5cb7755c7046c06f5112090aba7cabc262b9ed3f5",
+            "contract_hash": "c571e20cef23af005a0ebc65cde9affce6f7f61e2b4d319eb804e4e1a9c8c50d",
             "criterion": "Tieline must reject repository contract documents that violate the accepted Story and Acceptance Criterion schema.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "4230230485eb6a0349638ad6219079cf0c0b3738957ecd8477dab399d3b61ca6",
                 "target": {
@@ -28,6 +29,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "9aed2036f597e76209167acdc3ff73d8dceb50842a5acfffd42e30e1feaaee14",
                 "target": {
@@ -37,8 +39,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "3f15cb80178a5d8d463f9eeb0c99a500320c185843588ea35d8b2312741a9efe",
+                "reviewed_content_hash": "5292a67f6107ac2dd74195cbd8815babb8c5a0910be48d10d437fe53b0f7f78b",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/schema.ts",
@@ -46,8 +49,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "4b22c3ffb795335d3411fefb28adf686805155ef45d8688636cad33a1f8f03f4",
+                "reviewed_content_hash": "44c6f462a64a7fd399cbb5b44bb49bb7f4cfcfb0ee4ae6aeb1611e27e8710a57",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/validate.ts",
@@ -55,8 +59,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "19f3d11c2b5b191bf27f0093765c5bba91ce69c68a66a24167e511821d1b32b5",
+                "reviewed_content_hash": "a0842c812679f97ae23a84f4d062547091ac1d79f1bd12155d5098e1d14aeb77",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -74,12 +79,13 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "9f0e330536f2ca5d03d150e05285299d3f07b190e2357dab0443e5a86a1d757a",
+            "contract_hash": "09af17ffb75ab3e3e19c4ac8773735a2f6a507b617f28483738ef81d50a90b4c",
             "criterion": "Tieline must compile deterministic manifests and report direct-AC and repository mapping coverage with explicit gaps.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "1bfd9f0d62f19d9906729ed3382a35aa24256ee747b709f6fd427e66fb549247",
+                "reviewed_content_hash": "150c2826587e7fe6d29976185913eab18e04dca4e3b41993859276b5dae87ace",
                 "target": {
                   "kind": "code",
                   "path": "src/commands/contract.ts",
@@ -87,6 +93,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "fbea3757e99fae29e4c35a29ac13eba324b8967637328ce23b0cd7942f2dab67",
                 "target": {
@@ -96,8 +103,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "b8ea337e4bcf6693df2f712fb7bf0abdc848de5b5e18488ea65af16aa7ea21ce",
+                "reviewed_content_hash": "7b38b6a9d157359f304b5cd8231a61824f3c524e05308a8b499eafd848119f7e",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/manifest.ts",
@@ -105,8 +113,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "90436f6a11e354e21a1dd7225b9e0024a94c8b069d06b026bf82a68c1c8b4cb8",
+                "reviewed_content_hash": "f381c517d558c4dd2473c7dfefa7e019a3df28c8867f66b4ef4b9d5a6b3eb733",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -115,8 +124,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "19f3d11c2b5b191bf27f0093765c5bba91ce69c68a66a24167e511821d1b32b5",
+                "reviewed_content_hash": "a0842c812679f97ae23a84f4d062547091ac1d79f1bd12155d5098e1d14aeb77",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -125,8 +135,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "b353c83d3ee230c86c2bfeb27e33294f0b98058460dd28f9ebc9a56a80775771",
+                "reviewed_content_hash": "c5971b2e7f097345515c825f8471c58413c481f548657370eed3238706ea8da1",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -159,10 +170,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "272f384b168e51dbabb57ecea719773683840496d95e5097968352bbbf495565",
+            "contract_hash": "f58cfd249e89384c184540624898e6a862860a0fa03a385a5c98787f7eda8f73",
             "criterion": "Tieline must report affected Acceptance Criteria and freshness for changed, renamed, or deleted linked paths without blocking on semantic findings.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "ca6eca419f5addb10098798e458d685c46c03455cb861d3203814afd68206985",
                 "target": {
@@ -172,8 +184,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "b8cf43553b2ab0c49cc91e58db347f22d84c9a5db22fe2a66410558220e26dfd",
+                "reviewed_content_hash": "d7e3812f62cea10c903bd16a2380c465ea8a04b516d89fbde965ee7c6653b2ed",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/impact.ts",
@@ -181,8 +194,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "94654903b247afd26da09a78dd05eee0a549eeea91cb2b922e41bbf447d6061c",
+                "reviewed_content_hash": "a84cf4914077026a8c2778cb053e450374c42a74d77e308301640dddd1c22677",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -208,12 +222,13 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "b55c561c5a880d82d3dd2ead2d178893228d362fc771208172a1d9d5e47afdef",
+            "contract_hash": "f02efe5490a38c050fae1167614c9c049e63603931cba14c1c12828edec40eda",
             "criterion": "Tieline must render accepted Stories and Acceptance Criteria as a self-contained human-readable review page.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "1bfd9f0d62f19d9906729ed3382a35aa24256ee747b709f6fd427e66fb549247",
+                "reviewed_content_hash": "150c2826587e7fe6d29976185913eab18e04dca4e3b41993859276b5dae87ace",
                 "target": {
                   "kind": "code",
                   "path": "src/commands/contract.ts",
@@ -221,8 +236,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "bdca2aea1a1014c37d17bf2cdad3e50c408bc8ac1f718b4d2477603fad4df676",
+                "reviewed_content_hash": "c066e207de9b3ac1ca21172f9e6ccda4b55689aba41d825097f50aed79146e4c",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/review-page.ts",
@@ -230,8 +246,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "90436f6a11e354e21a1dd7225b9e0024a94c8b069d06b026bf82a68c1c8b4cb8",
+                "reviewed_content_hash": "f381c517d558c4dd2473c7dfefa7e019a3df28c8867f66b4ef4b9d5a6b3eb733",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -249,12 +266,13 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "2fe850ad01547e2da553e59328923c0faa98c710b49514317ac83d425a4a8a9c",
+            "contract_hash": "f86b5de23d7c2d73fa3a9e7e869f1746f9ab7e0ca6395041c6d78262612f3549",
             "criterion": "Tieline must store the compiled manifest as one file per capability beside a repository-level index, must delete the file of any capability the contract no longer declares, and must refuse to read a manifest whose file names disagree with the capabilities they hold.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "1bfd9f0d62f19d9906729ed3382a35aa24256ee747b709f6fd427e66fb549247",
+                "reviewed_content_hash": "150c2826587e7fe6d29976185913eab18e04dca4e3b41993859276b5dae87ace",
                 "target": {
                   "kind": "code",
                   "path": "src/commands/contract.ts",
@@ -262,8 +280,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "b8ea337e4bcf6693df2f712fb7bf0abdc848de5b5e18488ea65af16aa7ea21ce",
+                "reviewed_content_hash": "7b38b6a9d157359f304b5cd8231a61824f3c524e05308a8b499eafd848119f7e",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/manifest.ts",
@@ -271,8 +290,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "90436f6a11e354e21a1dd7225b9e0024a94c8b069d06b026bf82a68c1c8b4cb8",
+                "reviewed_content_hash": "f381c517d558c4dd2473c7dfefa7e019a3df28c8867f66b4ef4b9d5a6b3eb733",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -281,8 +301,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "b353c83d3ee230c86c2bfeb27e33294f0b98058460dd28f9ebc9a56a80775771",
+                "reviewed_content_hash": "c5971b2e7f097345515c825f8471c58413c481f548657370eed3238706ea8da1",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -315,10 +336,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "4d47026f26b951001e602d934f3a8e6075170bda6e25e4f65e5fc1610a75adea",
+            "contract_hash": "8efa277938f7c53ddc53116b182d5d302d639f04f4eb2e864ae820574bcb8dc3",
             "criterion": "Tieline must fail the check when the committed manifest differs from the manifest the contract compiles to, unless that gate is explicitly downgraded.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "enforces",
                 "reviewed_content_hash": "ca6eca419f5addb10098798e458d685c46c03455cb861d3203814afd68206985",
                 "target": {
@@ -328,6 +350,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "2b4a059e4509d43be4954fbaf8e57f76a650f8657bb13eaf67754faf3a3abce1",
                 "target": {
@@ -337,8 +360,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "94654903b247afd26da09a78dd05eee0a549eeea91cb2b922e41bbf447d6061c",
+                "reviewed_content_hash": "a84cf4914077026a8c2778cb053e450374c42a74d77e308301640dddd1c22677",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -374,6 +398,134 @@
             ],
             "stable_id": "CONTRACT-001-AC6",
             "supersedes": null
+          },
+          {
+            "aliases": [],
+            "applies_to": null,
+            "contract_hash": "3f2b24169185c3d8bb008393ad0e9a2dc5d03c4e9b42f39233af6e64570a467e",
+            "criterion": "Tieline must require every contract link to state whether its claim was authored, inferred, or materialized, and must preserve that provenance through compiled manifests, repository synchronization, and every exact claim read.",
+            "links": [
+              {
+                "provenance": "authored",
+                "relation": "enforces",
+                "reviewed_content_hash": "a8fee643ee68cdb20a6c6920d77e83185e3d660747d6bd9daf252be866e98205",
+                "target": {
+                  "kind": "code",
+                  "path": "migrations/0001_baseline.sql",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "enforces",
+                "reviewed_content_hash": "5292a67f6107ac2dd74195cbd8815babb8c5a0910be48d10d437fe53b0f7f78b",
+                "target": {
+                  "kind": "code",
+                  "path": "src/contract/schema.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "484a403c56ce158b6d1a388580201cda1673361318a6b8f98c3537d91e904042",
+                "target": {
+                  "kind": "code",
+                  "path": "src/adapters/postgres/contract-read-repository.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "15910de6c8fc05fecec96615d20b26f36be85288adb6ec2d0c32a5dfbd3f77cf",
+                "target": {
+                  "kind": "code",
+                  "path": "src/adapters/postgres/contract-sync-repository.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "30eb256e64525dd8c8e5b9a4086b5b7037ad4cde42ca7285f34cb9438e0954f8",
+                "target": {
+                  "kind": "code",
+                  "path": "src/contract/link-plausibility.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "7b38b6a9d157359f304b5cd8231a61824f3c524e05308a8b499eafd848119f7e",
+                "target": {
+                  "kind": "code",
+                  "path": "src/contract/manifest.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "tests",
+                "reviewed_content_hash": "5e36b65da676de069e31bc8f60fd3a94e58dc63a559152c26ee1e0a904a0d65a",
+                "target": {
+                  "framework_hint": "custom-script",
+                  "kind": "test",
+                  "path": "scripts/integration-contract-sync.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "tests",
+                "reviewed_content_hash": "a0842c812679f97ae23a84f4d062547091ac1d79f1bd12155d5098e1d14aeb77",
+                "target": {
+                  "framework_hint": "custom-script",
+                  "kind": "test",
+                  "path": "scripts/test-contract.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "tests",
+                "reviewed_content_hash": "c5971b2e7f097345515c825f8471c58413c481f548657370eed3238706ea8da1",
+                "target": {
+                  "framework_hint": "custom-script",
+                  "kind": "test",
+                  "path": "scripts/test-manifest.ts",
+                  "repository": "tieline"
+                }
+              }
+            ],
+            "position": 6,
+            "rationale": "Relation and target describe what a link claims, while provenance records how that claim entered its current authority surface. Keeping this low-cardinality origin distinct from freshness and grade lets agents interpret a claim without turning mutable review facts into contract identity.",
+            "scenarios": [
+              {
+                "given": "a contract link has no provenance",
+                "position": 0,
+                "stable_id": "CONTRACT-001-AC7-S1",
+                "then": "Tieline must reject the link instead of guessing where its claim came from",
+                "when": "the repository contract is validated"
+              },
+              {
+                "given": "only a contract link's provenance changes",
+                "position": 1,
+                "stable_id": "CONTRACT-001-AC7-S2",
+                "then": "Tieline must change the owning contract hash without creating a second link identity",
+                "when": "the contract manifest is compiled"
+              },
+              {
+                "given": "an accepted repository link was copied during planning-to-repository authority transfer",
+                "position": 2,
+                "stable_id": "CONTRACT-001-AC7-S3",
+                "then": "Tieline must preserve materialized as the origin of that exact claim",
+                "when": "the repository contract is synchronized and read"
+              }
+            ],
+            "stable_id": "CONTRACT-001-AC7",
+            "supersedes": null
           }
         ],
         "actor": "maintainer",
@@ -397,10 +549,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "c2b91d1159fbf10e95681a5830cff9c08d14f1589271c8cc3576c85ad6761350",
+            "contract_hash": "7360e197c8a9fb50eab8f469aa111b1e3d7bfd929598c63cfdb3db6998e1fbda",
             "criterion": "Tieline must report every acceptance criterion linked to an exact repository-relative path, must distinguish a link carried by the acceptance criterion itself from one carried only by its Story, and must return an explicit has_criteria, no_criteria, or not_found status for every requested path.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "2b4a059e4509d43be4954fbaf8e57f76a650f8657bb13eaf67754faf3a3abce1",
                 "target": {
@@ -410,8 +563,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "1bfd9f0d62f19d9906729ed3382a35aa24256ee747b709f6fd427e66fb549247",
+                "reviewed_content_hash": "150c2826587e7fe6d29976185913eab18e04dca4e3b41993859276b5dae87ace",
                 "target": {
                   "kind": "code",
                   "path": "src/commands/contract.ts",
@@ -419,8 +573,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "9e61af309c2520cdc7c3059a23e682fb75070cbf128813382d96261b7083357f",
+                "reviewed_content_hash": "ea7ba4f3505baae9ab983969963282127103c40fc684ef71af3d36c43775e79f",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/path-criteria.ts",
@@ -428,8 +583,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "204afd3ceae22da32b8ccb0cc01d37daabfcca827648d3163b58d3a10d0cc1fb",
+                "reviewed_content_hash": "0ea67f77e3f48f0ee06e46b0715cc60fda317bc8d05f8fea83d928fdd8f33495",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/reconciliation.ts",
@@ -437,8 +593,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "061607e8016e8239e7b3a80ed6c91a54df06fcfa1f407006225dbfc1a16547c2",
+                "reviewed_content_hash": "6e43db7ad9e27b74eaa4bd15ee319fb19bdce56df8f8648d1d4f7bd00d3174e4",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -478,12 +635,13 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "59f982120ac612a3ef9285a93c9d84cacf3dfd1049e89873d80afae5054d1836",
+            "contract_hash": "04b3afe3e072d2bee0d43e2c006bfdb5939db8f12c322860ac069c92d74e43e8",
             "criterion": "The path-criteria lookup must answer from the compiled manifest alone, so Tieline must serve get_path_criteria over MCP with no database connection and must return a named, actionable message when no workspace or no readable manifest is found.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "7a2a01b03478e1be1f717fe86e88a1b9eb5cb16958b61a0fed746dd7a2d7cb9b",
+                "reviewed_content_hash": "a2a3924107310dcc18bb7f9fe9f59d0c1322418105104a45610a695d7cb2d755",
                 "target": {
                   "kind": "code",
                   "path": "src/schemas.ts",
@@ -491,6 +649,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "cf449a59d5a0abb879e6fb298c11c8557a0897edb0d546aefed506b1259c897e",
                 "target": {
@@ -500,6 +659,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "afe20bb1393a54e6e2bbaeea8caae10138d748aa33802c37c6758a5e0436aade",
                 "target": {
@@ -509,8 +669,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "061607e8016e8239e7b3a80ed6c91a54df06fcfa1f407006225dbfc1a16547c2",
+                "reviewed_content_hash": "6e43db7ad9e27b74eaa4bd15ee319fb19bdce56df8f8648d1d4f7bd00d3174e4",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -563,6 +724,6 @@
   },
   "input": {
     "path": ".tieline/spec/contract.yaml",
-    "sha256": "bae3c77d7b334251a26acb1714d08598a96f96765a868ab4c527687aa97fd821"
+    "sha256": "8274a3cadcd69223dc31bc611f8fe5a24b72d3b3eb42a114224917bce8683d43"
   }
 }

--- a/.tieline/manifest/EVIDENCE.json
+++ b/.tieline/manifest/EVIDENCE.json
@@ -12,10 +12,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "a4d958937c92134b9fdec955276cf5cabaf96359ee146f093b8fc7142a57f7d0",
+            "contract_hash": "11cffd41797117a7c4854c738d005f2bfc45e7dbeb4d1cb5e66453e51d91a726",
             "criterion": "Tieline must append an Observation before semantic matching and allow it to remain unattributed.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "4cef226cccd7a9a79c00bb3ba04dc22edfa3117149b4b7f49220d7d33fe080b9",
                 "target": {
@@ -25,6 +26,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "ce4738531f00a323c5371fa0632f6dc0c334bb75eb6e16f905ea20ca60c9e08d",
                 "target": {
@@ -34,6 +36,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "603c8337d00a8c6aa828979f50c5fcc4397d17b58c2bae2e646bed94fa1b4190",
                 "target": {
@@ -43,8 +46,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "84ae986325de79954f9bd55889eb840bcd74280ea3bd27efd644dfac67804d8e",
+                "reviewed_content_hash": "0abce4d686d4317e1348c8864b3c8d9161cb8c948bf0ecff92be273442366980",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -53,6 +57,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
                 "reviewed_content_hash": "d2a61b2e35316b1540673dedea1b04455463e28f31bb1b11e38a612e5e80ef37",
                 "target": {
@@ -97,10 +102,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "3efad825a4f51e4db508f750385e2812fad6257b78dd19d114072f24cf843ba6",
+            "contract_hash": "46135db99819b3fe3966b1d579848bd6f95e335aa6e14add625b631300801ff0",
             "criterion": "Tieline must let a Backlog Item target zero or more Stories and Acceptance Criteria without becoming their lifecycle container.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "c4a1432a19c2f9e886e73d886c86176de1bb70444b25a0e7a1ea4bff79bff636",
                 "target": {
@@ -110,6 +116,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "c3587cb3b916f279a83dd150cf25c4485a42fedb386e78b9b10c0a0e8b6ca724",
                 "target": {
@@ -119,8 +126,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "84ae986325de79954f9bd55889eb840bcd74280ea3bd27efd644dfac67804d8e",
+                "reviewed_content_hash": "0abce4d686d4317e1348c8864b3c8d9161cb8c948bf0ecff92be273442366980",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -155,10 +163,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "93b50772a2cac5cdc2879cc14122765cfb4df537955e58871a288323d2958c84",
+            "contract_hash": "8bc2245658060e07b74bb0abf722b8491c1f3af4edf7f896b256bb7cca2b56a8",
             "criterion": "Tieline must resolve help content by source and external identifier while preserving Story and Acceptance Criterion backlinks.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "4ad017180e7b563fd83184b5a52e13100fc0cafaea2775fc49627aaf7722c2e2",
                 "target": {
@@ -168,6 +177,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "ba6d3573cd111f4a59d462cb78b2a0627f3c96aa5ce5ee5f130da404f64aa7e9",
                 "target": {
@@ -177,6 +187,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "ee6149d24121327462dfca0d6620be890989ed2e7f2fd2343669e2fdb41b200f",
                 "target": {
@@ -186,6 +197,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "7a1704bdea68bdda8ee5749630fdf3d423a752a749157bf74633ece4837bb18a",
                 "target": {
@@ -195,6 +207,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "741227ce2f0875a4fcce49899819335e7aa48684d02aabbad298b7fe1ac9f280",
                 "target": {
@@ -204,8 +217,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "ee0e74592e60aca7f0c2aa1ab082617ef419a5a7ef5a8c5fad041bbdd1d86410",
+                "reviewed_content_hash": "5e36b65da676de069e31bc8f60fd3a94e58dc63a559152c26ee1e0a904a0d65a",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -240,6 +254,6 @@
   },
   "input": {
     "path": ".tieline/spec/evidence.yaml",
-    "sha256": "b7e5d5f1edc8bbbca4f53c2b46bbd8e90f578a0617fab3ddf73d093c9f9a9d2c"
+    "sha256": "1d36522a8c0c45233cf4d4042fe033499d917cb7b198034b5ed282ebe5746f92"
   }
 }

--- a/.tieline/manifest/GRADING.json
+++ b/.tieline/manifest/GRADING.json
@@ -15,12 +15,13 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "23fe52d08887cbe780304121179f66dae0478c6ee5e03ebf9fd34e18752826ac",
+            "contract_hash": "0310d453a9a807fb781099e41d68db192975e27d7bc7f34ddf0b9fb03fdd7164",
             "criterion": "Tieline must emit every local contract link claimed by a changed, renamed, added, or deleted path, must preserve direct and Story-fallback claims as distinct entries, and must not use lexical plausibility to remove an entry.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "203695a1d1c02b7d2a4e5bab44489689c87407f128f0ea5c7b9d01418f7e4e28",
+                "reviewed_content_hash": "f5aed29bc056a3299c96ab58b029b1faa23b2c3414b5731e58d29349a9d032a5",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/grade.ts",
@@ -29,8 +30,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "204afd3ceae22da32b8ccb0cc01d37daabfcca827648d3163b58d3a10d0cc1fb",
+                "reviewed_content_hash": "0ea67f77e3f48f0ee06e46b0715cc60fda317bc8d05f8fea83d928fdd8f33495",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/reconciliation.ts",
@@ -39,8 +41,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "0985e00d2d0ebac7ba7b1674d9a52ea0ddf3475ae9801eedc8c8c5f1e9d26fdd",
+                "reviewed_content_hash": "f2021bcade671d043f5cdc10896023cf06d76d69b716f825fca977a8724610c4",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -80,12 +83,13 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "baa1d2f4ca8cefd9120aa3d60a094807eadcdfaaf456fcd2858d11b897649f32",
+            "contract_hash": "86614c7939cfa8190db91db80bc9a3c6f84dca14c7a22d4028d670479cd45224",
             "criterion": "Tieline must give each grading entry a deterministic identity and a sorted citation allow-list derived from the canonical source-symbol index, while artifacts that cannot be examined must receive an empty allow-list instead of a guessed citation.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "203695a1d1c02b7d2a4e5bab44489689c87407f128f0ea5c7b9d01418f7e4e28",
+                "reviewed_content_hash": "f5aed29bc056a3299c96ab58b029b1faa23b2c3414b5731e58d29349a9d032a5",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/grade.ts",
@@ -94,6 +98,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "ee6be06bcab7fdd68a1ae729dadb5e760212c8add5bf481a8e75067a2fa11c9e",
                 "target": {
@@ -104,8 +109,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "0985e00d2d0ebac7ba7b1674d9a52ea0ddf3475ae9801eedc8c8c5f1e9d26fdd",
+                "reviewed_content_hash": "f2021bcade671d043f5cdc10896023cf06d76d69b716f825fca977a8724610c4",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -138,10 +144,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "0651897433ade380aae5ca09f514c3e4b067f1c0df5e5088b4a24c25ef8efabe",
+            "contract_hash": "796d92b9bc285c70027461a10c420ac7490cf9f327b530d48a9366f7a14438d2",
             "criterion": "Contract grading must derive and verify its scope from the compiled manifest, working tree, and Git diff without a database, network request, model client, or persisted grade record.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "2b4a059e4509d43be4954fbaf8e57f76a650f8657bb13eaf67754faf3a3abce1",
                 "target": {
@@ -152,8 +159,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "1bfd9f0d62f19d9906729ed3382a35aa24256ee747b709f6fd427e66fb549247",
+                "reviewed_content_hash": "150c2826587e7fe6d29976185913eab18e04dca4e3b41993859276b5dae87ace",
                 "target": {
                   "kind": "code",
                   "path": "src/commands/contract.ts",
@@ -162,8 +170,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "0985e00d2d0ebac7ba7b1674d9a52ea0ddf3475ae9801eedc8c8c5f1e9d26fdd",
+                "reviewed_content_hash": "f2021bcade671d043f5cdc10896023cf06d76d69b716f825fca977a8724610c4",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -198,12 +207,13 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "d77fa41392dfa515d33da718d037e6340e7ceb58b55e5bb6d064e3dd8e69e8e6",
+            "contract_hash": "8b5b3e7324a6bb7cc77cab64c518860535409387ca1dfcaf57f4b50219473b55",
             "criterion": "Tieline must accept only supported, partial, or unsupported verdicts, must require partial and unsupported reasons, and must downgrade a supported verdict to unsupported with fabricated_citation when its citation is absent from the entry's allow-list.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "enforces",
-                "reviewed_content_hash": "203695a1d1c02b7d2a4e5bab44489689c87407f128f0ea5c7b9d01418f7e4e28",
+                "reviewed_content_hash": "f5aed29bc056a3299c96ab58b029b1faa23b2c3414b5731e58d29349a9d032a5",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/grade.ts",
@@ -212,8 +222,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "203695a1d1c02b7d2a4e5bab44489689c87407f128f0ea5c7b9d01418f7e4e28",
+                "reviewed_content_hash": "f5aed29bc056a3299c96ab58b029b1faa23b2c3414b5731e58d29349a9d032a5",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/grade.ts",
@@ -222,8 +233,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "0985e00d2d0ebac7ba7b1674d9a52ea0ddf3475ae9801eedc8c8c5f1e9d26fdd",
+                "reviewed_content_hash": "f2021bcade671d043f5cdc10896023cf06d76d69b716f825fca977a8724610c4",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -249,12 +261,13 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "40c25004dcdc0072e8ac4c7c81443062149bb411cb4ba55e3c65014895343f23",
+            "contract_hash": "2d98ce33a6dae53144a249ec3af6b3c24867c8a5ebd0dd381fd0468cde1fe7de",
             "criterion": "Tieline must report every scoped entry omitted from a verdict document as unsupported, and must reject duplicate or out-of-scope entry identities as malformed submissions.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "203695a1d1c02b7d2a4e5bab44489689c87407f128f0ea5c7b9d01418f7e4e28",
+                "reviewed_content_hash": "f5aed29bc056a3299c96ab58b029b1faa23b2c3414b5731e58d29349a9d032a5",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/grade.ts",
@@ -263,8 +276,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "0985e00d2d0ebac7ba7b1674d9a52ea0ddf3475ae9801eedc8c8c5f1e9d26fdd",
+                "reviewed_content_hash": "f2021bcade671d043f5cdc10896023cf06d76d69b716f825fca977a8724610c4",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -297,12 +311,13 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "ebf18621f92dd6ae5c5d2914f2a80c07f87f84c4276687e08fec0659eed6cd38",
+            "contract_hash": "0e1f7e0686284a644a93a6e6fcc21285b55c499072b44e82c3f3ff3412b0075e",
             "criterion": "Grade verification must print every unsupported result and exit zero by default, but it must exit non-zero when strict mode is explicitly requested and an unsupported result remains.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "1bfd9f0d62f19d9906729ed3382a35aa24256ee747b709f6fd427e66fb549247",
+                "reviewed_content_hash": "150c2826587e7fe6d29976185913eab18e04dca4e3b41993859276b5dae87ace",
                 "target": {
                   "kind": "code",
                   "path": "src/commands/contract.ts",
@@ -311,8 +326,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "203695a1d1c02b7d2a4e5bab44489689c87407f128f0ea5c7b9d01418f7e4e28",
+                "reviewed_content_hash": "f5aed29bc056a3299c96ab58b029b1faa23b2c3414b5731e58d29349a9d032a5",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/grade.ts",
@@ -321,8 +337,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "0985e00d2d0ebac7ba7b1674d9a52ea0ddf3475ae9801eedc8c8c5f1e9d26fdd",
+                "reviewed_content_hash": "f2021bcade671d043f5cdc10896023cf06d76d69b716f825fca977a8724610c4",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -355,10 +372,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "3d0ab939458bac1934593e662957e87344b839436617cb48e78d908615f2a154",
+            "contract_hash": "ee66a0baf65dd19f779dfe877884eb841c3bf0a52bff49b64993b2da0be3cad1",
             "criterion": "The grading skill must direct the host agent to read and judge every scoped artifact, print every judgment before verification, cite only exact emitted symbols, treat unsupported as useful evidence, and leave contract YAML unchanged.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "420d5666fdfc79256a163408fb0fc79c89cc8d2b24c9d8ab9403d71fdf1ee52e",
                 "target": {
@@ -394,6 +412,6 @@
   },
   "input": {
     "path": ".tieline/spec/grading.yaml",
-    "sha256": "bcaff6f4f254954cb4f6d122927d49dc3b5cb5894883d35b793f9e60099de157"
+    "sha256": "4c9e239faadad8b5e3392ee441aa4fc9445a64b7a049cf20931340f0e4f8897a"
   }
 }

--- a/.tieline/manifest/MATCHING.json
+++ b/.tieline/manifest/MATCHING.json
@@ -12,10 +12,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "252dc68e90bd5e4b191b932299c4478f9f3005b4359a8aaa19dc4824a3bfcadc",
+            "contract_hash": "f8b4307a86adfe06bcb39930547dd3191e5db1587b78931afc6c3afa41a092b4",
             "criterion": "Tieline must derive separate semantic documents for Stories, Acceptance Criteria, Scenarios, Backlog Items, and sanitized Observations.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "enforces",
                 "reviewed_content_hash": "d95a7d4fa16a2bb3c0338f0bf2ef2a488b24a293436f07c33e33eb5500884996",
                 "target": {
@@ -25,6 +26,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "b0d31a33fb78baca4843965305f51b2f4ef33e9cbaa8311d2a9e305e87a373a6",
                 "target": {
@@ -34,6 +36,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "266ddb411c0d793bd65f0d5b37f86c63f01d570491de6d4051878ee9f92e7a0e",
                 "target": {
@@ -43,6 +46,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
                 "reviewed_content_hash": "ef95b8f1115a2fe335c81f73aca5025e9f8e77d91cd4bab0d5f099c97f8ab0d5",
                 "target": {
@@ -62,12 +66,13 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "6e5b4ac47ad981ab84dc3f047bfaa0f325c2149e645f85899962b064276c286d",
+            "contract_hash": "d95eb9a78b478aa142f95c863673f56c13627f724f867929d43f5af6b4b42b53",
             "criterion": "Tieline must apply retrieval metadata as narrowing filters before combining always-on full-text and identifier recall with optional vector, alias, artifact-overlap, and three-hop graph signals through reciprocal rank fusion.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "enforces",
-                "reviewed_content_hash": "9f99c3ac24bd8f87617d85e1ccf8aa8486ca05351a70a38f8f275a6bbb24a7a6",
+                "reviewed_content_hash": "a8fee643ee68cdb20a6c6920d77e83185e3d660747d6bd9daf252be866e98205",
                 "target": {
                   "kind": "code",
                   "path": "migrations/0001_baseline.sql",
@@ -75,6 +80,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "64640888aa510a254bee13e878c88709b5b6897ef232e86b532dc5f07a560ff6",
                 "target": {
@@ -84,6 +90,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "0add224b4610126cbc9018e7c98b9c69fd94f49567f33e44b8ca63ed44f6410d",
                 "target": {
@@ -93,6 +100,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "46335b97ce3859cea4d71d4b8503055a17a6c3f2c0e64625f4fe3b4bca824ade",
                 "target": {
@@ -102,6 +110,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "5ced89ffc9675ef3210532f5cf0d72c768b64abe9f6c9d2b5c6d1a2d0f1f5a64",
                 "target": {
@@ -111,6 +120,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "4945ef4e73ce620eaed6afe073d023f9cf3aa6e4ba998b890c36f6cf7476af86",
                 "target": {
@@ -120,6 +130,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "5a2a0f53379ae8e323fe3fc5d8f218ba35812f8151ccb135a27fc2a10acbbf2a",
                 "target": {
@@ -129,6 +140,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
                 "reviewed_content_hash": "ad6f14683c96f6cc208fe7d66bc65b15995f7876a6c8b77cb7ee7fb65f4384e5",
                 "target": {
@@ -139,6 +151,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
                 "reviewed_content_hash": "7a8667501e1cce7be148e33939b7e34e462a326ebe727b183286dcfc685d8238",
                 "target": {
@@ -149,8 +162,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "84ae986325de79954f9bd55889eb840bcd74280ea3bd27efd644dfac67804d8e",
+                "reviewed_content_hash": "0abce4d686d4317e1348c8864b3c8d9161cb8c948bf0ecff92be273442366980",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -159,6 +173,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
                 "reviewed_content_hash": "c9590556f14e3417b74497161c5547a25375c0e1a4b01a3e34ae2fc744b896df",
                 "target": {
@@ -169,6 +184,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
                 "reviewed_content_hash": "f73ab70075032befa93734f30d0cbb2834d38752e9ce695436059ad22ddd0f97",
                 "target": {
@@ -203,10 +219,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "a2ff57f20560439eb3330c52325f2f80b6817ef465952100f59138b02d2718a3",
+            "contract_hash": "da806abe99a3ba7f1453cd632c8503ef9e6e838e3c27d10bd461bc4c056fba62",
             "criterion": "Tieline must keep similarity-only relationships suggested until an explicit decision confirms or dismisses them.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "286a32fce01b3ed27e560044ba75254decf897a2174ceeafcb5d72c89f263a31",
                 "target": {
@@ -216,6 +233,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "adf23ebbe927ba6534bae791fd0de53a72a7996b8062a0bc647f00d699425595",
                 "target": {
@@ -225,6 +243,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "71ad6de042cc2478a586ebebab37efc7c7d279d0353c9488be3741982fd920ba",
                 "target": {
@@ -234,8 +253,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "84ae986325de79954f9bd55889eb840bcd74280ea3bd27efd644dfac67804d8e",
+                "reviewed_content_hash": "0abce4d686d4317e1348c8864b3c8d9161cb8c948bf0ecff92be273442366980",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -261,10 +281,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "b82f958e58880eb820901e76e205817a8f3a7c2b2d306dd5ca4cf4900582f6e9",
+            "contract_hash": "530c08f62c7123434e60b7d4d00f263a57c51a8bc1d24c82ecba53ab7b8d742f",
             "criterion": "Tieline must withhold a semantic candidate whose vector, lexical, and alias signals all fall below an absolute magnitude floor, even when its blended rank-fusion score clears the presentation cutoff.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "5ced89ffc9675ef3210532f5cf0d72c768b64abe9f6c9d2b5c6d1a2d0f1f5a64",
                 "target": {
@@ -274,6 +295,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "adf23ebbe927ba6534bae791fd0de53a72a7996b8062a0bc647f00d699425595",
                 "target": {
@@ -283,6 +305,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
                 "reviewed_content_hash": "f73ab70075032befa93734f30d0cbb2834d38752e9ce695436059ad22ddd0f97",
                 "target": {
@@ -337,6 +360,6 @@
   },
   "input": {
     "path": ".tieline/spec/matching.yaml",
-    "sha256": "ca88d8f9307dffa5ec09541786bca9923c3f8bf60c4c2163f629df7b3bd2d576"
+    "sha256": "84fcb2866f1fdfa8d93bed0850332f6f1583ea15e69e97bcd2aa9c2393d3436d"
   }
 }

--- a/.tieline/manifest/RETRIEVAL.json
+++ b/.tieline/manifest/RETRIEVAL.json
@@ -12,12 +12,13 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "fb1b21b857828ddf13651627168357b0c5d8cf64abd9152a88c81f21e10922dd",
+            "contract_hash": "a7f4ab92747947a6f39ffc10d5f98e200d22d312bd49a08d07911d8f260124fb",
             "criterion": "Tieline must return structured Stories with ordered Acceptance Criteria, direct and fallback links, coverage, freshness, lifecycle, and authority.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "11407c5f095e20c2b6c24c981faed9248e5e83f237cb7cb76355f46166b79758",
+                "reviewed_content_hash": "484a403c56ce158b6d1a388580201cda1673361318a6b8f98c3537d91e904042",
                 "target": {
                   "kind": "code",
                   "path": "src/adapters/postgres/contract-read-repository.ts",
@@ -25,8 +26,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "eab7b061c4c84c4a78c2f9494c970aaa548e4a9ab860b2d6d4766db9f568ac84",
+                "reviewed_content_hash": "0ed8ee5102600c032a0416652f263126dc8c46fc25f0b5479c74fb84bb81d06d",
                 "target": {
                   "kind": "code",
                   "path": "src/domain/contract-read-store.ts",
@@ -34,8 +36,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "7a2a01b03478e1be1f717fe86e88a1b9eb5cb16958b61a0fed746dd7a2d7cb9b",
+                "reviewed_content_hash": "a2a3924107310dcc18bb7f9fe9f59d0c1322418105104a45610a695d7cb2d755",
                 "target": {
                   "kind": "code",
                   "path": "src/schemas.ts",
@@ -43,6 +46,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "58fd53a2cf5de05f2f34872cb5207948e6b38a3ff65a6c209b3e96d1f6d666ee",
                 "target": {
@@ -52,6 +56,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "9588c406d2b7c9658e540a3aa449612d9e8f0ea83029bdef8b1a5d8276a3099f",
                 "target": {
@@ -61,8 +66,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "b871959e64279007e2fac1ebe5a603c978f1f6361128d6c880f7e3e7f204efd2",
+                "reviewed_content_hash": "a9bd06ecf5b2a31bef077035601c86881b61a3a13c9a99ec6cefb9c5e2f525f6",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -97,10 +103,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "4215ac8c86d3a474887f5b300c8dbf9cf01cc04ca672cc4333c7c786b119f60c",
+            "contract_hash": "d077d3a51d94f74db1d599f2cacb21d812b7045b812543cbe7aa6176f96fe5ef",
             "criterion": "Tieline must resolve a versioned retrieval profile before cross-type search and allow caller filters only to narrow it.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "592337d53da8741d33cd359aeb820cfca90d148929464828373b4760713d4335",
                 "target": {
@@ -110,6 +117,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "03156259c3016f0b25c5e066d90cc4a8b4fc8ad4f2c5407c1f07d80d2e797c19",
                 "target": {
@@ -119,6 +127,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "dde55e5cdad297b87f27f86cabe62d90838b07e9b5b594aba168ea28f031a677",
                 "target": {
@@ -128,8 +137,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "84ae986325de79954f9bd55889eb840bcd74280ea3bd27efd644dfac67804d8e",
+                "reviewed_content_hash": "0abce4d686d4317e1348c8864b3c8d9161cb8c948bf0ecff92be273442366980",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -138,6 +148,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
                 "reviewed_content_hash": "c9590556f14e3417b74497161c5547a25375c0e1a4b01a3e34ae2fc744b896df",
                 "target": {
@@ -182,6 +193,6 @@
   },
   "input": {
     "path": ".tieline/spec/retrieval.yaml",
-    "sha256": "ad69d289dd799e31e25d8606a52b988d862ca46385c6bde25bb4165f0399bd15"
+    "sha256": "374b78c2519251ab401a436f3306fe145dd19a14137b166348a6e3da58abe0d6"
   }
 }

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -12,10 +12,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "5099992110380ea506cd6cee93f5974344603ef186292e7102dad4a605183add",
+            "contract_hash": "e54b533738a4792fa4acd31017085c08b9692274cfab37bc46927b01063b2abf",
             "criterion": "Tieline must keep shared repository configuration portable while storing clone-local setup state and database credentials in a private external profile.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "2b4a059e4509d43be4954fbaf8e57f76a650f8657bb13eaf67754faf3a3abce1",
                 "target": {
@@ -25,6 +26,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "9cb0dd77df7ecbc802670a5143206b94d3a1db8f3f3f054f0aabe7e6f80576aa",
                 "target": {
@@ -34,6 +36,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "8c3113f8ac4d302ae35edc88a662127cf2aa42c20cdb196385c269c20533cd3a",
                 "target": {
@@ -43,6 +46,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "c3c8153279cbf890b9487d8d549cc783313dc8bef3685fca9014701b3e0731b3",
                 "target": {
@@ -52,6 +56,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
                 "reviewed_content_hash": "18a50d6bbf9011cf1d2137d2117de8dd4a2c35a9ef7e5ffd674d3e003f7ad5cb",
                 "target": {
@@ -71,10 +76,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "e9b7b7f85519ebd06ac00c994e9378aaa445085a8fdd4a341eb366b3356c38f1",
+            "contract_hash": "ba48dbddce90658dc0ef897612ba44842c83b669220dec2ef1e5c3d0a7bd3b80",
             "criterion": "Tieline must report workspace initialization, clone-local setup, and database-backed capability configuration as separate states.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "6453abe79100aad8774a580b49d3684b890a9e03d14851e0e7814458bd6d5b9f",
                 "target": {
@@ -84,6 +90,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "8124daf81c62a307a05f0b381795e92d8493fe4f637848192aaab37f8b377cc3",
                 "target": {
@@ -93,6 +100,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "8c3113f8ac4d302ae35edc88a662127cf2aa42c20cdb196385c269c20533cd3a",
                 "target": {
@@ -102,6 +110,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
                 "reviewed_content_hash": "18a50d6bbf9011cf1d2137d2117de8dd4a2c35a9ef7e5ffd674d3e003f7ad5cb",
                 "target": {
@@ -121,10 +130,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "ff24de9f97f85b3adef0e5cfb207cd736ee501b218896fa841044e1fd41d705a",
+            "contract_hash": "7a48cb595945ad2f25ff5740b143f657877eb11de5154e2ad39d123932c53c72",
             "criterion": "Tieline must surface detected source roots and preflight warnings while leaving the specification empty until repository-specific semantic onboarding.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "2b4a059e4509d43be4954fbaf8e57f76a650f8657bb13eaf67754faf3a3abce1",
                 "target": {
@@ -134,6 +144,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "9cb0dd77df7ecbc802670a5143206b94d3a1db8f3f3f054f0aabe7e6f80576aa",
                 "target": {
@@ -143,6 +154,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
                 "reviewed_content_hash": "18a50d6bbf9011cf1d2137d2117de8dd4a2c35a9ef7e5ffd674d3e003f7ad5cb",
                 "target": {
@@ -179,10 +191,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "51b8ba56c3717a544f018fa4110ddfea39dbb904d1af6e2f996408ab2820b822",
+            "contract_hash": "2c36a87351e38b2c5b24bdeefffb3347b0e7fdc0cfa9b03395b19352db538a22",
             "criterion": "Tieline must compose read, evidence-write, and planning-write capabilities without exposing repository synchronization through MCP tools.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "enforces",
                 "reviewed_content_hash": "c6182fb317a886f75fd3f68c54f7d8ba8276cfb9c8be6382f83510cd8929e34a",
                 "target": {
@@ -192,6 +205,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "enforces",
                 "reviewed_content_hash": "b0eb2f3b599e78aed08bf888a4c077cf874fd2b2510ba55faab7345f2da7fbba",
                 "target": {
@@ -201,6 +215,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "enforces",
                 "reviewed_content_hash": "fd605375737ec2aa2387403ec392230bc9246092535c77c7e5897ecdc77215db",
                 "target": {
@@ -210,6 +225,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "enforces",
                 "reviewed_content_hash": "41cba159faded83d20a635574f94e099767be29b70059f3c9ef4e1b0f24ba7dc",
                 "target": {
@@ -219,6 +235,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "cf449a59d5a0abb879e6fb298c11c8557a0897edb0d546aefed506b1259c897e",
                 "target": {
@@ -228,6 +245,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "1466752fe7326878746de366c6de4e7d70a7a2209a37b8b38858c5b9138befff",
                 "target": {
@@ -237,6 +255,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
                 "reviewed_content_hash": "c9590556f14e3417b74497161c5547a25375c0e1a4b01a3e34ae2fc744b896df",
                 "target": {
@@ -256,10 +275,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "96db593fe00db001785d183336e14c7e24cff9b1a944e39ac0f1cfc4ff0c30a8",
+            "contract_hash": "9f2a3f9ecc2551ef813537badadb438679d4f6a8dc0c807d49682968c85d2e34",
             "criterion": "Tieline must serve stdio by default and require explicit gateway configuration for non-loopback HTTP.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "enforces",
                 "reviewed_content_hash": "f8071433f0755226afdf3ad8ef2ad0aa2831cb7a32bc583f778c09bd0269a7c0",
                 "target": {
@@ -269,6 +289,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "1f479c20a7c785e83b58440e9fdd4a9c616d9128fa28ab6980dde664a2980c77",
                 "target": {
@@ -278,6 +299,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "6ff8930f8bce5c9621a558bb89a160f408228b7912c741038dd2615a57217e76",
                 "target": {
@@ -287,6 +309,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "f47ad8b3b82aefd57beaf218e8274ba27f592d513d391b541f709e6807164531",
                 "target": {
@@ -296,6 +319,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "153cac6da711d91437b62f1a6d12db8ef2c64f9ea41086341cf3ac0bddbb1f41",
                 "target": {
@@ -305,6 +329,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "469c89ce5d7f97d333ac69396e60c20630d54d362b20a9bf6b7b41c4bc1e3cce",
                 "target": {
@@ -314,6 +339,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
                 "reviewed_content_hash": "0451f7da677c969573d5e0b444190b00807d1794ae3126123a3f5f9f79bea1e1",
                 "target": {
@@ -333,10 +359,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "81c3603e5c5fdd89ac8ce3f5bf51d4085a60756eb3b1290394e460502e842274",
+            "contract_hash": "7384d08a80cc6ffa9a2feece4f3902d63c96b5b341622dac62cfa3f9b0977b97",
             "criterion": "Tieline must provide a loud in-memory test seam for contract and tool verification without weakening production adapters.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "0aecc59b02491316c83f90a82da9358a6969464d4b0386d08676ee0251e660da",
                 "target": {
@@ -346,8 +373,9 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "b871959e64279007e2fac1ebe5a603c978f1f6361128d6c880f7e3e7f204efd2",
+                "reviewed_content_hash": "a9bd06ecf5b2a31bef077035601c86881b61a3a13c9a99ec6cefb9c5e2f525f6",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -365,10 +393,11 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "568094a6297e4c82d0081dbeca76bb8d8b2b21a6f4dd062282b75bdb7fd4f709",
+            "contract_hash": "ffe88f8ca0bf0d4945fdac2450abf904d4f226dc7c9d94b48b991a61bbd2a070",
             "criterion": "Tieline must expose a semantic-authoring prompt that uses configured repository context and falls back to disclosed local duplicate checks when database-backed matching is unavailable.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "84b74d5650baad503a10fb6d223e1186a015daf6af9ccb9a4e7a707043c7dfeb",
                 "target": {
@@ -378,6 +407,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "579c7e6f6496dcc5317b1c2a1f5c24124bf3c9352753241051334cbcc08534c7",
                 "target": {
@@ -387,6 +417,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "implements",
                 "reviewed_content_hash": "cf449a59d5a0abb879e6fb298c11c8557a0897edb0d546aefed506b1259c897e",
                 "target": {
@@ -396,6 +427,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
                 "reviewed_content_hash": "c9590556f14e3417b74497161c5547a25375c0e1a4b01a3e34ae2fc744b896df",
                 "target": {
@@ -406,6 +438,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
                 "reviewed_content_hash": "18a50d6bbf9011cf1d2137d2117de8dd4a2c35a9ef7e5ffd674d3e003f7ad5cb",
                 "target": {
@@ -442,12 +475,13 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "bc03344cdc305074401567d58ffeaa3c06326c0b971274ea2e6fb9a9ccb76e1c",
+            "contract_hash": "57dbd2fa6845c6737c9d8f3d0e2d56c2862bf25a26652d4e0ab8af9b359d02e6",
             "criterion": "Tieline must run the clean lifecycle integration suite against a disposable baseline database.",
             "links": [
               {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "6e5f17dc0c9072307dda57cf1cdb696ee351383b0ccfa9f13ec86c6a651630ed",
+                "reviewed_content_hash": "f880865dd401fff0dc575ae86b4ed9c422b42e6748079cf79a31454dfdcf6906",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -456,6 +490,7 @@
                 }
               },
               {
+                "provenance": "authored",
                 "relation": "tests",
                 "reviewed_content_hash": "9133932de363ec718bccc57763811a7e812fff735de1a1d8c1f17d8797e885af",
                 "target": {
@@ -492,6 +527,6 @@
   },
   "input": {
     "path": ".tieline/spec/runtime.yaml",
-    "sha256": "ed095b34bcc16b61abe096f04105fdace46954edd2daf6a620ab77424ad4b7eb"
+    "sha256": "e3fd93045805b511324228a7fccd8bae26a1c63f1f06f8737b3570adabb5f53d"
   }
 }

--- a/.tieline/manifest/index.json
+++ b/.tieline/manifest/index.json
@@ -1,6 +1,6 @@
 {
   "repository": {
-    "commit": "e6e342ffaf0289ab231018fb2aa5bdcdb074aeae",
+    "commit": "96bb59a6cb06148b9beb4ca855de63fb560c8728",
     "key": "tieline"
   },
   "schema_version": 1

--- a/.tieline/manifest/index.json
+++ b/.tieline/manifest/index.json
@@ -1,6 +1,6 @@
 {
   "repository": {
-    "commit": "f88799e53dd3999004714d612e6a0a114f238613",
+    "commit": "e6e342ffaf0289ab231018fb2aa5bdcdb074aeae",
     "key": "tieline"
   },
   "schema_version": 1

--- a/.tieline/spec/authority.yaml
+++ b/.tieline/spec/authority.yaml
@@ -15,21 +15,25 @@ capability:
           criterion: Tieline must allow planning writers to create and revise only backlog Stories and their Acceptance Criteria.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/domain/planning-contract-write-store.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/adapters/postgres/planning-story-repository.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tools/planning-stories.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -50,26 +54,31 @@ capability:
               then: Tieline must project the merged definition and preserve the later planning revision as a handoff conflict
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/domain/repository-sync-store.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/contract/sync.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/adapters/postgres/contract-sync-repository.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tools/handoff-conflicts.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -79,37 +88,44 @@ capability:
           criterion: Tieline must keep read, planning-write, repository-sync, and offline-admin database responsibilities separate.
           links:
             - relation: enforces
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/adapters/postgres/connections.ts
             - relation: enforces
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/commands/migrate.ts
             - relation: enforces
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tieline/preflight.ts
             - relation: enforces
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tieline/profile.ts
             - relation: enforces
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tieline/setup.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
                 path: scripts/test-baseline.ts
                 framework_hint: custom-script
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -124,11 +140,13 @@ capability:
               then: the code asset for the former path must be removed, while an asset owned by another repository or still linked by another contract record must be retained
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/adapters/postgres/contract-sync-repository.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline

--- a/.tieline/spec/contract.yaml
+++ b/.tieline/spec/contract.yaml
@@ -21,26 +21,31 @@ capability:
           rationale: Structural failures make semantic impact and synchronization untrustworthy.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/contract/schema.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/contract/load.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/contract/validate.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/contract/index.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -57,33 +62,39 @@ capability:
               then: Tieline must report that coverage is not measured instead of reporting 100 percent
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/contract/manifest.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/contract/coverage.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/commands/contract.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
                 path: scripts/test-contract.ts
                 framework_hint: custom-script
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
                 path: scripts/test-manifest.ts
                 framework_hint: custom-script
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -98,16 +109,19 @@ capability:
               then: Tieline must report the linked criterion as impacted and stale
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/contract/impact.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/commands/check.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -118,16 +132,19 @@ capability:
           rationale: Maintainers outside the implementation can review the same repository-owned contract accepted by the pull request.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/contract/review-page.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/commands/contract.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -145,22 +162,26 @@ capability:
               then: Tieline must refuse the manifest and name both the file and the capability instead of accepting the capability under the wrong identity
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/contract/manifest.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/commands/contract.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
                 path: scripts/test-manifest.ts
                 framework_hint: custom-script
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -181,20 +202,94 @@ capability:
               then: Tieline must report the compilation failure once rather than also reporting it as a stale manifest
           links:
             - relation: enforces
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/commands/check.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/cli.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
                 path: scripts/test-impact.ts
+                framework_hint: custom-script
+        - key: CONTRACT-001-AC7
+          criterion: Tieline must require every contract link to state whether its claim was authored, inferred, or materialized, and must preserve that provenance through compiled manifests, repository synchronization, and every exact claim read.
+          rationale: Relation and target describe what a link claims, while provenance records how that claim entered its current authority surface. Keeping this low-cardinality origin distinct from freshness and grade lets agents interpret a claim without turning mutable review facts into contract identity.
+          scenarios:
+            - given: a contract link has no provenance
+              when: the repository contract is validated
+              then: Tieline must reject the link instead of guessing where its claim came from
+            - given: only a contract link's provenance changes
+              when: the contract manifest is compiled
+              then: Tieline must change the owning contract hash without creating a second link identity
+            - given: an accepted repository link was copied during planning-to-repository authority transfer
+              when: the repository contract is synchronized and read
+              then: Tieline must preserve materialized as the origin of that exact claim
+          links:
+            - relation: enforces
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/contract/schema.ts
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/contract/manifest.ts
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/adapters/postgres/contract-sync-repository.ts
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/adapters/postgres/contract-read-repository.ts
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/contract/link-plausibility.ts
+            - relation: enforces
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: migrations/0001_baseline.sql
+            - relation: tests
+              provenance: authored
+              target:
+                kind: test
+                repository: tieline
+                path: scripts/test-contract.ts
+                framework_hint: custom-script
+            - relation: tests
+              provenance: authored
+              target:
+                kind: test
+                repository: tieline
+                path: scripts/test-manifest.ts
+                framework_hint: custom-script
+            - relation: tests
+              provenance: authored
+              target:
+                kind: test
+                repository: tieline
+                path: scripts/integration-contract-sync.ts
                 framework_hint: custom-script
     - key: CONTRACT-002
       title: Learn which acceptance criteria apply to a path before editing it
@@ -221,26 +316,31 @@ capability:
               then: Tieline must return not_found distinctly from an existing path with no criteria
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/contract/reconciliation.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/contract/path-criteria.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/commands/contract.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/cli.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -258,21 +358,25 @@ capability:
               then: Tieline must name the missing workspace and the command that creates one
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tools/path-criteria.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/server.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/schemas.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline

--- a/.tieline/spec/evidence.yaml
+++ b/.tieline/spec/evidence.yaml
@@ -19,27 +19,32 @@ capability:
               then: Tieline must return the stored record for a later matching retry
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/domain/evidence-write-store.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/adapters/postgres/observation-repository.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tools/observations.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
                 path: scripts/test-evidence.ts
                 framework_hint: custom-script
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -56,16 +61,19 @@ capability:
           criterion: Tieline must let a Backlog Item target zero or more Stories and Acceptance Criteria without becoming their lifecycle container.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/adapters/postgres/backlog-repository.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tools/backlog-items.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -82,31 +90,37 @@ capability:
           criterion: Tieline must resolve help content by source and external identifier while preserving Story and Acceptance Criterion backlinks.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/authoring/help-schema.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/adapters/postgres/help-repository.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/commands/import-help.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tools/find_help.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tools/get_help_article.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline

--- a/.tieline/spec/grading.yaml
+++ b/.tieline/spec/grading.yaml
@@ -29,18 +29,21 @@ capability:
               then: Tieline must emit distinct entries whose linked_path values preserve both contract targets
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/contract/reconciliation.ts
                 selector: function:buildContractClaimIndex
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/contract/grade.ts
                 selector: function:buildGradeScope
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -58,18 +61,21 @@ capability:
               then: Tieline must emit an empty citation allow-list without failing the scope
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/contract/selector.ts
                 selector: function:indexSourceSymbols
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/contract/grade.ts
                 selector: function:citableSymbolsForPath
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -80,18 +86,21 @@ capability:
           rationale: The semantic judgment belongs to the host agent, while both Tieline phases remain deterministic and usable in the same offline pull-request loop as contract validation.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/commands/contract.ts
                 selector: function:runGrade
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/cli.ts
                 selector: function:buildProgram
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -112,18 +121,21 @@ capability:
               then: Tieline must report unsupported with fabricated_citation
           links:
             - relation: enforces
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/contract/grade.ts
                 selector: function:parseGradeVerdicts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/contract/grade.ts
                 selector: function:verifyGradeVerdicts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -141,12 +153,14 @@ capability:
               then: Tieline must reject the submission instead of choosing or ignoring a verdict
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/contract/grade.ts
                 selector: function:verifyGradeVerdicts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -164,18 +178,21 @@ capability:
               then: Tieline must print the unsupported result and exit non-zero
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/contract/grade.ts
                 selector: function:verifyGradeVerdicts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/commands/contract.ts
                 selector: function:runGrade
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -186,6 +203,7 @@ capability:
           rationale: The host judgment is the only non-deterministic phase, so its refusal and audit rules are part of the shipped workflow.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline

--- a/.tieline/spec/matching.yaml
+++ b/.tieline/spec/matching.yaml
@@ -19,21 +19,25 @@ capability:
           rationale: Focused documents preserve specificity and avoid re-embedding unrelated criteria.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/derived/embedding-documents.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/embeddings.ts
             - relation: enforces
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/adapters/postgres/vector.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -50,65 +54,77 @@ capability:
               then: Tieline must return full-text or identifier matches with explicit signal features and match reasons
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/domain/semantic-search-store.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/adapters/postgres/semantic-repository.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/adapters/postgres/search-context.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/ranking.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tools/find_related.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tools/search-knowledge.ts
             - relation: enforces
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: migrations/0001_baseline.sql
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
                 path: scripts/test-ranking.ts
                 framework_hint: custom-script
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
                 path: scripts/evaluate-retrieval.ts
                 framework_hint: custom-script
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
                 path: scripts/integration-evidence.ts
                 framework_hint: custom-script
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
                 path: scripts/smoke.ts
                 framework_hint: custom-script
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -122,21 +138,25 @@ capability:
               then: its state must remain suggested
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/semantic-matching.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/backlog-advisor.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tools/attributions.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -154,16 +174,19 @@ capability:
               then: the candidate must be retained because an exact alias match is a deterministic identifier match rather than a fuzzy one
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/ranking.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/semantic-matching.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline

--- a/.tieline/spec/retrieval.yaml
+++ b/.tieline/spec/retrieval.yaml
@@ -15,31 +15,37 @@ capability:
           criterion: Tieline must return structured Stories with ordered Acceptance Criteria, direct and fallback links, coverage, freshness, lifecycle, and authority.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/types.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/domain/contract-read-store.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/adapters/postgres/contract-read-repository.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/schemas.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tools/query_stories.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -60,27 +66,32 @@ capability:
               then: Tieline must search only the repository intersection
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/adapters/postgres/profile-repository.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/commands/profile.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/resources.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
                 path: scripts/integration-evidence.ts
                 framework_hint: custom-script
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline

--- a/.tieline/spec/runtime.yaml
+++ b/.tieline/spec/runtime.yaml
@@ -15,26 +15,31 @@ capability:
           criterion: Tieline must keep shared repository configuration portable while storing clone-local setup state and database credentials in a private external profile.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/cli.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tieline/init.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tieline/status.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tieline/workspace.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -45,21 +50,25 @@ capability:
           rationale: A tracked config cannot prove that another clone has credentials or semantic matching available.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tieline/profile.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tieline/setup.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tieline/status.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -69,16 +78,19 @@ capability:
           criterion: Tieline must surface detected source roots and preflight warnings while leaving the specification empty until repository-specific semantic onboarding.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/cli.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tieline/init.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -95,36 +107,43 @@ capability:
           criterion: Tieline must compose read, evidence-write, and planning-write capabilities without exposing repository synchronization through MCP tools.
           links:
             - relation: enforces
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/domain/knowledge-store.ts
             - relation: enforces
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/adapters/postgres/postgres-store.ts
             - relation: enforces
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/default-store.ts
             - relation: enforces
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/store.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/server.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tools/shared.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -134,36 +153,43 @@ capability:
           criterion: Tieline must serve stdio by default and require explicit gateway configuration for non-loopback HTTP.
           links:
             - relation: enforces
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/config.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/http.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/index.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/loadEnv.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/commands/serve.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/stdio.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -173,11 +199,13 @@ capability:
           criterion: Tieline must provide a loud in-memory test seam for contract and tool verification without weakening production adapters.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/domain/testing/fake-knowledge-store.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -187,27 +215,32 @@ capability:
           criterion: Tieline must expose a semantic-authoring prompt that uses configured repository context and falls back to disclosed local duplicate checks when database-backed matching is unavailable.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/prompts.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/server.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: skills/tieline-author/SKILL.md
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
                 path: scripts/smoke.ts
                 framework_hint: custom-script
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -224,12 +257,14 @@ capability:
           criterion: Tieline must run the clean lifecycle integration suite against a disposable baseline database.
           links:
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
                 path: scripts/integration.ts
                 framework_hint: custom-script
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline

--- a/README.md
+++ b/README.md
@@ -94,17 +94,20 @@ capability:
               then: only production contract records must be returned
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/adapters/postgres/semantic-repository.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
                 path: scripts/integration-evidence.ts
                 framework_hint: custom-script
             - relation: documents
+              provenance: authored
               target:
                 kind: help
                 source: intercom
@@ -116,6 +119,9 @@ render the familiar “As a … I want … so that …” sentence. Each accepte
 one observable outcome using `<subject> must <outcome> [when <condition>]`.
 Scenarios use framework-neutral Given/When/Then text. Test locators may include a
 `framework_hint`, but no test framework is required.
+
+Every link states its provenance: `authored` for a deliberate human-authored
+claim, `inferred` for a derived claim, or `materialized` for a copied projection.
 
 Stable IDs are identity, not embedding prose. Aliases support alternate language,
 applicability distinguishes legitimately different behavior, and `supersedes`

--- a/docs/plans/2026-08-04-001-feat-contract-link-provenance-plan.md
+++ b/docs/plans/2026-08-04-001-feat-contract-link-provenance-plan.md
@@ -1,0 +1,186 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+title: "Contract link provenance - Plan"
+date: 2026-08-04
+type: feat
+depth: standard
+---
+
+# Contract link provenance - Plan
+
+## Goal capsule
+
+- **Objective:** Record where every contract claim came from and preserve that origin from accepted YAML through compiled manifests, database projections, and agent-facing reads.
+- **User:** Maintainers and agents inspecting or authoring Tieline contracts.
+- **Boundary:** Provenance describes claim origin. It does not score evidence, record a grader, timestamp a decision, or become part of link identity.
+- **Compatibility posture:** This is intentionally breaking while Tieline has no users: every link must state provenance, with no optional field or inferred default.
+
+## Product contract
+
+### Problem
+
+The relation and target describe what a contract link claims, while freshness and grade describe aspects of its evidence. None records how the claim entered the contract. Agents therefore cannot distinguish a directly authored claim from one introduced by inference or carried through planning materialization.
+
+### Requirements
+
+- **R1.** Every accepted and planning contract link must require exactly one stable provenance value: `authored`, `inferred`, or `materialized`.
+- **R2.** Provenance must mean where the claim came from and remain distinct from grade, freshness, authority, and link scope.
+- **R3.** Existing repository-maintained links and representative authored test fixtures must be explicitly labeled `authored`; no parser or storage default may guess a missing value.
+- **R4.** Compiled manifests must serialize provenance and include it in existing link-bearing contract semantics, so changing provenance changes the owning Story or Acceptance Criterion contract hash.
+- **R5.** Repository sync must persist provenance for code, test, and help links, and contract reads must return it for direct and Story-fallback evidence.
+- **R6.** Deterministic manifest-backed path lookup, reconciliation, grading scope, impact reporting, and link-review output must preserve provenance when they expose a particular claim.
+- **R7.** Provenance must not become part of the link identity tuple. Re-labeling the same owner, target, and relation updates claim metadata rather than creating a second link.
+- **R8.** Mutable facts such as grader identity, timestamps, commits, or confidence must remain outside authored YAML and contract-link provenance.
+- **R9.** One owner must not declare the same relation and target more than once with contradictory provenance values.
+
+### Key decisions
+
+- **KTD1. Required explicit provenance.** Use a required field and label the corpus rather than an optional field or `authored` default, because silent defaults erase the exact distinction this feature exists to retain. Governs R1 and R3. (session-settled: user-directed — chosen over optional/defaulted provenance after the no-user migration tradeoff was stated)
+- **KTD2. Small stable vocabulary.** Limit provenance to `authored | inferred | materialized`; keep mutable grading and audit facts in derived output. Governs R2 and R8. (session-settled: user-directed — chosen over richer mutable metadata because link fields participate in contract hashes)
+- **KTD3. Metadata, not identity.** Persist provenance on each ownership junction and update it with the link, without widening primary keys or locator maps. Governs R5 and R7.
+- **KTD4. Agent-visible end to end.** Any representation that returns a concrete contract claim carries its provenance; aggregate coverage and semantic identifiers need not incorporate it. Governs R5 and R6.
+
+### Acceptance examples
+
+- An accepted link with no provenance fails validation with an actionable schema issue.
+- Identical code links labeled `authored`, `inferred`, and `materialized` each parse when tested independently.
+- Changing only a criterion link from `authored` to `inferred` changes that criterion's `contract_hash` and serialized manifest link.
+- Syncing the same link after changing only provenance updates one junction row rather than creating another.
+- Declaring the same owner, relation, and target twice with different provenance fails validation rather than selecting a value by source order.
+- `query_stories` returns provenance for code/test and help links, including Story fallback links.
+- Contract graph evidence edges return provenance; hierarchy and lifecycle edges return no provenance because they are not contract links.
+- `get_path_criteria`, reconciliation JSON, grade scope, and impact JSON retain the provenance of the exact manifest link that produced each claim.
+
+## Planning contract
+
+### Current architecture constraints
+
+- `src/contract/schema.ts` owns accepted/planning link validation; `src/contract/manifest.ts` has a separate strict schema for compiled artifacts.
+- `criterionSemantics()` and `storySemantics()` include source links verbatim, so provenance naturally participates in contract hashes.
+- `src/adapters/postgres/contract-sync-repository.ts` replaces owner-link junctions on sync; the four junction tables in `migrations/0001_baseline.sql` are the projection boundary.
+- `src/adapters/postgres/contract-read-repository.ts` reconstructs the shared `ContractEvidenceLink` returned by query tools.
+- `buildContractClaimIndex()` is the shared traversal for reconciliation and deterministic path lookup. Provenance must be added to that claim record rather than recovered by another manifest walk.
+- The repository uses script-based tests and a compiled, sharded manifest that must be regenerated before push.
+
+### Provenance semantics
+
+- `authored`: the claim was introduced directly by a person in its current planning or repository authority surface.
+- `inferred`: the claim originated in deterministic or model-assisted inference in its current authority surface and retains that origin through review within that surface.
+- `materialized`: the accepted repository claim was copied from a planning record during planning-to-repository authority transfer.
+
+The values describe mutually exclusive introduction paths, not current trust or ownership. A planning link is `authored` or `inferred`; materialization deliberately establishes `materialized` on the repository copy, regardless of the planning link's earlier origin. Later review within the same authority surface does not rewrite provenance merely because a human approved the claim.
+
+## Implementation units
+
+### U1 - Require and compile provenance
+
+**Goal:** Establish the source and manifest data contracts.
+
+**Files:**
+
+- Update `src/contract/schema.ts`
+- Update `src/contract/validate.ts`
+- Update `src/contract/manifest.ts`
+- Update `scripts/test-contract.ts`
+- Update `scripts/test-manifest.ts`
+
+**Approach:** Export one canonical provenance vocabulary/type, require it in every discriminated contract-link arm, copy it into `ManifestLink`, and require it when reading manifest shards. Keep the existing link sort and identity based on relation plus target; the complete serialized link still participates in Story/criterion semantic hashes. Validate duplicate owner links by relation plus canonical target while excluding provenance from that key, so contradictory source declarations fail instead of relying on order.
+
+**Proof first:** Cover rejection of a missing field, acceptance of all three values, duplicate identity with conflicting provenance, manifest round-trip, and a contract-hash change caused only by provenance.
+
+### U2 - Persist and return provenance
+
+**Goal:** Preserve origin through repository synchronization and structured contract reads.
+
+**Files:**
+
+- Update `migrations/0001_baseline.sql`
+- Update `src/adapters/postgres/contract-sync-repository.ts`
+- Update `src/adapters/postgres/contract-read-repository.ts`
+- Update `src/domain/contract-read-store.ts`
+- Update `scripts/integration-contract-sync.ts`
+- Update `scripts/test-contract-read.ts`
+
+**Approach:** Add a required constrained provenance column to all four Story/criterion code/help junctions. Insert provenance during replacement sync and select it into `ContractEvidenceLink`. Contract graph evidence edges copy the link provenance, while hierarchy and lifecycle edges omit it. Do not add provenance to junction primary keys. Because there are no deployed users, update the baseline rather than add a compatibility migration.
+
+**Proof first:** Assert code/test/help persistence and read-back, Story fallback visibility, and metadata replacement without duplicate link identity. Run the database integration when a usable Postgres/pgvector service is available; otherwise report the environmental limitation while retaining compile and unit proof.
+
+### U3 - Propagate provenance through claim views
+
+**Goal:** Make the new distinction available anywhere an agent sees a concrete contract claim.
+
+**Files:**
+
+- Update `src/contract/reconciliation.ts`
+- Update `src/contract/path-criteria.ts`
+- Update `src/contract/impact.ts`
+- Update `src/contract/grade.ts`
+- Update `src/contract/link-plausibility.ts`
+- Update `src/contract/review-page.ts`
+- Update `src/schemas.ts`
+- Update corresponding `scripts/test-*.ts` contract tests
+
+**Approach:** Add provenance to existing claim/result records at the point each record is constructed. Path lookup and grading inherit it from reconciliation's shared claim index; no additional manifest walk is allowed. Contract-definition impact entries use `provenance: null` because they do not arise from a link; linked and broken-link impacts carry the exact value. Show provenance beside concrete links in the contract review page. Preserve existing ordering and IDs because provenance is metadata rather than identity.
+
+**Proof first:** Extend exact JSON assertions for direct and Story-fallback claims, and prove a path lookup receives provenance without a new traversal.
+
+### U4 - Migrate the accepted corpus and self-host the rule
+
+**Goal:** Leave no unlabeled contract link and record the behavior in Tieline's own contract.
+
+**Files:**
+
+- Update every `.tieline/spec/*.yaml` link
+- Update YAML fixtures under `scripts/`
+- Update typed `ManifestLink` and `ContractEvidenceLink` fixtures under `scripts/`
+- Update the appropriate criterion in `.tieline/spec/contract.yaml`
+- Regenerate `.tieline/manifest/`
+
+**Approach:** Label all existing accepted claims `authored`. Use `inferred` and `materialized` only in focused tests that establish their semantics. Re-read every spec before selecting the self-hosted stable ID. Run `tieline contract compile .` after all source and spec edits and commit the generated manifest.
+
+**Proof first:** Add a corpus/schema assertion that missing provenance fails, then migrate all fixtures until the full suite passes without a fallback.
+
+## Verification contract
+
+- `npm run test:contract`
+- `npm run test:contract-read`
+- `npm run test:integration:contract-sync` when database prerequisites are available
+- `npm run build`
+- `node dist/cli.js contract validate .`
+- `node dist/cli.js contract compile .`
+- `node dist/cli.js contract coverage .`
+- `node dist/cli.js contract reconcile . --base origin/main`
+- `node dist/cli.js check --base origin/main`
+- `git diff --exit-code -- .tieline/manifest`
+
+## Dependency order
+
+```text
+U1 -> U2 -> U3 -> U4 -> review -> PR -> green CI -> merge
+```
+
+## Risks and mitigations
+
+- **Silent data loss:** A schema-only change could drop provenance in Postgres. U2 requires persistence and read-back proof across all four junctions.
+- **Identity inflation:** Adding provenance to primary keys could allow contradictory duplicate claims. KTD3 keeps existing identity and replaces metadata.
+- **Parallel contract traversal:** Re-deriving provenance for path lookup would regress the shared-index design. U3 extends `ClaimingCriterion` once.
+- **Stale generated evidence:** Provenance changes contract hashes and manifest content. U4 makes compilation and a clean manifest diff a shipping gate.
+
+## Out of scope
+
+- Recording grade, grader, confidence, timestamps, commits, or audit history in YAML provenance.
+- Automatically inferring or rewriting provenance.
+- Changing coverage semantics, link plausibility ranking, freshness, or grade behavior.
+- Compatibility defaults or upgrade migrations for users that do not exist.
+
+## Definition of done
+
+- All contract links require and serialize one valid provenance.
+- Existing contracts and fixtures are explicitly labeled without a default.
+- Database sync/read and agent-facing exact claim views preserve the value.
+- No link identity or aggregate coverage semantics change.
+- Tests, build, contract verification, and compiled manifest are clean.
+- The PR is reviewed, CI is green, and the branch is merged.

--- a/migrations/0001_baseline.sql
+++ b/migrations/0001_baseline.sql
@@ -178,6 +178,7 @@ create table story_code_assets (
   story_id uuid not null references user_stories(id) on delete cascade,
   asset_id uuid not null references code_assets(id),
   relation text not null check (relation in ('implements', 'enforces', 'tests')),
+  provenance text not null check (provenance in ('authored', 'inferred', 'materialized')),
   reviewed_content_hash text check (
     reviewed_content_hash is null or reviewed_content_hash ~ '^[a-f0-9]{64}$'
   ),
@@ -188,6 +189,7 @@ create table criterion_code_assets (
   criterion_id uuid not null references acceptance_criteria(id) on delete cascade,
   asset_id uuid not null references code_assets(id),
   relation text not null check (relation in ('implements', 'enforces', 'tests')),
+  provenance text not null check (provenance in ('authored', 'inferred', 'materialized')),
   reviewed_content_hash text check (
     reviewed_content_hash is null or reviewed_content_hash ~ '^[a-f0-9]{64}$'
   ),
@@ -198,6 +200,7 @@ create table story_help_articles (
   story_id uuid not null references user_stories(id) on delete cascade,
   article_id uuid not null references help_articles(id),
   relation text not null default 'documents' check (relation = 'documents'),
+  provenance text not null check (provenance in ('authored', 'inferred', 'materialized')),
   primary key (story_id, article_id)
 );
 
@@ -205,6 +208,7 @@ create table criterion_help_articles (
   criterion_id uuid not null references acceptance_criteria(id) on delete cascade,
   article_id uuid not null references help_articles(id),
   relation text not null default 'documents' check (relation = 'documents'),
+  provenance text not null check (provenance in ('authored', 'inferred', 'materialized')),
   primary key (criterion_id, article_id)
 );
 

--- a/scripts/integration-contract-sync.ts
+++ b/scripts/integration-contract-sync.ts
@@ -56,7 +56,14 @@ capability:
         record_id: ${input.originId}
         revision: ${input.originRevision}
       links:
+        - relation: implements
+          provenance: materialized
+          target:
+            kind: code
+            repository: sync-integration
+            path: src/story.ts
         - relation: documents
+          provenance: materialized
           target:
             kind: help
             source: intercom
@@ -68,12 +75,14 @@ capability:
             roles: [admin]
           links:
             - relation: tests
+              provenance: materialized
               target:
                 kind: test
                 repository: sync-integration
                 path: scripts/sync.test.ts
                 framework_hint: custom
             - relation: documents
+              provenance: materialized
               target:
                 kind: help
                 source: intercom
@@ -81,6 +90,7 @@ capability:
 ${
   input.implementationPath
     ? `            - relation: implements
+              provenance: materialized
               target:
                 kind: code
                 repository: sync-integration
@@ -106,7 +116,9 @@ const sql = postgres(adminUrl, { max: 1, prepare: false });
 const root = mkdtempSync(resolve(tmpdir(), "tieline-contract-sync-"));
 mkdirSync(resolve(root, ".tieline/spec"), { recursive: true });
 mkdirSync(resolve(root, "scripts"), { recursive: true });
+mkdirSync(resolve(root, "src"), { recursive: true });
 writeFileSync(resolve(root, "scripts/sync.test.ts"), "assert(contractSync);\n");
+writeFileSync(resolve(root, "src/story.ts"), "export const story = true;\n");
 
 try {
   const [repository] = await sql<{ id: string }[]>`
@@ -344,12 +356,39 @@ try {
     readStory.acceptance_criteria[0]!.fallback_story_links[0]!.scope,
     "story_fallback"
   );
+  assert.equal(
+    readStory.acceptance_criteria[0]!.fallback_story_links[0]!.provenance,
+    "materialized"
+  );
+  assert.deepEqual(
+    readStory.acceptance_criteria[0]!.fallback_story_links.map(
+      (link) => [link.relation, link.provenance]
+    ),
+    [
+      ["implements", "materialized"],
+      ["documents", "materialized"],
+    ]
+  );
+  assert.ok(
+    readStory.acceptance_criteria[0]!.direct_links.every(
+      (link) => link.provenance === "materialized"
+    )
+  );
   assert.equal(criterionRead?.criterion.direct_links.length, 2);
   assert.ok(
     repositoryGraph.edges.some(
       (edge) =>
+        edge.source === "story:sync-integration:SYNC-001" &&
+        edge.relation === "implements" &&
+        edge.provenance === "materialized"
+    )
+  );
+  assert.ok(
+    repositoryGraph.edges.some(
+      (edge) =>
         edge.source === "ac:sync-integration:SYNC-001-AC1" &&
-        edge.relation === "tests"
+        edge.relation === "tests" &&
+        edge.provenance === "materialized"
     )
   );
   assert.ok(
@@ -357,7 +396,8 @@ try {
       (edge) =>
         edge.source === "ac:sync-integration:SYNC-001-AC1" &&
         edge.target === "ac:sync-integration:SYNC-001-AC2" &&
-        edge.relation === "superseded_by"
+        edge.relation === "superseded_by" &&
+        edge.provenance === undefined
     )
   );
 
@@ -644,11 +684,16 @@ try {
     values (${repository.id}, 'code', 'src/linked-by-foreign-criterion.ts')
     returning id`;
   await sql`
-    insert into story_code_assets (story_id, asset_id, relation)
-    values (${foreignStory.id}, ${storyLinkedAsset.id}, 'implements')`;
+    insert into story_code_assets (story_id, asset_id, relation, provenance)
+    values (
+      ${foreignStory.id}, ${storyLinkedAsset.id}, 'implements', 'authored'
+    )`;
   await sql`
-    insert into criterion_code_assets (criterion_id, asset_id, relation)
-    values (${foreignCriterion.id}, ${criterionLinkedAsset.id}, 'implements')`;
+    insert into criterion_code_assets (
+      criterion_id, asset_id, relation, provenance
+    ) values (
+      ${foreignCriterion.id}, ${criterionLinkedAsset.id}, 'implements', 'authored'
+    )`;
 
   mkdirSync(resolve(root, "src"), { recursive: true });
   writeFileSync(
@@ -716,6 +761,7 @@ try {
       "src/after-rename.ts",
       "src/linked-by-foreign-criterion.ts",
       "src/linked-by-foreign-story.ts",
+      "src/story.ts",
     ]
   );
   const [foreignPathTwinAfter] = await sql<{ id: string }[]>`

--- a/scripts/integration-evidence.ts
+++ b/scripts/integration-evidence.ts
@@ -132,9 +132,9 @@ try {
     )`;
   await sql`
     insert into criterion_code_assets (
-      criterion_id, asset_id, relation
+      criterion_id, asset_id, relation, provenance
     ) values (
-      ${repositoryCriterion.id}, ${searchAsset.id}, 'implements'
+      ${repositoryCriterion.id}, ${searchAsset.id}, 'implements', 'authored'
     )`;
   const [inactiveAsset] = await sql<{ id: string }[]>`
     insert into code_assets (
@@ -145,9 +145,9 @@ try {
     returning id`;
   await sql`
     insert into criterion_code_assets (
-      criterion_id, asset_id, relation
+      criterion_id, asset_id, relation, provenance
     ) values (
-      ${inactiveCriterion.id}, ${inactiveAsset.id}, 'implements'
+      ${inactiveCriterion.id}, ${inactiveAsset.id}, 'implements', 'authored'
     )`;
   const regionalCriteria = await sql<{ id: string; stable_id: string }[]>`
     insert into acceptance_criteria (

--- a/scripts/integration-lifecycle.ts
+++ b/scripts/integration-lifecycle.ts
@@ -95,11 +95,13 @@ capability:
               then: ${storyDefinition.scenario.then}
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: ${repositoryKey}
                 path: src/lifecycle.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: ${repositoryKey}

--- a/scripts/test-contract-command.ts
+++ b/scripts/test-contract-command.ts
@@ -53,6 +53,7 @@ capability:
 ${Array.from(
   { length: 7 },
   (_, index) => `        - relation: implements
+          provenance: authored
           target:
             kind: code
             repository: contract-command-test
@@ -69,16 +70,19 @@ ${Array.from(
               then: the accepted stories and criteria must be readable in a browser
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: contract-command-test
                 path: src/behavior.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: contract-command-test
                 path: src/behavior.test.ts
             - relation: documents
+              provenance: authored
               target:
                 kind: help
                 source: docs
@@ -140,6 +144,7 @@ ${reviewCriteria
 ${entry.paths
   .map(
     (path) => `            - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: contract-command-test
@@ -198,6 +203,7 @@ try {
   assert.match(reviewPage, /id="story-content"/);
   assert.match(reviewPage, /data-story-link/);
   assert.match(reviewPage, /Acceptance criteria/);
+  assert.match(reviewPage, /implements · authored/);
   assert.match(reviewPage, /window\.print/);
   assert.doesNotMatch(reviewPage, /href="javascript:/);
 

--- a/scripts/test-contract-read.ts
+++ b/scripts/test-contract-read.ts
@@ -17,6 +17,7 @@ function codeLink(
 ): ContractEvidenceLink {
   return {
     relation,
+    provenance: "authored",
     scope,
     target: {
       kind: relation === "tests" ? "test" : "code",
@@ -35,6 +36,7 @@ function helpLink(
 ): ContractEvidenceLink {
   return {
     relation: "documents",
+    provenance: "materialized",
     scope,
     target: {
       kind: "help",
@@ -189,14 +191,16 @@ assert.ok(
   graph.edges.some(
     (edge) =>
       edge.source === "ac:tieline:STORY-001-AC1" &&
-      edge.relation === "tests"
+      edge.relation === "tests" &&
+      edge.provenance === "authored"
   )
 );
 assert.ok(
   graph.edges.some(
     (edge) =>
       edge.source === "ac:tieline:STORY-001-AC1" &&
-      edge.relation === "documents"
+      edge.relation === "documents" &&
+      edge.provenance === "materialized"
   )
 );
 assert.ok(
@@ -204,7 +208,8 @@ assert.ok(
     (edge) =>
       edge.source === "ac:tieline:STORY-001-AC1" &&
       edge.target === "ac:tieline:STORY-001-AC2" &&
-      edge.relation === "superseded_by"
+      edge.relation === "superseded_by" &&
+      edge.provenance === undefined
   )
 );
 

--- a/scripts/test-contract.ts
+++ b/scripts/test-contract.ts
@@ -14,6 +14,7 @@ import {
   validateAcceptedContractDocuments,
 } from "../src/contract/index.js";
 import {
+  contractLinkSchema,
   planningStorySchema,
   renderUserStory,
   type AcceptedContractDocument,
@@ -68,6 +69,7 @@ function document(overrides: Partial<AcceptedContractDocument> = {}): AcceptedCo
               links: [
                 {
                   relation: "tests",
+                  provenance: "authored",
                   target: {
                     kind: "test",
                     repository: "tieline",
@@ -108,6 +110,27 @@ await test("accepts an incomplete backlog Story through the planning schema", ()
   assert.deepEqual(parsed.acceptance_criteria, []);
 });
 
+await test("requires explicit provenance and accepts every stable claim origin", () => {
+  const target = {
+    kind: "code" as const,
+    repository: "tieline",
+    path: "src/contract/schema.ts",
+  };
+  assert.equal(
+    contractLinkSchema.safeParse({ relation: "implements", target }).success,
+    false,
+    "a missing origin must never be guessed"
+  );
+  for (const provenance of ["authored", "inferred", "materialized"] as const) {
+    assert.equal(
+      contractLinkSchema.safeParse({ relation: "implements", provenance, target })
+        .success,
+      true,
+      `${provenance} should be a valid stable provenance`
+    );
+  }
+});
+
 console.log("accepted YAML loading and validation");
 
 await test("loads strict YAML and preserves locator arrays and scalar values", () => {
@@ -135,6 +158,7 @@ capability:
           criterion: Tieline must accept framework-agnostic test locators.
           links:
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -179,6 +203,7 @@ await test("rejects duplicate IDs, broken supersession, and escaping paths", () 
   first.capability.stories[0]!.acceptance_criteria[0]!.links = [
     {
       relation: "implements",
+      provenance: "authored",
       target: { kind: "code", repository: "tieline", path: "../outside.ts" },
     },
   ];
@@ -233,6 +258,27 @@ await test("warns without failing when AC text normalizes to an existing criteri
   assert.match(result.warnings[0]!, /equivalent criterion text/i);
 });
 
+await test("rejects duplicate link identity even when provenance conflicts", () => {
+  const invalid = document();
+  const criterion = invalid.capability.stories[0]!.acceptance_criteria[0]!;
+  criterion.links = [
+    criterion.links[0]!,
+    { ...criterion.links[0]!, provenance: "inferred" },
+  ];
+  assert.throws(
+    () =>
+      validateAcceptedContractDocuments([
+        { path: "duplicate-links.yaml", document: invalid },
+      ]),
+    (error: unknown) => {
+      assert.ok(error instanceof ContractValidationError);
+      assert.match(error.message, /same 'tests' link target/i);
+      assert.match(error.message, /conflicting provenance 'authored' and 'inferred'/i);
+      return true;
+    }
+  );
+});
+
 await test("prunes ignored directories before resolving their contents", () => {
   const root = mkdtempSync(resolve(tmpdir(), "tieline-coverage-"));
   const outside = mkdtempSync(resolve(tmpdir(), "tieline-outside-"));
@@ -265,6 +311,7 @@ capability:
           criterion: Tieline must prune ignored paths before resolving symlinks.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
@@ -361,6 +408,7 @@ function documentWithSelector(selector: string): AcceptedContractDocument {
   base.capability.stories[0]!.acceptance_criteria[0]!.links = [
     {
       relation: "implements",
+      provenance: "authored",
       target: {
         kind: "code",
         repository: "tieline",

--- a/scripts/test-grade.ts
+++ b/scripts/test-grade.ts
@@ -73,6 +73,7 @@ capability:
       lifecycle: production
       links:
         - relation: implements
+          provenance: authored
           target:
             kind: code
             repository: ${REPOSITORY}
@@ -82,21 +83,25 @@ capability:
           criterion: Tieline must emit every changed link without relevance filtering.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: ${REPOSITORY}
                 path: src/feature.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: ${REPOSITORY}
                 path: src/renamed.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: ${REPOSITORY}
                 path: src/shared.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: another-repository
@@ -105,11 +110,13 @@ capability:
           criterion: Tieline must retain changed evidence that has no readable symbols.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: ${REPOSITORY}
                 path: src/deleted.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: ${REPOSITORY}
@@ -143,6 +150,7 @@ capability:
   assert.equal(feature.entries[0]?.acceptance_criterion_stable_id, "FEATURE-001-AC1");
   assert.equal(feature.entries[0]?.acceptance_criterion, "Tieline must emit every changed link without relevance filtering.");
   assert.equal(feature.entries[0]?.relation, "implements");
+  assert.equal(feature.entries[0]?.provenance, "authored");
   assert.equal(feature.entries[0]?.link_scope, "direct");
   assert.equal(feature.entries[0]?.path, "src/feature.ts");
   assert.equal(feature.entries[0]?.previous_path, null);

--- a/scripts/test-impact.ts
+++ b/scripts/test-impact.ts
@@ -79,11 +79,13 @@ capability:
           criterion: Tieline must report a changed implementation path.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: impact-fixture
                 path: src/feature.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: impact-fixture
@@ -158,6 +160,7 @@ capability:
   });
   assert.equal(contractChanged.length, 1);
   assert.equal(contractChanged[0].reason, "contract_definition_changed");
+  assert.equal(contractChanged[0].provenance, null);
   assert.equal(contractChanged[0].path, ".tieline/contract");
   assert.equal(
     contractChanged[0].acceptance_criterion,
@@ -192,6 +195,7 @@ capability:
   assert.equal(brokenOutsideDiff.length, 1);
   assert.equal(brokenOutsideDiff[0].path, "scripts/feature.test.ts");
   assert.equal(brokenOutsideDiff[0].reason, "link_target_broken");
+  assert.equal(brokenOutsideDiff[0].provenance, "authored");
   assert.equal(brokenOutsideDiff[0].freshness, "broken");
   assert.equal(brokenOutsideDiff[0].broken_cause, "missing");
   assert.equal(
@@ -589,6 +593,7 @@ capability:
           criterion: Tieline must report the manifest as stale.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: impact-fixture

--- a/scripts/test-link-plausibility.ts
+++ b/scripts/test-link-plausibility.ts
@@ -178,6 +178,7 @@ function pathOf(topic: Topic): string {
 function codeLink(path: string, relation = "implements"): ManifestLink {
   return {
     relation: relation as ManifestLink["relation"],
+    provenance: "authored",
     target: { kind: "code", repository: REPOSITORY, path },
     reviewed_content_hash: null,
   };
@@ -286,6 +287,7 @@ try {
           codeLink("assets/blob.bin"),
           {
             relation: "documents",
+            provenance: "authored",
             target: {
               kind: "help",
               source: "helpcenter",
@@ -295,6 +297,7 @@ try {
           },
           {
             relation: "implements",
+            provenance: "authored",
             target: {
               kind: "code",
               repository: "another-repository",
@@ -468,6 +471,7 @@ try {
   assert.equal(candidate.path, "src/timezone.ts");
   assert.equal(candidate.repository, REPOSITORY);
   assert.equal(candidate.relation, "implements");
+  assert.equal(candidate.provenance, "authored");
   assert.equal(candidate.rank, 1);
   assert.ok(candidate.score < DEFAULT_ABSOLUTE_SCORE_FLOOR);
   assert.ok(candidate.percentile > 0 && candidate.percentile < 0.2);
@@ -559,6 +563,7 @@ try {
   assert.equal(skipReasons.get("src/elsewhere.ts"), "other_repository");
   assert.equal(report.skipped.length, 6);
   for (const skipped of report.skipped) {
+    assert.equal(skipped.provenance, "authored");
     assert.ok(
       !report.review_candidates.some((entry) => entry.path === skipped.path),
       `${skipped.path} was skipped and must produce no finding`

--- a/scripts/test-manifest.ts
+++ b/scripts/test-manifest.ts
@@ -61,6 +61,7 @@ capability:
         revision: 2
       links:
         - relation: implements
+          provenance: authored
           target:
             kind: code
             repository: tieline
@@ -74,12 +75,14 @@ capability:
               then: both manifest files are byte-identical
           links:
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
                 path: scripts/contract.test.ts
                 framework_hint: custom
             - relation: documents
+              provenance: authored
               target:
                 kind: help
                 source: intercom
@@ -145,6 +148,7 @@ await test("compiles byte-identical JSON with source, origin, relation, and arti
       revision: 2,
     });
     assert.match(story.links[0]!.reviewed_content_hash!, /^[a-f0-9]{64}$/);
+    assert.equal(story.links[0]!.provenance, "authored");
     const testLink = story.acceptance_criteria[0]!.links.find(
       (link) => link.target.kind === "test"
     );
@@ -156,6 +160,44 @@ await test("compiles byte-identical JSON with source, origin, relation, and arti
       helpLink!.reviewed_content_hash,
       null,
       "unresolved help locators stay in the manifest without inventing content"
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test("changes contract semantics when only link provenance changes", () => {
+  const root = fixture();
+  try {
+    const before = compileContractManifest({
+      repositoryRoot: root,
+      repositoryKey: "tieline",
+      commit: "abc123",
+    });
+    const specPath = resolve(root, ".tieline/spec/contract.yaml");
+    const authored = readFileSync(specPath, "utf8");
+    writeFileSync(
+      specPath,
+      authored.replace(
+        "            - relation: tests\n              provenance: authored",
+        "            - relation: tests\n              provenance: inferred"
+      )
+    );
+    const after = compileContractManifest({
+      repositoryRoot: root,
+      repositoryKey: "tieline",
+      commit: "abc123",
+    });
+    const beforeStory = before.capabilities[0]!.stories[0]!;
+    const afterStory = after.capabilities[0]!.stories[0]!;
+    const beforeCriterion = beforeStory.acceptance_criteria[0]!;
+    const afterCriterion = afterStory.acceptance_criteria[0]!;
+
+    assert.equal(beforeStory.contract_hash, afterStory.contract_hash);
+    assert.notEqual(beforeCriterion.contract_hash, afterCriterion.contract_hash);
+    assert.equal(
+      afterCriterion.links.find((link) => link.relation === "tests")!.provenance,
+      "inferred"
     );
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -253,6 +295,29 @@ await test("rejects malformed nested content in a reviewed manifest", () => {
       (error: unknown) => {
         assert.ok(error instanceof ContractManifestError);
         assert.match(error.message, /reviewed_content_hash/i);
+        assert.match(error.message, /CONTRACT\.json/);
+        return true;
+      }
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+await test("rejects a reviewed manifest link with no provenance", () => {
+  const root = fixture();
+  try {
+    const compiled = compile(root);
+    const link = compiled.manifest.capabilities[0]!.stories[0]!
+      .acceptance_criteria[0]!.links[0]! as unknown as Record<string, unknown>;
+    delete link.provenance;
+    const directory = manifestDirectory(root);
+    writeContractManifest(directory, compiled);
+    assert.throws(
+      () => readContractManifest(directory),
+      (error: unknown) => {
+        assert.ok(error instanceof ContractManifestError);
+        assert.match(error.message, /provenance/i);
         assert.match(error.message, /CONTRACT\.json/);
         return true;
       }

--- a/scripts/test-path-criteria.ts
+++ b/scripts/test-path-criteria.ts
@@ -86,11 +86,13 @@ capability:
       lifecycle: production
       links:
         - relation: implements
+          provenance: authored
           target:
             kind: code
             repository: path-criteria-fixture
             path: src/story-only.ts
         - relation: implements
+          provenance: authored
           target:
             kind: code
             repository: path-criteria-fixture
@@ -100,21 +102,25 @@ capability:
           criterion: Tieline must return the acceptance criterion that links a path.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: path-criteria-fixture
                 path: src/direct.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: path-criteria-fixture
                 path: src/shared.ts
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: other-repository
                 path: src/elsewhere.ts
             - relation: documents
+              provenance: authored
               target:
                 kind: help
                 source: docs
@@ -123,6 +129,7 @@ capability:
           criterion: Tieline must return every acceptance criterion that links a path.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: path-criteria-fixture
@@ -192,6 +199,7 @@ try {
   assert.equal(first?.capability_stable_id, "PATH-CRITERIA");
   assert.equal(first?.story_stable_id, "PATH-CRITERIA-001");
   assert.equal(first?.story_title, "Look up path criteria");
+  assert.equal(first?.provenance, "authored");
 
   const report = lookupPathCriteria({
     manifest,

--- a/scripts/test-reconciliation.ts
+++ b/scripts/test-reconciliation.ts
@@ -77,6 +77,7 @@ capability:
       lifecycle: production
       links:
         - relation: implements
+          provenance: authored
           target:
             kind: code
             repository: reconciliation-fixture
@@ -86,11 +87,13 @@ capability:
           criterion: Tieline must list the acceptance criteria claiming a changed path.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: reconciliation-fixture
                 path: src/claimed-direct.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: reconciliation-fixture
@@ -99,6 +102,7 @@ capability:
           criterion: Tieline must report a changed path whose evidence was removed.
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: reconciliation-fixture
@@ -167,6 +171,7 @@ capability:
     "Tieline must list the acceptance criteria claiming a changed path."
   );
   assert.equal(direct.claimed_by[0].relation, "implements");
+  assert.equal(direct.claimed_by[0].provenance, "authored");
   assert.equal(
     direct.claimed_by[0].story_title,
     "See what the contract already claims"

--- a/skills/tieline-author/references/contract.md
+++ b/skills/tieline-author/references/contract.md
@@ -44,11 +44,13 @@ capability:
               then: the parent AC and Story are included
           links:
             - relation: implements
+              provenance: authored
               target:
                 kind: code
                 repository: tieline
                 path: src/tools/find_related.ts
             - relation: tests
+              provenance: authored
               target:
                 kind: test
                 repository: tieline
@@ -59,3 +61,5 @@ capability:
 Accepted Stories require actor, goal, benefit, and at least one complete AC.
 Aliases preserve alternative phrasing. Supersession preserves identity when two
 contract records are intentionally consolidated.
+Every link requires `provenance`: `authored` for a deliberate claim, `inferred`
+for a derived claim, or `materialized` for a copied projection.

--- a/src/adapters/postgres/contract-read-repository.ts
+++ b/src/adapters/postgres/contract-read-repository.ts
@@ -18,7 +18,10 @@ import {
   type HandoffConflictRecord,
   type QueryContractStoriesResult,
 } from "../../domain/contract-read-store.js";
-import type { Applicability } from "../../contract/schema.js";
+import type {
+  Applicability,
+  LinkProvenance,
+} from "../../contract/schema.js";
 import type {
   ContractAuthority,
   StoryLifecycle,
@@ -76,6 +79,7 @@ interface ScenarioRow {
 interface CodeLinkRow {
   owner_id: string;
   relation: "implements" | "enforces" | "tests";
+  provenance: LinkProvenance;
   reviewed_content_hash: string | null;
   current_content_hash: string | null;
   kind: "code" | "test";
@@ -87,6 +91,7 @@ interface CodeLinkRow {
 
 interface HelpLinkRow {
   owner_id: string;
+  provenance: LinkProvenance;
   source: string;
   external_id: string;
   title: string | null;
@@ -121,6 +126,7 @@ function codeEvidenceLink(
 ): ContractEvidenceLink {
   return {
     relation: row.relation,
+    provenance: row.provenance,
     scope,
     target: {
       kind: row.kind,
@@ -140,6 +146,7 @@ function helpEvidenceLink(
 ): ContractEvidenceLink {
   return {
     relation: "documents",
+    provenance: row.provenance,
     scope,
     target: {
       kind: "help",
@@ -325,6 +332,7 @@ async function fetchStoryCodeLinks(
     select
       sca.story_id as owner_id,
       sca.relation,
+      sca.provenance,
       sca.reviewed_content_hash,
       ca.content_hash as current_content_hash,
       ca.kind,
@@ -348,6 +356,7 @@ async function fetchCriterionCodeLinks(
     select
       cca.criterion_id as owner_id,
       cca.relation,
+      cca.provenance,
       cca.reviewed_content_hash,
       ca.content_hash as current_content_hash,
       ca.kind,
@@ -370,6 +379,7 @@ async function fetchStoryHelpLinks(
   return sql<HelpLinkRow[]>`
     select
       sha.story_id as owner_id,
+      sha.provenance,
       ha.source,
       ha.external_id,
       ha.title,
@@ -388,6 +398,7 @@ async function fetchCriterionHelpLinks(
   return sql<HelpLinkRow[]>`
     select
       cha.criterion_id as owner_id,
+      cha.provenance,
       ha.source,
       ha.external_id,
       ha.title,

--- a/src/adapters/postgres/contract-sync-repository.ts
+++ b/src/adapters/postgres/contract-sync-repository.ts
@@ -314,19 +314,24 @@ async function replaceStoryLinks(
     if (link.target.kind === "help") {
       const articleId = await ensureHelpArticle(tx, link);
       await tx`
-        insert into story_help_articles (story_id, article_id, relation)
-        values (${storyId}, ${articleId}, 'documents')
+        insert into story_help_articles (
+          story_id, article_id, relation, provenance
+        ) values (
+          ${storyId}, ${articleId}, 'documents', ${link.provenance}
+        )
         on conflict do nothing`;
     } else {
       const assetId = await ensureCodeAsset(tx, ownerRepositoryKey, link);
       await tx`
         insert into story_code_assets (
-          story_id, asset_id, relation, reviewed_content_hash
+          story_id, asset_id, relation, provenance, reviewed_content_hash
         ) values (
-          ${storyId}, ${assetId}, ${link.relation}, ${link.reviewed_content_hash}
+          ${storyId}, ${assetId}, ${link.relation}, ${link.provenance},
+          ${link.reviewed_content_hash}
         )
         on conflict (story_id, asset_id, relation) do update
-          set reviewed_content_hash = excluded.reviewed_content_hash`;
+          set provenance = excluded.provenance,
+              reviewed_content_hash = excluded.reviewed_content_hash`;
     }
   }
 }
@@ -343,19 +348,24 @@ async function replaceCriterionLinks(
     if (link.target.kind === "help") {
       const articleId = await ensureHelpArticle(tx, link);
       await tx`
-        insert into criterion_help_articles (criterion_id, article_id, relation)
-        values (${criterionId}, ${articleId}, 'documents')
+        insert into criterion_help_articles (
+          criterion_id, article_id, relation, provenance
+        ) values (
+          ${criterionId}, ${articleId}, 'documents', ${link.provenance}
+        )
         on conflict do nothing`;
     } else {
       const assetId = await ensureCodeAsset(tx, ownerRepositoryKey, link);
       await tx`
         insert into criterion_code_assets (
-          criterion_id, asset_id, relation, reviewed_content_hash
+          criterion_id, asset_id, relation, provenance, reviewed_content_hash
         ) values (
-          ${criterionId}, ${assetId}, ${link.relation}, ${link.reviewed_content_hash}
+          ${criterionId}, ${assetId}, ${link.relation}, ${link.provenance},
+          ${link.reviewed_content_hash}
         )
         on conflict (criterion_id, asset_id, relation) do update
-          set reviewed_content_hash = excluded.reviewed_content_hash`;
+          set provenance = excluded.provenance,
+              reviewed_content_hash = excluded.reviewed_content_hash`;
     }
   }
 }

--- a/src/commands/contract.ts
+++ b/src/commands/contract.ts
@@ -330,14 +330,14 @@ function renderLinkReview(
   }
   for (const candidate of report.review_candidates) {
     io.write(
-      `\n  ${candidate.acceptance_criterion_stable_id}  ${candidate.relation} ${candidate.path}\n`
+      `\n  ${candidate.acceptance_criterion_stable_id}  ${candidate.relation} · ${candidate.provenance} ${candidate.path}\n`
     );
     io.write(wrap(candidate.rationale, 88, "    "));
   }
   if (report.review_candidates.length) io.write("\n");
   for (const skip of report.skipped) {
     io.write(
-      `  skipped ${skip.acceptance_criterion_stable_id} ${skip.path ?? "(no path)"} (${skip.reason})\n`
+      `  skipped ${skip.acceptance_criterion_stable_id} ${skip.path ?? "(no path)"} (${skip.provenance}, ${skip.reason})\n`
     );
   }
   for (const note of report.notes) io.write(wrap(`note  ${note}`, 88, "  "));
@@ -382,7 +382,7 @@ function renderReconciliation(
       io.write(`\n  ${change.path} (${changeLabel(change)})\n`);
       for (const claim of change.claimed_by) {
         io.write(
-          `    ${claim.acceptance_criterion_stable_id}  ${claim.relation} ${claim.linked_path} (${claim.link_scope})\n`
+          `    ${claim.acceptance_criterion_stable_id}  ${claim.relation} ${claim.linked_path} (${claim.provenance}, ${claim.link_scope})\n`
         );
         io.write(wrap(claim.acceptance_criterion, 88, "      "));
       }

--- a/src/contract/grade.ts
+++ b/src/contract/grade.ts
@@ -14,6 +14,7 @@ import type { RepositoryPathChange } from "./impact.js";
 import type { ContractManifest } from "./manifest.js";
 import {
   analyzeContractReconciliation,
+  type ClaimingCriterion,
   type ReconciliationChangeStatus,
   type ReconciliationLinkScope,
   type ReconciliationRelation,
@@ -36,6 +37,7 @@ export interface GradeScopeEntry {
   acceptance_criterion_stable_id: string;
   acceptance_criterion: string;
   relation: ReconciliationRelation;
+  provenance: ClaimingCriterion["provenance"];
   link_scope: ReconciliationLinkScope;
   /** Repository path named by this contract link. */
   linked_path: string;
@@ -185,6 +187,7 @@ export function buildGradeScope(input: BuildGradeScopeInput): GradeScope {
           claim.acceptance_criterion_stable_id,
         acceptance_criterion: claim.acceptance_criterion,
         relation: claim.relation,
+        provenance: claim.provenance,
         link_scope: claim.link_scope,
         linked_path: claim.linked_path,
         path: change.path,
@@ -218,7 +221,7 @@ export function renderGradeScopeText(scope: GradeScope): string {
         ? ""
         : `, contract target ${entry.linked_path}`;
     lines.push(
-      `\n  ${entry.id}  ${entry.acceptance_criterion_stable_id} ${entry.relation} ${entry.path} (${entry.link_scope}, ${entry.reason}${target})\n`
+      `\n  ${entry.id}  ${entry.acceptance_criterion_stable_id} ${entry.relation} ${entry.path} (${entry.provenance}, ${entry.link_scope}, ${entry.reason}${target})\n`
     );
     lines.push(`    ${entry.acceptance_criterion}\n`);
     lines.push(

--- a/src/contract/impact.ts
+++ b/src/contract/impact.ts
@@ -8,6 +8,7 @@ import {
   createArtifactHashResolver,
   type ArtifactHashResolver,
 } from "./manifest.js";
+import type { LinkProvenance } from "./schema.js";
 
 export type RepositoryPathChange =
   | { status: "modified" | "added" | "deleted"; path: string }
@@ -31,6 +32,8 @@ export interface AcceptanceCriterionImpact {
   /** The acceptance criterion sentence exactly as it was accepted. */
   acceptance_criterion: string;
   relation: string;
+  /** Null only for a synthetic contract-definition impact with no link. */
+  provenance: LinkProvenance | null;
   link_scope: "direct" | "story_fallback" | "contract";
   path: string;
   reason:
@@ -136,6 +139,7 @@ function linkedImpact(input: {
     acceptance_criterion_stable_id: input.criterion.stable_id,
     acceptance_criterion: input.criterion.criterion,
     relation: input.link.relation,
+    provenance: input.link.provenance,
     link_scope: input.scope,
     path: input.link.target.path,
     reason: reason(change),
@@ -174,6 +178,7 @@ function brokenLinkImpact(input: {
     acceptance_criterion_stable_id: input.criterion.stable_id,
     acceptance_criterion: input.criterion.criterion,
     relation: input.link.relation,
+    provenance: input.link.provenance,
     link_scope: input.scope,
     path: input.link.target.path,
     reason: "link_target_broken",
@@ -219,6 +224,7 @@ export function analyzeContractImpact(input: {
             acceptance_criterion_stable_id: criterion.stable_id,
             acceptance_criterion: criterion.criterion,
             relation: "defines",
+            provenance: null,
             link_scope: "contract",
             path: input.specDirectory ?? ".tieline/spec",
             reason: "contract_definition_changed",

--- a/src/contract/link-plausibility.ts
+++ b/src/contract/link-plausibility.ts
@@ -168,6 +168,7 @@ export interface LinkPlausibilitySkip {
   story_stable_id: string;
   acceptance_criterion_stable_id: string;
   relation: string;
+  provenance: ManifestLink["provenance"];
   path: string | null;
   reason: LinkPlausibilitySkipReason;
 }
@@ -177,6 +178,7 @@ export interface LinkPlausibilityReviewCandidate {
   story_stable_id: string;
   acceptance_criterion_stable_id: string;
   relation: string;
+  provenance: ManifestLink["provenance"];
   path: string;
   score: number;
   /** 1 is the weakest link in the repository's own distribution. */
@@ -564,6 +566,7 @@ interface ScoredLink {
   story_stable_id: string;
   acceptance_criterion_stable_id: string;
   relation: string;
+  provenance: ManifestLink["provenance"];
   path: string;
   measurement: ScorableLexicalPlausibility;
 }
@@ -633,6 +636,7 @@ export function analyzeLinkPlausibility(
     story: ManifestStory;
     criterion: ManifestAcceptanceCriterion;
     relation: string;
+    provenance: ManifestLink["provenance"];
     path: string;
   }> = [];
 
@@ -647,6 +651,7 @@ export function analyzeLinkPlausibility(
               story_stable_id: story.stable_id,
               acceptance_criterion_stable_id: criterion.stable_id,
               relation: link.relation,
+              provenance: link.provenance,
               path: link.target.kind === "help" ? null : link.target.path,
               reason: targetSkip,
             });
@@ -670,6 +675,7 @@ export function analyzeLinkPlausibility(
               story_stable_id: story.stable_id,
               acceptance_criterion_stable_id: criterion.stable_id,
               relation: link.relation,
+              provenance: link.provenance,
               path,
               reason: readSkip,
             });
@@ -679,6 +685,7 @@ export function analyzeLinkPlausibility(
             story,
             criterion,
             relation: link.relation,
+            provenance: link.provenance,
             path,
           });
         }
@@ -706,6 +713,7 @@ export function analyzeLinkPlausibility(
         story_stable_id: entry.story.stable_id,
         acceptance_criterion_stable_id: entry.criterion.stable_id,
         relation: entry.relation,
+        provenance: entry.provenance,
         path: entry.path,
         reason: "no_discriminating_terms",
       });
@@ -715,6 +723,7 @@ export function analyzeLinkPlausibility(
       story_stable_id: entry.story.stable_id,
       acceptance_criterion_stable_id: entry.criterion.stable_id,
       relation: entry.relation,
+      provenance: entry.provenance,
       path: entry.path,
       measurement,
     });
@@ -799,6 +808,7 @@ export function analyzeLinkPlausibility(
         story_stable_id: entry.story_stable_id,
         acceptance_criterion_stable_id: entry.acceptance_criterion_stable_id,
         relation: entry.relation,
+        provenance: entry.provenance,
         path: entry.path,
         score: entry.measurement.score,
         rank,
@@ -868,6 +878,7 @@ export function toLinkReviewSuggestion(input: {
       acceptance_criterion_stable_id:
         input.candidate.acceptance_criterion_stable_id,
       relation: input.candidate.relation,
+      provenance: input.candidate.provenance,
       path: input.candidate.path,
       rank: input.candidate.rank,
       percentile: input.candidate.percentile,

--- a/src/contract/manifest.ts
+++ b/src/contract/manifest.ts
@@ -14,6 +14,7 @@ import {
   applicabilitySchema,
   codeTargetSchema,
   helpTargetSchema,
+  linkProvenanceSchema,
   planningOriginSchema,
   scenarioSchema,
   testTargetSchema,
@@ -37,6 +38,7 @@ export interface ManifestInput {
 
 export interface ManifestLink {
   relation: ContractLink["relation"];
+  provenance: ContractLink["provenance"];
   target: ContractLink["target"];
   reviewed_content_hash: string | null;
   /**
@@ -315,6 +317,7 @@ const manifestLinkSchema = z.union([
   z
     .object({
       relation: z.enum(["implements", "enforces"]),
+      provenance: linkProvenanceSchema,
       target: codeTargetSchema,
       reviewed_content_hash: hashSchema.nullable(),
     })
@@ -322,6 +325,7 @@ const manifestLinkSchema = z.union([
   z
     .object({
       relation: z.literal("tests"),
+      provenance: linkProvenanceSchema,
       target: testTargetSchema,
       reviewed_content_hash: hashSchema.nullable(),
     })
@@ -329,6 +333,7 @@ const manifestLinkSchema = z.union([
   z
     .object({
       relation: z.literal("documents"),
+      provenance: linkProvenanceSchema,
       target: helpTargetSchema,
       reviewed_content_hash: z.null(),
     })
@@ -707,6 +712,7 @@ function compileLinks(
   return links
     .map((link) => ({
       relation: link.relation,
+      provenance: link.provenance,
       target: link.target,
       reviewed_content_hash: reviewedContentHash(context, link),
     }))

--- a/src/contract/path-criteria.ts
+++ b/src/contract/path-criteria.ts
@@ -25,6 +25,7 @@ export interface PathCriterion {
   acceptance_criterion_stable_id: string;
   criterion: string;
   relation: ReconciliationRelation;
+  provenance: ClaimingCriterion["provenance"];
   link_scope: ReconciliationLinkScope;
 }
 
@@ -66,6 +67,7 @@ function pathCriterion(claim: ClaimingCriterion): PathCriterion {
     acceptance_criterion_stable_id: claim.acceptance_criterion_stable_id,
     criterion: claim.acceptance_criterion,
     relation: claim.relation,
+    provenance: claim.provenance,
     link_scope: claim.link_scope,
   };
 }
@@ -195,7 +197,7 @@ export function renderPathCriteriaText(report: PathCriteriaReport): string {
     lines.push(`  ${result.status}  ${result.answer}\n`);
     for (const criterion of result.criteria) {
       lines.push(
-        `    applies  ${criterion.acceptance_criterion_stable_id} ${criterion.link_scope} ${criterion.relation} (${criterion.story_stable_id} ${criterion.story_title})\n`
+        `    applies  ${criterion.acceptance_criterion_stable_id} ${criterion.link_scope} ${criterion.relation} · ${criterion.provenance} (${criterion.story_stable_id} ${criterion.story_title})\n`
       );
       lines.push(`             ${criterion.criterion}\n`);
     }

--- a/src/contract/reconciliation.ts
+++ b/src/contract/reconciliation.ts
@@ -70,6 +70,8 @@ export interface ClaimingCriterion {
   /** The acceptance criterion sentence exactly as it was accepted. */
   acceptance_criterion: string;
   relation: ReconciliationRelation;
+  /** How the contract's owner established this relationship. */
+  provenance: ManifestLink["provenance"];
   /**
    * `direct` when the link sits on the acceptance criterion itself,
    * `story_fallback` when it is inherited from the owning Story.
@@ -285,6 +287,7 @@ export function buildContractClaimIndex(
             acceptance_criterion_stable_id: criterion.stable_id,
             acceptance_criterion: criterion.criterion,
             relation: link.relation,
+            provenance: link.provenance,
             link_scope: scope,
             linked_path: path,
           };

--- a/src/contract/review-page.ts
+++ b/src/contract/review-page.ts
@@ -72,7 +72,7 @@ function renderLinks(links: ContractLink[]): string {
           const target = externalUrl
             ? `<a href="${escapeHtml(externalUrl)}" target="_blank" rel="noreferrer">${label}</a>`
             : `<span>${label}</span>`;
-          return `<li><small>${escapeHtml(link.relation)}</small>${target}</li>`;
+          return `<li><small>${escapeHtml(link.relation)} · ${escapeHtml(link.provenance)}</small>${target}</li>`;
         })
         .join("")}
     </ul>
@@ -617,7 +617,7 @@ export function renderContractReviewPage(
       text-align: center;
     }
     .references ul { display: grid; gap: .35rem; margin: .6rem 0 0 1.25rem; padding: 0; list-style: none; }
-    .references li { display: grid; grid-template-columns: 68px minmax(0, 1fr); gap: .5rem; font: .66rem/1.45 var(--mono); }
+    .references li { display: grid; grid-template-columns: 138px minmax(0, 1fr); gap: .5rem; font: .66rem/1.45 var(--mono); }
     .references small { color: var(--muted); }
     .issue-details {
       position: sticky;

--- a/src/contract/schema.ts
+++ b/src/contract/schema.ts
@@ -75,22 +75,32 @@ export const helpTargetSchema = z
   })
   .strict();
 
+export const LINK_PROVENANCES = [
+  "authored",
+  "inferred",
+  "materialized",
+] as const;
+export const linkProvenanceSchema = z.enum(LINK_PROVENANCES);
+
 export const contractLinkSchema = z.union([
   z
     .object({
       relation: z.enum(["implements", "enforces"]),
+      provenance: linkProvenanceSchema,
       target: codeTargetSchema,
     })
     .strict(),
   z
     .object({
       relation: z.literal("tests"),
+      provenance: linkProvenanceSchema,
       target: testTargetSchema,
     })
     .strict(),
   z
     .object({
       relation: z.literal("documents"),
+      provenance: linkProvenanceSchema,
       target: helpTargetSchema,
     })
     .strict(),
@@ -191,6 +201,7 @@ export const acceptedContractDocumentSchema = z
 
 export type Applicability = z.infer<typeof applicabilitySchema>;
 export type ContractScenario = z.infer<typeof scenarioSchema>;
+export type LinkProvenance = z.infer<typeof linkProvenanceSchema>;
 export type ContractLink = z.infer<typeof contractLinkSchema>;
 export type ContractTarget = ContractLink["target"];
 export type AcceptanceCriterion = z.infer<typeof acceptanceCriterionSchema>;

--- a/src/contract/validate.ts
+++ b/src/contract/validate.ts
@@ -131,6 +131,36 @@ function validateLink(
   }
 }
 
+function linkIdentity(link: ContractLink): string {
+  return JSON.stringify([link.relation, link.target]);
+}
+
+function validateLinks(
+  path: string,
+  owner: string,
+  links: ContractLink[],
+  vocabulary: SelectorVocabulary,
+  issues: string[]
+): void {
+  const seen = new Map<string, ContractLink>();
+  for (const link of links) {
+    validateLink(path, link, vocabulary, issues);
+    const identity = linkIdentity(link);
+    const existing = seen.get(identity);
+    if (!existing) {
+      seen.set(identity, link);
+      continue;
+    }
+    const detail =
+      existing.provenance === link.provenance
+        ? `with provenance '${link.provenance}' more than once`
+        : `with conflicting provenance '${existing.provenance}' and '${link.provenance}'`;
+    issues.push(
+      `${path}: '${owner}' declares the same '${link.relation}' link target ${detail}`
+    );
+  }
+}
+
 function findSupersessionCycle(
   start: string,
   records: Map<string, StableRecord>
@@ -198,7 +228,7 @@ export function validateAcceptedContractDocuments(
         path: sourcePath,
         supersedes: story.supersedes,
       });
-      for (const link of story.links) validateLink(sourcePath, link, vocabulary, issues);
+      validateLinks(sourcePath, story.key, story.links, vocabulary, issues);
       for (const criterion of story.acceptance_criteria) {
         addRecord(criterion.key, {
           kind: "criterion",
@@ -206,7 +236,13 @@ export function validateAcceptedContractDocuments(
           supersedes: criterion.supersedes,
           criterion: criterion.criterion,
         });
-        for (const link of criterion.links) validateLink(sourcePath, link, vocabulary, issues);
+        validateLinks(
+          sourcePath,
+          criterion.key,
+          criterion.links,
+          vocabulary,
+          issues
+        );
         const normalized = normalizeSemanticText(criterion.criterion);
         const existing = criteriaByText.get(normalized);
         if (existing && existing.key !== criterion.key) {

--- a/src/domain/contract-read-store.ts
+++ b/src/domain/contract-read-store.ts
@@ -1,4 +1,7 @@
-import type { Applicability } from "../contract/schema.js";
+import type {
+  Applicability,
+  LinkProvenance,
+} from "../contract/schema.js";
 import type {
   ContractAuthority,
   StoryLifecycle,
@@ -33,6 +36,7 @@ export interface ContractHelpTarget {
 
 export interface ContractEvidenceLink {
   relation: "implements" | "enforces" | "tests" | "documents";
+  provenance: LinkProvenance;
   scope: "direct" | "story_fallback";
   target: ContractCodeTarget | ContractHelpTarget;
   reviewed_content_hash: string | null;
@@ -171,6 +175,8 @@ export interface ContractGraphEdge {
     | "documents"
     | "superseded_by";
   scope: "hierarchy" | "direct" | "story_fallback" | "lifecycle";
+  /** Present only for evidence edges backed by an accepted contract link. */
+  provenance?: LinkProvenance;
 }
 
 export interface ContractGraph {
@@ -325,6 +331,7 @@ export function buildContractGraph(
       target: id,
       relation: link.relation,
       scope: link.scope,
+      provenance: link.provenance,
     });
   }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -6,6 +6,7 @@ import {
 import {
   codeTargetSchema,
   helpTargetSchema,
+  linkProvenanceSchema,
   testTargetSchema,
 } from "./contract/schema.js";
 
@@ -264,6 +265,7 @@ export const getPathCriteriaOutputShape = {
           acceptance_criterion_stable_id: z.string(),
           criterion: z.string(),
           relation: z.enum(["implements", "enforces", "tests"]),
+          provenance: linkProvenanceSchema,
           link_scope: z.enum(["direct", "story_fallback"]),
         })
       ),


### PR DESCRIPTION
## Summary

Continues the contract-integrity program after deterministic evidence grading. Contract links now state whether each claim was authored, inferred, or materialized, and exact claim reads preserve that origin from source contract through compiled manifest and PostgreSQL projection.

Provenance remains metadata, not link identity. This keeps stable IDs and existing relationship semantics unchanged while rejecting duplicate claims that disagree about their origin. Missing provenance is an actionable validation error; there is no silent default.

Session-settled decisions carried from planning: provenance is required rather than defaulted, and the vocabulary is limited to `authored | inferred | materialized` so mutable evidence and audit facts stay out of the contract model (user-directed).

## Validation

- Full contract, manifest, read-store, command, impact, plausibility, reconciliation, path-criteria, and grading suites pass.
- Full PostgreSQL/pgvector integration suite passes, including all four ownership junctions and story-fallback reads.
- Build and self-host checks pass: compile, validate, coverage, reconciliation, freshness, and broken-link checks.
- The compiled self-host manifest includes `CONTRACT-001-AC7` and is current for this commit's source content.

## Post-Deploy Monitoring & Validation

- Watch the first contract synchronization after merge for missing-provenance validation failures or PostgreSQL `NOT NULL`/check-constraint errors.
- Healthy behavior is a completed sync whose exact claim reads include provenance and whose manifest freshness check stays green.
- If synchronization fails, the maintainer should inspect the reported link and revert this PR if the corpus or baseline database cannot be corrected immediately.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
