### PR TITLE
fix(contract): eliminate revision-only manifest conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,2 @@
 # Auto detect text files and perform LF normalization
 * text=auto
-
-# The manifest index carries the compiled commit, so every branch changes it.
-# Line-merging it would produce an index neither branch compiled; refusing the
-# merge makes the recompile explicit.
-.tieline/manifest/index.json -merge

--- a/.tieline/manifest/AUTHORITY.json
+++ b/.tieline/manifest/AUTHORITY.json
@@ -89,7 +89,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "15910de6c8fc05fecec96615d20b26f36be85288adb6ec2d0c32a5dfbd3f77cf",
+                "reviewed_content_hash": "80e52aca071017a7a1c7451f4d54abe6316ec090f2e6519b20e01ef5e5bf5d87",
                 "target": {
                   "kind": "code",
                   "path": "src/adapters/postgres/contract-sync-repository.ts",
@@ -99,7 +99,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "5887a1dd6baba9655bde50a48999281c2e4a68d54e915034e2a3bc7770556f75",
+                "reviewed_content_hash": "240cd259d2bb285e16c05d2dc733404c789c879d021331eb97f54005cf130cab",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/sync.ts",
@@ -109,7 +109,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "32de0cf0779ef97953f99d631af747645ed95e21b0c26f48d0de46306f86adbd",
+                "reviewed_content_hash": "07cbd663e6602180679f28f406211d98162e7a87261d1fafc2c8c214b3d2a605",
                 "target": {
                   "kind": "code",
                   "path": "src/domain/repository-sync-store.ts",
@@ -129,7 +129,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "5e36b65da676de069e31bc8f60fd3a94e58dc63a559152c26ee1e0a904a0d65a",
+                "reviewed_content_hash": "1095a4924b5c6dfdd436d4d526dff24055003a111bc6004b8db07981591a1abb",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -246,7 +246,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "15910de6c8fc05fecec96615d20b26f36be85288adb6ec2d0c32a5dfbd3f77cf",
+                "reviewed_content_hash": "80e52aca071017a7a1c7451f4d54abe6316ec090f2e6519b20e01ef5e5bf5d87",
                 "target": {
                   "kind": "code",
                   "path": "src/adapters/postgres/contract-sync-repository.ts",
@@ -256,7 +256,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "5e36b65da676de069e31bc8f60fd3a94e58dc63a559152c26ee1e0a904a0d65a",
+                "reviewed_content_hash": "1095a4924b5c6dfdd436d4d526dff24055003a111bc6004b8db07981591a1abb",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -61,7 +61,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "a0842c812679f97ae23a84f4d062547091ac1d79f1bd12155d5098e1d14aeb77",
+                "reviewed_content_hash": "850186d50b17c7d97433e6ef7e844c6cf83122f5ba6d06f88d4e24cb3d5a3248",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -85,7 +85,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "150c2826587e7fe6d29976185913eab18e04dca4e3b41993859276b5dae87ace",
+                "reviewed_content_hash": "33e66f296cc4576b2b0e19c42dbac5859e16284fdaef572c0b9ca29d335fae3c",
                 "target": {
                   "kind": "code",
                   "path": "src/commands/contract.ts",
@@ -105,7 +105,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "7b38b6a9d157359f304b5cd8231a61824f3c524e05308a8b499eafd848119f7e",
+                "reviewed_content_hash": "ad0ffc8f8f34c1623325b8ca7fc1227d6e4116d729083a051321c062bbfbaeea",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/manifest.ts",
@@ -115,7 +115,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "f381c517d558c4dd2473c7dfefa7e019a3df28c8867f66b4ef4b9d5a6b3eb733",
+                "reviewed_content_hash": "7106e9171f6c05f20fe799add3eba902e4768bb5921f70b8d97460c7e29cd3c9",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -126,7 +126,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "a0842c812679f97ae23a84f4d062547091ac1d79f1bd12155d5098e1d14aeb77",
+                "reviewed_content_hash": "850186d50b17c7d97433e6ef7e844c6cf83122f5ba6d06f88d4e24cb3d5a3248",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -137,7 +137,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c5971b2e7f097345515c825f8471c58413c481f548657370eed3238706ea8da1",
+                "reviewed_content_hash": "848dd1b69f5b7d16e5fc3b43cf138881ef592aa1da8d366d4321766f9cd93647",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -176,7 +176,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "ca6eca419f5addb10098798e458d685c46c03455cb861d3203814afd68206985",
+                "reviewed_content_hash": "9a281f760ef57eed4ef071751e7b664d40ce75d585456b15550319486b03fe69",
                 "target": {
                   "kind": "code",
                   "path": "src/commands/check.ts",
@@ -196,7 +196,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "a84cf4914077026a8c2778cb053e450374c42a74d77e308301640dddd1c22677",
+                "reviewed_content_hash": "09d68a51eb9306300481d7caa18737323f6bfd236e75db4750a4ecc8fc5d6c63",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -228,7 +228,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "150c2826587e7fe6d29976185913eab18e04dca4e3b41993859276b5dae87ace",
+                "reviewed_content_hash": "33e66f296cc4576b2b0e19c42dbac5859e16284fdaef572c0b9ca29d335fae3c",
                 "target": {
                   "kind": "code",
                   "path": "src/commands/contract.ts",
@@ -248,7 +248,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "f381c517d558c4dd2473c7dfefa7e019a3df28c8867f66b4ef4b9d5a6b3eb733",
+                "reviewed_content_hash": "7106e9171f6c05f20fe799add3eba902e4768bb5921f70b8d97460c7e29cd3c9",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -272,7 +272,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "150c2826587e7fe6d29976185913eab18e04dca4e3b41993859276b5dae87ace",
+                "reviewed_content_hash": "33e66f296cc4576b2b0e19c42dbac5859e16284fdaef572c0b9ca29d335fae3c",
                 "target": {
                   "kind": "code",
                   "path": "src/commands/contract.ts",
@@ -282,7 +282,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "7b38b6a9d157359f304b5cd8231a61824f3c524e05308a8b499eafd848119f7e",
+                "reviewed_content_hash": "ad0ffc8f8f34c1623325b8ca7fc1227d6e4116d729083a051321c062bbfbaeea",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/manifest.ts",
@@ -292,7 +292,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "f381c517d558c4dd2473c7dfefa7e019a3df28c8867f66b4ef4b9d5a6b3eb733",
+                "reviewed_content_hash": "7106e9171f6c05f20fe799add3eba902e4768bb5921f70b8d97460c7e29cd3c9",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -303,7 +303,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c5971b2e7f097345515c825f8471c58413c481f548657370eed3238706ea8da1",
+                "reviewed_content_hash": "848dd1b69f5b7d16e5fc3b43cf138881ef592aa1da8d366d4321766f9cd93647",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -342,7 +342,7 @@
               {
                 "provenance": "authored",
                 "relation": "enforces",
-                "reviewed_content_hash": "ca6eca419f5addb10098798e458d685c46c03455cb861d3203814afd68206985",
+                "reviewed_content_hash": "9a281f760ef57eed4ef071751e7b664d40ce75d585456b15550319486b03fe69",
                 "target": {
                   "kind": "code",
                   "path": "src/commands/check.ts",
@@ -352,7 +352,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2b4a059e4509d43be4954fbaf8e57f76a650f8657bb13eaf67754faf3a3abce1",
+                "reviewed_content_hash": "7f4c267a3f6f579c0f58039402379667446dd9c80248e24a2cd3f122e2f15e79",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -362,7 +362,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "a84cf4914077026a8c2778cb053e450374c42a74d77e308301640dddd1c22677",
+                "reviewed_content_hash": "09d68a51eb9306300481d7caa18737323f6bfd236e75db4750a4ecc8fc5d6c63",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -438,7 +438,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "15910de6c8fc05fecec96615d20b26f36be85288adb6ec2d0c32a5dfbd3f77cf",
+                "reviewed_content_hash": "80e52aca071017a7a1c7451f4d54abe6316ec090f2e6519b20e01ef5e5bf5d87",
                 "target": {
                   "kind": "code",
                   "path": "src/adapters/postgres/contract-sync-repository.ts",
@@ -458,7 +458,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "7b38b6a9d157359f304b5cd8231a61824f3c524e05308a8b499eafd848119f7e",
+                "reviewed_content_hash": "ad0ffc8f8f34c1623325b8ca7fc1227d6e4116d729083a051321c062bbfbaeea",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/manifest.ts",
@@ -468,7 +468,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "5e36b65da676de069e31bc8f60fd3a94e58dc63a559152c26ee1e0a904a0d65a",
+                "reviewed_content_hash": "1095a4924b5c6dfdd436d4d526dff24055003a111bc6004b8db07981591a1abb",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -479,7 +479,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "a0842c812679f97ae23a84f4d062547091ac1d79f1bd12155d5098e1d14aeb77",
+                "reviewed_content_hash": "850186d50b17c7d97433e6ef7e844c6cf83122f5ba6d06f88d4e24cb3d5a3248",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -490,7 +490,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c5971b2e7f097345515c825f8471c58413c481f548657370eed3238706ea8da1",
+                "reviewed_content_hash": "848dd1b69f5b7d16e5fc3b43cf138881ef592aa1da8d366d4321766f9cd93647",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -526,6 +526,216 @@
             ],
             "stable_id": "CONTRACT-001-AC7",
             "supersedes": null
+          },
+          {
+            "aliases": [],
+            "applies_to": null,
+            "contract_hash": "c13e8199f8a250daf0da3ed54b24e2232b92a38c8858c5c26f5a254aa5fa4cbf",
+            "criterion": "Tieline must keep the compiled manifest independent of Git revision, identify exact manifest reads with a content-derived digest, and supply Git commit provenance explicitly only when synchronizing the reviewed manifest to the database.",
+            "links": [
+              {
+                "provenance": "authored",
+                "relation": "enforces",
+                "reviewed_content_hash": "1a1dbe176bc233b499d35a57db7513f2941c99ab9759f177830c9149be99005b",
+                "target": {
+                  "kind": "code",
+                  "path": ".gitattributes",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "enforces",
+                "reviewed_content_hash": "9a281f760ef57eed4ef071751e7b664d40ce75d585456b15550319486b03fe69",
+                "target": {
+                  "kind": "code",
+                  "path": "src/commands/check.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "80e52aca071017a7a1c7451f4d54abe6316ec090f2e6519b20e01ef5e5bf5d87",
+                "target": {
+                  "kind": "code",
+                  "path": "src/adapters/postgres/contract-sync-repository.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "7f4c267a3f6f579c0f58039402379667446dd9c80248e24a2cd3f122e2f15e79",
+                "target": {
+                  "kind": "code",
+                  "path": "src/cli.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "33e66f296cc4576b2b0e19c42dbac5859e16284fdaef572c0b9ca29d335fae3c",
+                "target": {
+                  "kind": "code",
+                  "path": "src/commands/contract.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "ad0ffc8f8f34c1623325b8ca7fc1227d6e4116d729083a051321c062bbfbaeea",
+                "target": {
+                  "kind": "code",
+                  "path": "src/contract/manifest.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "0862d9f55e918ac7b472158440088d3502df62b36aae9c3b501baf8a2c45c7c0",
+                "target": {
+                  "kind": "code",
+                  "path": "src/contract/path-criteria.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "240cd259d2bb285e16c05d2dc733404c789c879d021331eb97f54005cf130cab",
+                "target": {
+                  "kind": "code",
+                  "path": "src/contract/sync.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "07cbd663e6602180679f28f406211d98162e7a87261d1fafc2c8c214b3d2a605",
+                "target": {
+                  "kind": "code",
+                  "path": "src/domain/repository-sync-store.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "43316d7cf3e3fe7dc5f72be0a19b5ac4800d3a21134f40e833a752481157fe32",
+                "target": {
+                  "kind": "code",
+                  "path": "src/schemas.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "1b762f556bad084ab381140f935c7ea06ead122d4881fca21c3d516c491f9882",
+                "target": {
+                  "kind": "code",
+                  "path": "src/tieline/status.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "bccfd1f4aa6a92562d809bf3a1f2952f41a79c45dc5bcfbf6a950756ead54ece",
+                "target": {
+                  "kind": "code",
+                  "path": "src/tools/path-criteria.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "tests",
+                "reviewed_content_hash": "1095a4924b5c6dfdd436d4d526dff24055003a111bc6004b8db07981591a1abb",
+                "target": {
+                  "framework_hint": "custom-script",
+                  "kind": "test",
+                  "path": "scripts/integration-contract-sync.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "tests",
+                "reviewed_content_hash": "7106e9171f6c05f20fe799add3eba902e4768bb5921f70b8d97460c7e29cd3c9",
+                "target": {
+                  "framework_hint": "custom-script",
+                  "kind": "test",
+                  "path": "scripts/test-contract-command.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "tests",
+                "reviewed_content_hash": "848dd1b69f5b7d16e5fc3b43cf138881ef592aa1da8d366d4321766f9cd93647",
+                "target": {
+                  "framework_hint": "custom-script",
+                  "kind": "test",
+                  "path": "scripts/test-manifest.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "tests",
+                "reviewed_content_hash": "78b80c0d271a77fb5eaca2156a2e26eaf8cd0141f234e58cf3fe37d7467deff8",
+                "target": {
+                  "framework_hint": "custom-script",
+                  "kind": "test",
+                  "path": "scripts/test-path-criteria.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "tests",
+                "reviewed_content_hash": "bc1161a68f6d969f1228e0bdb4770a36566ed83cebffee7f7bcf56a81f60a4c6",
+                "target": {
+                  "framework_hint": "custom-script",
+                  "kind": "test",
+                  "path": "scripts/test-tieline.ts",
+                  "repository": "tieline"
+                }
+              }
+            ],
+            "position": 7,
+            "rationale": "A revision in the tracked repository-level index made every branch conflict in one shared generated file and became stale as soon as that generated file was committed. Content identity belongs to the reviewed manifest, while Git revision belongs to the runtime projection checkpoint and audit boundary.",
+            "scenarios": [
+              {
+                "given": "accepted specifications and linked artifacts whose content is unchanged across two Git revisions",
+                "position": 0,
+                "stable_id": "CONTRACT-001-AC8-S1",
+                "then": "the repository-level manifest index must remain byte-identical and must not record either Git revision",
+                "when": "the contract is compiled at each revision"
+              },
+              {
+                "given": "the content of the reviewed manifest changes",
+                "position": 1,
+                "stable_id": "CONTRACT-001-AC8-S2",
+                "then": "Tieline must return a different manifest digest identifying the complete reviewed manifest that answered",
+                "when": "exact path criteria are requested"
+              },
+              {
+                "given": "a reviewed manifest and an explicit runtime Git commit",
+                "position": 2,
+                "stable_id": "CONTRACT-001-AC8-S3",
+                "then": "Tieline must use that runtime commit for projection rows, checkpoint guards, sync results, and audit events without adding it to the reviewed manifest",
+                "when": "the repository contract is synchronized"
+              }
+            ],
+            "stable_id": "CONTRACT-001-AC8",
+            "supersedes": null
           }
         ],
         "actor": "maintainer",
@@ -555,7 +765,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2b4a059e4509d43be4954fbaf8e57f76a650f8657bb13eaf67754faf3a3abce1",
+                "reviewed_content_hash": "7f4c267a3f6f579c0f58039402379667446dd9c80248e24a2cd3f122e2f15e79",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -565,7 +775,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "150c2826587e7fe6d29976185913eab18e04dca4e3b41993859276b5dae87ace",
+                "reviewed_content_hash": "33e66f296cc4576b2b0e19c42dbac5859e16284fdaef572c0b9ca29d335fae3c",
                 "target": {
                   "kind": "code",
                   "path": "src/commands/contract.ts",
@@ -575,7 +785,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "ea7ba4f3505baae9ab983969963282127103c40fc684ef71af3d36c43775e79f",
+                "reviewed_content_hash": "0862d9f55e918ac7b472158440088d3502df62b36aae9c3b501baf8a2c45c7c0",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/path-criteria.ts",
@@ -595,7 +805,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "6e43db7ad9e27b74eaa4bd15ee319fb19bdce56df8f8648d1d4f7bd00d3174e4",
+                "reviewed_content_hash": "78b80c0d271a77fb5eaca2156a2e26eaf8cd0141f234e58cf3fe37d7467deff8",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -635,13 +845,13 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "04b3afe3e072d2bee0d43e2c006bfdb5939db8f12c322860ac069c92d74e43e8",
+            "contract_hash": "787fb7ed403c175926753c57ca19e3087b44de267cada8fbb66db500ab0320bb",
             "criterion": "The path-criteria lookup must answer from the compiled manifest alone, so Tieline must serve get_path_criteria over MCP with no database connection and must return a named, actionable message when no workspace or no readable manifest is found.",
             "links": [
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "a2a3924107310dcc18bb7f9fe9f59d0c1322418105104a45610a695d7cb2d755",
+                "reviewed_content_hash": "43316d7cf3e3fe7dc5f72be0a19b5ac4800d3a21134f40e833a752481157fe32",
                 "target": {
                   "kind": "code",
                   "path": "src/schemas.ts",
@@ -661,7 +871,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "afe20bb1393a54e6e2bbaeea8caae10138d748aa33802c37c6758a5e0436aade",
+                "reviewed_content_hash": "bccfd1f4aa6a92562d809bf3a1f2952f41a79c45dc5bcfbf6a950756ead54ece",
                 "target": {
                   "kind": "code",
                   "path": "src/tools/path-criteria.ts",
@@ -671,7 +881,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "6e43db7ad9e27b74eaa4bd15ee319fb19bdce56df8f8648d1d4f7bd00d3174e4",
+                "reviewed_content_hash": "78b80c0d271a77fb5eaca2156a2e26eaf8cd0141f234e58cf3fe37d7467deff8",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -687,7 +897,7 @@
                 "given": "no database connection is configured",
                 "position": 0,
                 "stable_id": "CONTRACT-002-AC2-S1",
-                "then": "Tieline must return the applicable acceptance criteria and the commit the manifest records",
+                "then": "Tieline must return the applicable acceptance criteria and the content-derived digest of the manifest that answered",
                 "when": "the contract criteria for a path are requested over MCP"
               },
               {
@@ -724,6 +934,6 @@
   },
   "input": {
     "path": ".tieline/spec/contract.yaml",
-    "sha256": "8274a3cadcd69223dc31bc611f8fe5a24b72d3b3eb42a114224917bce8683d43"
+    "sha256": "eb96330fc1f88d49dbd3b400655f0dc5db430d81241a417c757990ef547d1120"
   }
 }

--- a/.tieline/manifest/EVIDENCE.json
+++ b/.tieline/manifest/EVIDENCE.json
@@ -219,7 +219,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "5e36b65da676de069e31bc8f60fd3a94e58dc63a559152c26ee1e0a904a0d65a",
+                "reviewed_content_hash": "1095a4924b5c6dfdd436d4d526dff24055003a111bc6004b8db07981591a1abb",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/GRADING.json
+++ b/.tieline/manifest/GRADING.json
@@ -43,7 +43,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "f2021bcade671d043f5cdc10896023cf06d76d69b716f825fca977a8724610c4",
+                "reviewed_content_hash": "47a12a7e9106f3483f4afd7ec215a2e8ed028c812881f89bf7200e49cd936a9f",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -111,7 +111,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "f2021bcade671d043f5cdc10896023cf06d76d69b716f825fca977a8724610c4",
+                "reviewed_content_hash": "47a12a7e9106f3483f4afd7ec215a2e8ed028c812881f89bf7200e49cd936a9f",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -150,7 +150,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2b4a059e4509d43be4954fbaf8e57f76a650f8657bb13eaf67754faf3a3abce1",
+                "reviewed_content_hash": "7f4c267a3f6f579c0f58039402379667446dd9c80248e24a2cd3f122e2f15e79",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -161,7 +161,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "150c2826587e7fe6d29976185913eab18e04dca4e3b41993859276b5dae87ace",
+                "reviewed_content_hash": "33e66f296cc4576b2b0e19c42dbac5859e16284fdaef572c0b9ca29d335fae3c",
                 "target": {
                   "kind": "code",
                   "path": "src/commands/contract.ts",
@@ -172,7 +172,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "f2021bcade671d043f5cdc10896023cf06d76d69b716f825fca977a8724610c4",
+                "reviewed_content_hash": "47a12a7e9106f3483f4afd7ec215a2e8ed028c812881f89bf7200e49cd936a9f",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -235,7 +235,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "f2021bcade671d043f5cdc10896023cf06d76d69b716f825fca977a8724610c4",
+                "reviewed_content_hash": "47a12a7e9106f3483f4afd7ec215a2e8ed028c812881f89bf7200e49cd936a9f",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -278,7 +278,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "f2021bcade671d043f5cdc10896023cf06d76d69b716f825fca977a8724610c4",
+                "reviewed_content_hash": "47a12a7e9106f3483f4afd7ec215a2e8ed028c812881f89bf7200e49cd936a9f",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -317,7 +317,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "150c2826587e7fe6d29976185913eab18e04dca4e3b41993859276b5dae87ace",
+                "reviewed_content_hash": "33e66f296cc4576b2b0e19c42dbac5859e16284fdaef572c0b9ca29d335fae3c",
                 "target": {
                   "kind": "code",
                   "path": "src/commands/contract.ts",
@@ -339,7 +339,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "f2021bcade671d043f5cdc10896023cf06d76d69b716f825fca977a8724610c4",
+                "reviewed_content_hash": "47a12a7e9106f3483f4afd7ec215a2e8ed028c812881f89bf7200e49cd936a9f",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/RETRIEVAL.json
+++ b/.tieline/manifest/RETRIEVAL.json
@@ -38,7 +38,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "a2a3924107310dcc18bb7f9fe9f59d0c1322418105104a45610a695d7cb2d755",
+                "reviewed_content_hash": "43316d7cf3e3fe7dc5f72be0a19b5ac4800d3a21134f40e833a752481157fe32",
                 "target": {
                   "kind": "code",
                   "path": "src/schemas.ts",

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -18,7 +18,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2b4a059e4509d43be4954fbaf8e57f76a650f8657bb13eaf67754faf3a3abce1",
+                "reviewed_content_hash": "7f4c267a3f6f579c0f58039402379667446dd9c80248e24a2cd3f122e2f15e79",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -38,7 +38,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "8c3113f8ac4d302ae35edc88a662127cf2aa42c20cdb196385c269c20533cd3a",
+                "reviewed_content_hash": "1b762f556bad084ab381140f935c7ea06ead122d4881fca21c3d516c491f9882",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -58,7 +58,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "18a50d6bbf9011cf1d2137d2117de8dd4a2c35a9ef7e5ffd674d3e003f7ad5cb",
+                "reviewed_content_hash": "bc1161a68f6d969f1228e0bdb4770a36566ed83cebffee7f7bcf56a81f60a4c6",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -102,7 +102,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "8c3113f8ac4d302ae35edc88a662127cf2aa42c20cdb196385c269c20533cd3a",
+                "reviewed_content_hash": "1b762f556bad084ab381140f935c7ea06ead122d4881fca21c3d516c491f9882",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -112,7 +112,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "18a50d6bbf9011cf1d2137d2117de8dd4a2c35a9ef7e5ffd674d3e003f7ad5cb",
+                "reviewed_content_hash": "bc1161a68f6d969f1228e0bdb4770a36566ed83cebffee7f7bcf56a81f60a4c6",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -136,7 +136,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2b4a059e4509d43be4954fbaf8e57f76a650f8657bb13eaf67754faf3a3abce1",
+                "reviewed_content_hash": "7f4c267a3f6f579c0f58039402379667446dd9c80248e24a2cd3f122e2f15e79",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -156,7 +156,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "18a50d6bbf9011cf1d2137d2117de8dd4a2c35a9ef7e5ffd674d3e003f7ad5cb",
+                "reviewed_content_hash": "bc1161a68f6d969f1228e0bdb4770a36566ed83cebffee7f7bcf56a81f60a4c6",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -440,7 +440,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "18a50d6bbf9011cf1d2137d2117de8dd4a2c35a9ef7e5ffd674d3e003f7ad5cb",
+                "reviewed_content_hash": "bc1161a68f6d969f1228e0bdb4770a36566ed83cebffee7f7bcf56a81f60a4c6",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -481,7 +481,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "f880865dd401fff0dc575ae86b4ed9c422b42e6748079cf79a31454dfdcf6906",
+                "reviewed_content_hash": "feb99b560b8b247af9dd0f312ffcba29d8a48f02adf33d5ea6185ff3c610900f",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/index.json
+++ b/.tieline/manifest/index.json
@@ -1,7 +1,6 @@
 {
   "repository": {
-    "commit": "96bb59a6cb06148b9beb4ca855de63fb560c8728",
     "key": "tieline"
   },
-  "schema_version": 1
+  "schema_version": 2
 }

--- a/.tieline/spec/contract.yaml
+++ b/.tieline/spec/contract.yaml
@@ -291,6 +291,127 @@ capability:
                 repository: tieline
                 path: scripts/integration-contract-sync.ts
                 framework_hint: custom-script
+        - key: CONTRACT-001-AC8
+          criterion: Tieline must keep the compiled manifest independent of Git revision, identify exact manifest reads with a content-derived digest, and supply Git commit provenance explicitly only when synchronizing the reviewed manifest to the database.
+          rationale: A revision in the tracked repository-level index made every branch conflict in one shared generated file and became stale as soon as that generated file was committed. Content identity belongs to the reviewed manifest, while Git revision belongs to the runtime projection checkpoint and audit boundary.
+          scenarios:
+            - given: accepted specifications and linked artifacts whose content is unchanged across two Git revisions
+              when: the contract is compiled at each revision
+              then: the repository-level manifest index must remain byte-identical and must not record either Git revision
+            - given: the content of the reviewed manifest changes
+              when: exact path criteria are requested
+              then: Tieline must return a different manifest digest identifying the complete reviewed manifest that answered
+            - given: a reviewed manifest and an explicit runtime Git commit
+              when: the repository contract is synchronized
+              then: Tieline must use that runtime commit for projection rows, checkpoint guards, sync results, and audit events without adding it to the reviewed manifest
+          links:
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/contract/manifest.ts
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/contract/path-criteria.ts
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/contract/sync.ts
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/domain/repository-sync-store.ts
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/adapters/postgres/contract-sync-repository.ts
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/commands/contract.ts
+            - relation: enforces
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/commands/check.ts
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/cli.ts
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/schemas.ts
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/tools/path-criteria.ts
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/tieline/status.ts
+            - relation: enforces
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: .gitattributes
+            - relation: tests
+              provenance: authored
+              target:
+                kind: test
+                repository: tieline
+                path: scripts/test-manifest.ts
+                framework_hint: custom-script
+            - relation: tests
+              provenance: authored
+              target:
+                kind: test
+                repository: tieline
+                path: scripts/test-contract-command.ts
+                framework_hint: custom-script
+            - relation: tests
+              provenance: authored
+              target:
+                kind: test
+                repository: tieline
+                path: scripts/test-path-criteria.ts
+                framework_hint: custom-script
+            - relation: tests
+              provenance: authored
+              target:
+                kind: test
+                repository: tieline
+                path: scripts/test-tieline.ts
+                framework_hint: custom-script
+            - relation: tests
+              provenance: authored
+              target:
+                kind: test
+                repository: tieline
+                path: scripts/integration-contract-sync.ts
+                framework_hint: custom-script
     - key: CONTRACT-002
       title: Learn which acceptance criteria apply to a path before editing it
       actor: implementing agent
@@ -352,7 +473,7 @@ capability:
           scenarios:
             - given: no database connection is configured
               when: the contract criteria for a path are requested over MCP
-              then: Tieline must return the applicable acceptance criteria and the commit the manifest records
+              then: Tieline must return the applicable acceptance criteria and the content-derived digest of the manifest that answered
             - given: the server runs outside any Tieline workspace
               when: the contract criteria for a path are requested
               then: Tieline must name the missing workspace and the command that creates one

--- a/README.md
+++ b/README.md
@@ -241,25 +241,26 @@ tieline contract criteria src/commands/check.ts src/server.ts
 This is an exact path lookup, not semantic search. Each path is reported as
 `has_criteria`, `no_criteria`, or `not_found`; results with criteria preserve
 whether the link is `direct` on an acceptance criterion or a `story_fallback`.
-JSON output also carries the manifest commit that answered.
+JSON output also carries a content-derived `manifest_digest` identifying the
+complete reviewed manifest that answered.
 
 Compilation writes `.tieline/manifest/`, one file per capability plus a small
 index:
 
 ```
 .tieline/manifest/
-  index.json        schema version and the repository key and commit
+  index.json        schema version and the stable repository key
   CONTRACT.json     one capability, named after its stable ID, with the
   RETRIEVAL.json    specification file and hash it was compiled from
   ...
 ```
 
 A capability is exactly one specification file, so this is the boundary the
-contract already has. Two branches that change different capabilities now change
-different files and have nothing to conflict over. The index changes on every
-commit because it records one, and `.gitattributes` marks it `-merge` so git
-asks for a recompile instead of stitching two indexes together. Compiling
-deletes the file of any capability the specification no longer declares.
+contract already has. The schema-v2 index contains only stable repository
+identity, stays byte-identical for commit-only changes, and uses normal Git
+merging. Different capability shards avoid cross-capability conflicts; edits to
+the same shard use normal conflict resolution. Compiling deletes stale
+capability shards the specification no longer declares.
 
 Mapping coverage counts a repository file as mapped when any contract link names
 it. That records who claimed the file is evidence, not how much is known about

--- a/scripts/integration-contract-sync.ts
+++ b/scripts/integration-contract-sync.ts
@@ -1,14 +1,18 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import postgres from "postgres";
 import { PostgresContractReadRepository } from "../src/adapters/postgres/contract-read-repository.js";
 import { PostgresContractSyncRepository } from "../src/adapters/postgres/contract-sync-repository.js";
+import { runCli, type TielineCliIO } from "../src/cli.js";
 import { migrateDatabase } from "../src/commands/migrate.js";
 import {
   attachCurrentArtifactHashes,
   compileContractManifest,
+  compileContractManifestWithSources,
+  writeContractManifest,
 } from "../src/contract/manifest.js";
 import {
   ContractSyncCheckpointError,
@@ -185,7 +189,7 @@ try {
   const reads = new PostgresContractReadRepository(() => sql);
   const syncAsRepositoryRole = async (
     manifest: ContractManifest,
-    options?: ContractSyncOptions
+    options: ContractSyncOptions
   ) => {
     await sql.unsafe("set role tieline_repository_sync");
     try {
@@ -199,8 +203,15 @@ try {
   const reviewedFirstManifest = compileContractManifest({
     repositoryRoot: root,
     repositoryKey: "sync-integration",
-    commit: "commit-one",
   });
+  await assert.rejects(
+    store.sync(reviewedFirstManifest, { commit: "  " }),
+    /Repository sync commit cannot be empty/
+  );
+  await assert.rejects(
+    syncContractManifest(store, reviewedFirstManifest, { commit: "  " }),
+    /Repository sync commit cannot be empty/
+  );
   writeFileSync(
     resolve(root, "scripts/sync.test.ts"),
     "assert(contractSync && changedAfterReview);\n"
@@ -215,7 +226,8 @@ try {
       await syncSql.unsafe("set role tieline_repository_sync");
       return await syncContractManifest(
         new PostgresContractSyncRepository(syncSql),
-        firstManifest
+        firstManifest,
+        { commit: "commit-one" }
       );
     } finally {
       await syncSql.unsafe("reset role");
@@ -232,7 +244,35 @@ try {
   );
   const first = initialSyncs.find((result) => result.outcome === "synced")!;
   assert.equal(first.outcome, "synced");
+  assert.equal(first.commit, "commit-one");
   assert.deepEqual(first.conflicts, []);
+  const [runtimeCommitProjection] = await sql<{
+    capability_commit: string;
+    story_commit: string;
+    criterion_commit: string;
+    checkpoint_commit: string;
+    audit_commit: string;
+  }[]>`
+    select
+      (select repository_commit from capabilities
+       where repository_id = ${repository.id} and stable_id = 'SYNC') as capability_commit,
+      (select repository_commit from user_stories
+       where repository_id = ${repository.id} and stable_id = 'SYNC-001') as story_commit,
+      (select repository_commit from acceptance_criteria
+       where repository_id = ${repository.id} and stable_id = 'SYNC-001-AC1') as criterion_commit,
+      (select commit_sha from repository_sync_checkpoints
+       where repository_id = ${repository.id}) as checkpoint_commit,
+      (select detail->>'commit' from audit_events
+       where event_kind = 'repository_contract_synced'
+         and detail->>'repository' = 'sync-integration'
+       order by occurred_at desc, id desc limit 1) as audit_commit`;
+  assert.deepEqual(runtimeCommitProjection, {
+    capability_commit: "commit-one",
+    story_commit: "commit-one",
+    criterion_commit: "commit-one",
+    checkpoint_commit: "commit-one",
+    audit_commit: "commit-one",
+  });
   const reviewedTestLink =
     firstManifest.capabilities[0]!.stories[0]!.acceptance_criteria[0]!.links.find(
       (link) => link.target.kind === "test"
@@ -403,7 +443,9 @@ try {
 
   const [auditBeforeRepeat] = await sql<{ count: string }[]>`
     select count(*) from audit_events where event_kind = 'repository_contract_synced'`;
-  const repeated = await syncAsRepositoryRole(firstManifest);
+  const repeated = await syncAsRepositoryRole(firstManifest, {
+    commit: "commit-one",
+  });
   const [auditAfterRepeat] = await sql<{ count: string }[]>`
     select count(*) from audit_events where event_kind = 'repository_contract_synced'`;
   assert.equal(repeated.outcome, "unchanged");
@@ -438,14 +480,19 @@ try {
     compileContractManifest({
       repositoryRoot: root,
       repositoryKey: "sync-integration",
-      commit: "commit-two",
     }),
-    { expectedPreviousCommit: "commit-one" }
+    { commit: "commit-two", expectedPreviousCommit: "commit-one" }
   );
+  assert.equal(second.commit, "commit-two");
   assert.equal(second.retired_acceptance_criteria, 1);
-  const [retiredCriterion] = await sql<{ active: boolean }[]>`
-    select active from acceptance_criteria where id = ${ac2Id}`;
+  const [retiredCriterion] = await sql<{
+    active: boolean;
+    repository_commit: string;
+  }[]>`
+    select active, repository_commit
+    from acceptance_criteria where id = ${ac2Id}`;
   assert.equal(retiredCriterion.active, false);
+  assert.equal(retiredCriterion.repository_commit, "commit-two");
   const [activeRetiredScenarios] = await sql<{ count: string }[]>`
     select count(*) from scenarios where criterion_id = ${ac2Id} and active`;
   assert.equal(Number(activeRetiredScenarios.count), 0);
@@ -496,9 +543,8 @@ try {
       compileContractManifest({
         repositoryRoot: root,
         repositoryKey: "sync-integration",
-        commit: "collision-commit",
       }),
-      { expectedPreviousCommit: "commit-two" }
+      { commit: "collision-commit", expectedPreviousCommit: "commit-two" }
     ),
     ContractSyncCollisionError
   );
@@ -559,9 +605,8 @@ try {
     compileContractManifest({
       repositoryRoot: root,
       repositoryKey: "sync-integration",
-      commit: "commit-three",
     }),
-    { expectedPreviousCommit: "commit-two" }
+    { commit: "commit-three", expectedPreviousCommit: "commit-two" }
   );
   assert.deepEqual(conflictResult.conflicts, [
     {
@@ -614,9 +659,8 @@ try {
     compileContractManifest({
       repositoryRoot: root,
       repositoryKey: "sync-integration",
-      commit: "commit-four",
     }),
-    { expectedPreviousCommit: "commit-three" }
+    { commit: "commit-four", expectedPreviousCommit: "commit-three" }
   );
   assert.deepEqual(reconciled.conflicts, []);
   await sql.unsafe("set role tieline_reader");
@@ -636,9 +680,8 @@ try {
       compileContractManifest({
         repositoryRoot: root,
         repositoryKey: "sync-integration",
-        commit: "delayed-old-commit",
       }),
-      { expectedPreviousCommit: "commit-one" }
+      { commit: "delayed-old-commit", expectedPreviousCommit: "commit-one" }
     ),
     ContractSyncCheckpointError
   );
@@ -715,9 +758,8 @@ try {
     compileContractManifest({
       repositoryRoot: root,
       repositoryKey: "sync-integration",
-      commit: "commit-five",
     }),
-    { expectedPreviousCommit: "commit-four" }
+    { commit: "commit-five", expectedPreviousCommit: "commit-four" }
   );
   assert.equal(beforeRename.reconciled_code_assets, 0);
   const [projectedBeforeRename] = await sql<{ id: string }[]>`
@@ -745,9 +787,8 @@ try {
     compileContractManifest({
       repositoryRoot: root,
       repositoryKey: "sync-integration",
-      commit: "commit-six",
     }),
-    { expectedPreviousCommit: "commit-five" }
+    { commit: "commit-six", expectedPreviousCommit: "commit-five" }
   );
   assert.equal(afterRename.reconciled_code_assets, 1);
   const projectedPaths = await sql<{ path: string }[]>`
@@ -785,8 +826,8 @@ try {
     compileContractManifest({
       repositoryRoot: root,
       repositoryKey: "sync-integration",
-      commit: "commit-six",
-    })
+    }),
+    { commit: "commit-six" }
   );
   assert.equal(repaired.outcome, "unchanged");
   assert.equal(repaired.reconciled_code_assets, 1);
@@ -799,6 +840,101 @@ try {
     where source = 'intercom' and external_id = 'unresolved-help-article'`;
   assert.equal(helpStub.title, null);
   assert.equal(helpStub.markdown, null);
+
+  const manifestDirectory = resolve(root, ".tieline/manifest");
+  writeContractManifest(
+    manifestDirectory,
+    compileContractManifestWithSources({
+      repositoryRoot: root,
+      repositoryKey: "sync-integration",
+    })
+  );
+  const cliEnv = {
+    ...process.env,
+    DATABASE_URL_SYNC: adminUrl,
+    EMBEDDING_PROVIDER: "hash",
+  };
+  let cliOutput = "";
+  const cliIo: TielineCliIO = {
+    write(message) {
+      cliOutput += message;
+    },
+    error(message) {
+      throw new Error(message);
+    },
+    async question() {
+      throw new Error("contract sync integration must not prompt");
+    },
+  };
+  assert.equal(
+    await runCli(
+      [
+        "contract",
+        "sync",
+        root,
+        "--repo",
+        "sync-integration",
+        "--output",
+        manifestDirectory,
+        "--commit",
+        "cli-explicit-commit",
+        "--json",
+      ],
+      cliIo,
+      cliEnv
+    ),
+    0
+  );
+  assert.equal(JSON.parse(cliOutput).commit, "cli-explicit-commit");
+
+  execFileSync("git", ["init", "--quiet"], { cwd: root });
+  execFileSync("git", ["config", "user.email", "integration@tieline.test"], {
+    cwd: root,
+  });
+  execFileSync("git", ["config", "user.name", "Tieline Integration"], {
+    cwd: root,
+  });
+  execFileSync("git", ["add", "."], { cwd: root });
+  execFileSync("git", ["commit", "--quiet", "-m", "integration fixture"], {
+    cwd: root,
+  });
+  const fixtureCommit = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: root,
+    encoding: "utf8",
+  }).trim();
+  cliOutput = "";
+  assert.equal(
+    await runCli(
+      [
+        "contract",
+        "sync",
+        root,
+        "--repo",
+        "sync-integration",
+        "--output",
+        manifestDirectory,
+        "--json",
+      ],
+      cliIo,
+      cliEnv
+    ),
+    0
+  );
+  assert.equal(JSON.parse(cliOutput).commit, fixtureCommit);
+  const [cliCommitProjection] = await sql<{
+    checkpoint_commit: string;
+    audit_commit: string;
+  }[]>`
+    select
+      (select commit_sha from repository_sync_checkpoints
+       where repository_id = ${repository.id}) as checkpoint_commit,
+      (select detail->>'commit' from audit_events
+       where event_kind = 'repository_contract_synced'
+       order by occurred_at desc, id desc limit 1) as audit_commit`;
+  assert.deepEqual(cliCommitProjection, {
+    checkpoint_commit: fixtureCommit,
+    audit_commit: fixtureCommit,
+  });
 } finally {
   await sql.end({ timeout: 5 });
   rmSync(root, { recursive: true, force: true });

--- a/scripts/integration-lifecycle.ts
+++ b/scripts/integration-lifecycle.ts
@@ -250,7 +250,6 @@ try {
     compileContractManifest({
       repositoryRoot: root,
       repositoryKey,
-      commit: "accepted-lifecycle-contract",
     }),
     root
   );
@@ -258,7 +257,9 @@ try {
   assert.equal(materializedStory.planning_origin?.record_id, planningStory.id);
 
   const syncResult = await withRole("tieline_repository_sync", () =>
-    syncContractManifest(sync, manifest)
+    syncContractManifest(sync, manifest, {
+      commit: "accepted-lifecycle-contract",
+    })
   );
   assert.equal(syncResult.outcome, "synced");
   assert.deepEqual(syncResult.conflicts, []);

--- a/scripts/test-contract-command.ts
+++ b/scripts/test-contract-command.ts
@@ -220,8 +220,6 @@ try {
       root,
       "--repo",
       "contract-command-test",
-      "--commit",
-      "offline-proof",
       "--output",
       manifestPath,
       "--json",
@@ -230,6 +228,14 @@ try {
     {}
   );
   assert.equal(compileExit, 0);
+  await assert.rejects(
+    runCli(
+      ["contract", "compile", root, "--commit", "legacy-compile-commit"],
+      io,
+      {}
+    ),
+    /unknown option '--commit'/
+  );
   const compileResult = JSON.parse(output);
   assert.deepEqual(compileResult.files, [
     "BEHAVIOR.json",
@@ -243,8 +249,8 @@ try {
   assert.deepEqual(
     JSON.parse(readFileSync(resolve(manifestPath, "index.json"), "utf8")),
     {
-      schema_version: 1,
-      repository: { key: "contract-command-test", commit: "offline-proof" },
+      schema_version: 2,
+      repository: { key: "contract-command-test" },
     }
   );
   const behaviorShard = JSON.parse(
@@ -261,7 +267,6 @@ try {
       "compile",
       root,
       "--repo=contract-command-test",
-      "--commit=offline-proof",
       `--output=${manifestPath}`,
     ],
     io,
@@ -279,7 +284,6 @@ try {
       "compile",
       root,
       "--repo=contract-command-test",
-      "--commit=offline-proof",
       `--output=${manifestPath}`,
       "--json",
     ],
@@ -297,8 +301,6 @@ try {
       root,
       "--repo",
       "contract-command-test",
-      "--commit",
-      "offline-proof",
       "--json",
     ],
     io,
@@ -314,7 +316,7 @@ try {
     ...Array.from({ length: 7 }, (_unused, index) => `src/mapped-${index + 1}.ts`),
   ];
   assert.deepEqual(JSON.parse(output), {
-    repository: { key: "contract-command-test", commit: "offline-proof" },
+    repository: { key: "contract-command-test" },
     stories: 2,
     acceptance_criteria: 5,
     criteria_with_direct_links: 5,
@@ -349,7 +351,6 @@ try {
   const manifest = compileContractManifest({
     repositoryRoot: root,
     repositoryKey: "contract-command-test",
-    commit: "offline-proof",
   });
   const untiered = computeRepositoryMappingCoverage(manifest, {
     repositoryRoot: root,
@@ -400,8 +401,6 @@ try {
         root,
         "--repo",
         "contract-command-test",
-        "--commit",
-        "offline-proof",
         "--json",
       ],
       io,
@@ -424,8 +423,6 @@ try {
         root,
         "--repo",
         "contract-command-test",
-        "--commit",
-        "offline-proof",
       ],
       io,
       {}
@@ -446,8 +443,6 @@ try {
         root,
         "--repo",
         "contract-command-test",
-        "--commit",
-        "offline-proof",
         "--json",
       ],
       io,
@@ -489,8 +484,6 @@ try {
         root,
         "--repo",
         "contract-command-test",
-        "--commit",
-        "offline-proof",
       ],
       io,
       {}
@@ -537,8 +530,6 @@ try {
         root,
         "--repo",
         "contract-command-test",
-        "--commit",
-        "offline-proof",
         "--base",
         "HEAD",
         "--json",
@@ -596,8 +587,6 @@ try {
         root,
         "--repo",
         "contract-command-test",
-        "--commit",
-        "offline-proof",
         "--base",
         "HEAD",
       ],
@@ -627,8 +616,6 @@ try {
         root,
         "--repo",
         "contract-command-test",
-        "--commit",
-        "offline-proof",
         "--base",
         "HEAD",
         "--json",
@@ -665,8 +652,6 @@ try {
         root,
         "--repo",
         "contract-command-test",
-        "--commit",
-        "offline-proof",
         "--json",
       ],
       io,
@@ -697,8 +682,6 @@ try {
           root,
           "--repo",
           "contract-command-test",
-          "--commit",
-          "offline-proof",
           "--output",
           manifestPath,
         ],

--- a/scripts/test-contract.ts
+++ b/scripts/test-contract.ts
@@ -322,7 +322,6 @@ capability:
       compileContractManifest({
         repositoryRoot: root,
         repositoryKey: "tieline",
-        commit: "coverage-test",
       }),
       {
         repositoryRoot: root,
@@ -364,8 +363,8 @@ await test("does not describe an empty source scope as 100% covered", () => {
     mkdirSync(resolve(root, "src"), { recursive: true });
     const coverage = computeRepositoryMappingCoverage(
       {
-        schema_version: 1,
-        repository: { key: "tieline", commit: "empty" },
+        schema_version: 2,
+        repository: { key: "tieline" },
         inputs: [],
         capabilities: [],
       },

--- a/scripts/test-grade.ts
+++ b/scripts/test-grade.ts
@@ -127,7 +127,6 @@ capability:
   const manifest = compileContractManifest({
     repositoryRoot: root,
     repositoryKey: REPOSITORY,
-    commit: "grade-fixture",
     specDirectory: ".tieline/spec",
   });
   const scopeFor = (changes: RepositoryPathChange[]) =>
@@ -316,7 +315,6 @@ capability:
     compileContractManifestWithSources({
       repositoryRoot: root,
       repositoryKey: REPOSITORY,
-      commit: "HEAD",
       specDirectory: ".tieline/spec",
     })
   );

--- a/scripts/test-impact.ts
+++ b/scripts/test-impact.ts
@@ -103,7 +103,6 @@ capability:
   const compiled = compileContractManifestWithSources({
     repositoryRoot: root,
     repositoryKey: "impact-fixture",
-    commit: "HEAD",
     specDirectory: ".tieline/contract",
   });
   const manifest = compiled.manifest;

--- a/scripts/test-link-plausibility.ts
+++ b/scripts/test-link-plausibility.ts
@@ -225,8 +225,8 @@ function storyOf(topic: Topic, links: ManifestLink[]): ManifestStory {
 
 function manifestOf(stories: ManifestStory[]): ContractManifest {
   return {
-    schema_version: 1,
-    repository: { key: REPOSITORY, commit: "fixture" },
+    schema_version: 2,
+    repository: { key: REPOSITORY },
     inputs: [],
     capabilities: [
       {

--- a/scripts/test-manifest.ts
+++ b/scripts/test-manifest.ts
@@ -16,6 +16,7 @@ import {
   compileContractManifest,
   compileContractManifestWithSources,
   ContractManifestError,
+  manifestDigest,
   readContractManifest,
   serializeContractManifest,
   writeContractManifest,
@@ -119,7 +120,6 @@ function compile(root: string): CompiledContractManifest {
   return compileContractManifestWithSources({
     repositoryRoot: root,
     repositoryKey: "tieline",
-    commit: "abc123",
   });
 }
 
@@ -135,7 +135,6 @@ await test("compiles byte-identical JSON with source, origin, relation, and arti
     const options = {
       repositoryRoot: root,
       repositoryKey: "tieline",
-      commit: "abc123",
     };
     const first = compileContractManifest(options);
     const second = compileContractManifest(options);
@@ -166,13 +165,26 @@ await test("compiles byte-identical JSON with source, origin, relation, and arti
   }
 });
 
+await test("keeps the shared manifest index free of runtime revisions", () => {
+  const root = fixture();
+  try {
+    const directory = resolve(root, ".tieline/manifest");
+    writeContractManifest(directory, compile(root));
+    assert.deepEqual(
+      JSON.parse(readFileSync(resolve(directory, "index.json"), "utf8")),
+      { schema_version: 2, repository: { key: "tieline" } }
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 await test("changes contract semantics when only link provenance changes", () => {
   const root = fixture();
   try {
     const before = compileContractManifest({
       repositoryRoot: root,
       repositoryKey: "tieline",
-      commit: "abc123",
     });
     const specPath = resolve(root, ".tieline/spec/contract.yaml");
     const authored = readFileSync(specPath, "utf8");
@@ -186,7 +198,6 @@ await test("changes contract semantics when only link provenance changes", () =>
     const after = compileContractManifest({
       repositoryRoot: root,
       repositoryKey: "tieline",
-      commit: "abc123",
     });
     const beforeStory = before.capabilities[0]!.stories[0]!;
     const afterStory = after.capabilities[0]!.stories[0]!;
@@ -210,7 +221,6 @@ await test("changes only the linked artifact basis when repository content chang
     const options = {
       repositoryRoot: root,
       repositoryKey: "tieline",
-      commit: "abc123",
     };
     const before = compileContractManifest(options);
     writeFileSync(resolve(root, "scripts/contract.test.ts"), "assert(contract && current);\n");
@@ -226,6 +236,11 @@ await test("changes only the linked artifact basis when repository content chang
       (link) => link.target.kind === "test"
     );
     assert.notEqual(beforeTestLink!.reviewed_content_hash, afterTestLink!.reviewed_content_hash);
+    assert.notEqual(
+      manifestDigest(before),
+      manifestDigest(after),
+      "the assembled manifest digest changes with reviewed content"
+    );
     assert.deepEqual(
       beforeCriterion.links.map((link) => [link.relation, link.target]),
       afterCriterion.links.map((link) => [link.relation, link.target]),
@@ -243,7 +258,6 @@ await test("keeps reviewed hashes while measuring current artifact content for s
     const reviewed = compileContractManifest({
       repositoryRoot: root,
       repositoryKey: "tieline",
-      commit: "reviewed-commit",
     });
     const criterion =
       reviewed.capabilities[0]!.stories[0]!.acceptance_criteria[0]!;
@@ -268,6 +282,11 @@ await test("keeps reviewed hashes while measuring current artifact content for s
       serializeContractManifest(measured),
       /current_content_hash/,
       "runtime freshness measurements do not alter the reviewed manifest"
+    );
+    assert.equal(
+      manifestDigest(measured),
+      manifestDigest(reviewed),
+      "runtime-only current hashes do not change reviewed manifest identity"
     );
 
     rmSync(resolve(root, "scripts/contract.test.ts"));
@@ -356,8 +375,8 @@ await test("round-trips a compiled manifest through the directory it writes", ()
     assert.deepEqual(
       JSON.parse(readFileSync(resolve(directory, "index.json"), "utf8")),
       {
-        schema_version: 1,
-        repository: { key: "tieline", commit: "abc123" },
+        schema_version: 2,
+        repository: { key: "tieline" },
       }
     );
 
@@ -472,6 +491,35 @@ await test("reports a missing manifest directory or index instead of reading a p
   }
 });
 
+await test("rejects the legacy manifest index shape", () => {
+  const root = fixture();
+  try {
+    const directory = manifestDirectory(root);
+    writeContractManifest(directory, compile(root));
+    writeFileSync(
+      resolve(directory, "index.json"),
+      `${JSON.stringify(
+        {
+          schema_version: 1,
+          repository: { key: "tieline", commit: "legacy-commit" },
+        },
+        null,
+        2
+      )}\n`
+    );
+    assert.throws(
+      () => readContractManifest(directory),
+      (error: unknown) => {
+        assert.ok(error instanceof ContractManifestError);
+        assert.match(error.message, /schema_version/);
+        return true;
+      }
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 await test("rejects a manifest file whose name disagrees with the capability it holds", () => {
   const root = fixture();
   try {
@@ -537,7 +585,6 @@ await test("rejects a missing artifact in the repository being compiled", () => 
         compileContractManifest({
           repositoryRoot: root,
           repositoryKey: "tieline",
-          commit: "abc123",
         }),
       (error: unknown) => {
         assert.ok(error instanceof ContractManifestError);
@@ -557,7 +604,6 @@ await test("omits the reviewed hash of an unhashable artifact when asked to tole
     const manifest = compileContractManifest({
       repositoryRoot: root,
       repositoryKey: "tieline",
-      commit: "abc123",
       onUnhashableArtifact: "omit_hash",
     });
 
@@ -594,7 +640,6 @@ await test("tolerates an artifact that is a directory rather than a file", () =>
     const manifest = compileContractManifest({
       repositoryRoot: root,
       repositoryKey: "tieline",
-      commit: "abc123",
       onUnhashableArtifact: "omit_hash",
     });
     assert.equal(
@@ -606,7 +651,6 @@ await test("tolerates an artifact that is a directory rather than a file", () =>
         compileContractManifest({
           repositoryRoot: root,
           repositoryKey: "tieline",
-          commit: "abc123",
         }),
       (error: unknown) => {
         assert.ok(error instanceof ContractManifestError);
@@ -626,7 +670,6 @@ await test("emits stable ordering independent of YAML file discovery order", () 
     const manifest = compileContractManifest({
       repositoryRoot: root,
       repositoryKey: "tieline",
-      commit: "abc123",
     });
     assert.deepEqual(
       manifest.capabilities.map((capability) => capability.stable_id),

--- a/scripts/test-path-criteria.ts
+++ b/scripts/test-path-criteria.ts
@@ -18,6 +18,7 @@ import {
 } from "../src/contract/path-criteria.js";
 import {
   compileContractManifestWithSources,
+  manifestDigest,
   writeContractManifest,
   type ContractManifest,
 } from "../src/contract/manifest.js";
@@ -136,6 +137,23 @@ capability:
                 path: src/direct.ts
 `;
 
+const OTHER_SPEC = `version: 1
+capability:
+  key: OTHER-CAPABILITY
+  name: Unqueried contract content
+  description: Contract content outside the queried path still contributes to manifest identity.
+  stories:
+    - key: OTHER-CAPABILITY-001
+      title: Keep exact reads attributable
+      actor: implementing agent
+      goal: identify the complete reviewed contract behind an exact read
+      benefit: changes outside one lookup remain visible in its manifest identity
+      lifecycle: production
+      acceptance_criteria:
+        - key: OTHER-CAPABILITY-001-AC1
+          criterion: Tieline must include the first unqueried contract statement in manifest identity.
+`;
+
 function createFixture(withManifest: boolean): {
   root: string;
   manifest: ContractManifest;
@@ -145,6 +163,7 @@ function createFixture(withManifest: boolean): {
   mkdirSync(resolve(root, "src"), { recursive: true });
   writeFileSync(resolve(root, ".tieline/config.json"), workspaceConfig());
   writeFileSync(resolve(root, ".tieline/spec/path-criteria.yaml"), SPEC);
+  writeFileSync(resolve(root, ".tieline/spec/other.yaml"), OTHER_SPEC);
   writeFileSync(resolve(root, "src/direct.ts"), "export const direct = 1;\n");
   writeFileSync(resolve(root, "src/shared.ts"), "export const shared = 1;\n");
   writeFileSync(
@@ -158,7 +177,6 @@ function createFixture(withManifest: boolean): {
   const compiled = compileContractManifestWithSources({
     repositoryRoot: root,
     repositoryKey: "path-criteria-fixture",
-    commit: "path-criteria-fixture-commit",
     specDirectory: ".tieline/spec",
   });
   if (withManifest) {
@@ -212,10 +230,8 @@ try {
       "src/DIRECT.ts",
     ],
   });
-  assert.deepEqual(report.repository, {
-    key: "path-criteria-fixture",
-    commit: "path-criteria-fixture-commit",
-  });
+  assert.deepEqual(report.repository, { key: "path-criteria-fixture" });
+  assert.equal(report.manifest_digest, manifestDigest(manifest));
   assert.equal(report.has_criteria_paths, 2);
   assert.equal(report.no_criteria_paths, 1);
   assert.equal(report.not_found_paths, 2);
@@ -241,6 +257,35 @@ try {
   assert.equal(report.results[4]?.status, "not_found");
   assert.equal(report.results[4]?.exists, false);
 
+  writeFileSync(
+    resolve(root, ".tieline/spec/other.yaml"),
+    OTHER_SPEC.replace("first unqueried", "changed unqueried")
+  );
+  const changedManifest = compileContractManifestWithSources({
+    repositoryRoot: root,
+    repositoryKey: "path-criteria-fixture",
+    specDirectory: ".tieline/spec",
+  }).manifest;
+  const changedReport = lookupPathCriteria({
+    manifest: changedManifest,
+    repositoryRoot: root,
+    paths: ["src/direct.ts"],
+  });
+  assert.notEqual(
+    changedReport.manifest_digest,
+    report.manifest_digest,
+    "an unqueried capability still changes the complete manifest identity"
+  );
+  assert.deepEqual(
+    changedReport.results[0]?.criteria.map(
+      (criterion) => criterion.acceptance_criterion_stable_id
+    ),
+    report.results[0]?.criteria.map(
+      (criterion) => criterion.acceptance_criterion_stable_id
+    ),
+    "changing unqueried content does not change the path lookup itself"
+  );
+
   let output = "";
   const io: TielineCliIO = {
     write(message) {
@@ -262,7 +307,7 @@ try {
     ),
     0
   );
-  assert.match(output, /manifest commit path-criteria-fixture-commit/);
+  assert.match(output, new RegExp(`manifest ${manifestDigest(manifest)}`));
   assert.match(output, /PATH-CRITERIA-001-AC1 direct implements/);
   assert.match(output, /PATH-CRITERIA-001-AC1 story_fallback implements/);
 
@@ -288,7 +333,8 @@ try {
     cliReport.results.map((entry: { status: string }) => entry.status),
     ["no_criteria", "not_found"]
   );
-  assert.equal(cliReport.repository.commit, "path-criteria-fixture-commit");
+  assert.deepEqual(cliReport.repository, { key: "path-criteria-fixture" });
+  assert.equal(cliReport.manifest_digest, manifestDigest(manifest));
 
   const toolSource = readFileSync(
     resolve(projectRoot, "src/tools/path-criteria.ts"),
@@ -344,14 +390,16 @@ try {
   }
   assert.notEqual(handlerResult.isError, true);
   const structured = handlerResult.structuredContent as {
-    repository: { commit: string };
+    repository: { key: string };
+    manifest_digest: string;
     has_criteria_paths: number;
     no_criteria_paths: number;
     not_found_paths: number;
     results: Array<{ status: string; criteria: PathCriterion[] }>;
     note?: string;
   };
-  assert.equal(structured.repository.commit, "path-criteria-fixture-commit");
+  assert.deepEqual(structured.repository, { key: "path-criteria-fixture" });
+  assert.equal(structured.manifest_digest, manifestDigest(manifest));
   assert.equal(structured.has_criteria_paths, 1);
   assert.equal(structured.no_criteria_paths, 1);
   assert.equal(structured.not_found_paths, 1);
@@ -416,9 +464,9 @@ try {
   assert.notEqual(configuredWorkspaceResult.isError, true);
   assert.equal(
     (configuredWorkspaceResult.structuredContent as {
-      repository: { commit: string };
-    }).repository.commit,
-    "path-criteria-fixture-commit"
+      manifest_digest: string;
+    }).manifest_digest,
+    manifestDigest(manifest)
   );
 } finally {
   if (originalTielineWorkspace === undefined) {

--- a/scripts/test-reconciliation.ts
+++ b/scripts/test-reconciliation.ts
@@ -119,7 +119,6 @@ capability:
   const manifest = compileContractManifest({
     repositoryRoot: root,
     repositoryKey: "reconciliation-fixture",
-    commit: "HEAD",
     specDirectory: ".tieline/contract",
   });
 

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -250,6 +250,59 @@ try {
   assert.equal(parsedStatus.contract.acceptance_criteria, 0);
   assert.match(parsedStatus.next_action, /tieline_author/);
 
+  writeFileSync(
+    resolve(workspace.specDirectoryPath, "status.yaml"),
+    `version: 1
+capability:
+  key: STATUS
+  name: Workspace status
+  description: Workspace readiness reflects readable contract state.
+  stories:
+    - key: STATUS-001
+      title: Recover an unreadable manifest
+      actor: maintainer
+      goal: see when the compiled manifest must be regenerated
+      benefit: manifest-backed commands are usable after an upgrade
+      lifecycle: production
+      acceptance_criteria:
+        - key: STATUS-001-AC1
+          criterion: Tieline must direct maintainers to compile an unreadable manifest.
+`
+  );
+  mkdirSync(workspace.manifestPath, { recursive: true });
+  const legacyIndex = `${JSON.stringify(
+    {
+      schema_version: 1,
+      repository: { key: "example-repository", commit: "legacy-commit" },
+    },
+    null,
+    2
+  )}\n`;
+  const legacyIndexPath = resolve(workspace.manifestPath, "index.json");
+  writeFileSync(legacyIndexPath, legacyIndex);
+
+  const legacyManifestStatus = io();
+  assert.equal(
+    await runCli(
+      ["status", target, "--json"],
+      legacyManifestStatus.adapter,
+      { TIELINE_CONFIG_HOME: configHome }
+    ),
+    0
+  );
+  const parsedLegacyManifestStatus = JSON.parse(
+    legacyManifestStatus.output.join("")
+  ) as {
+    contract: { manifest_exists: boolean };
+    next_action: string;
+  };
+  assert.equal(parsedLegacyManifestStatus.contract.manifest_exists, false);
+  assert.match(
+    parsedLegacyManifestStatus.next_action,
+    /tieline contract compile \./
+  );
+  assert.equal(readFileSync(legacyIndexPath, "utf8"), legacyIndex);
+
   const environmentStatus = io();
   assert.equal(
     await runCli(["status", target, "--json"], environmentStatus.adapter, {

--- a/src/adapters/postgres/contract-sync-repository.ts
+++ b/src/adapters/postgres/contract-sync-repository.ts
@@ -900,8 +900,10 @@ export class PostgresContractSyncRepository
 
   async sync(
     manifest: ContractManifest,
-    options: ContractSyncOptions = {}
+    options: ContractSyncOptions
   ): Promise<ContractSyncResult> {
+    const commit = options.commit.trim();
+    if (!commit) throw new Error("Repository sync commit cannot be empty.");
     const counts = manifestCounts(manifest);
     return this.sql.begin(async (tx) => {
       await tx`
@@ -921,7 +923,7 @@ export class PostgresContractSyncRepository
         for update`;
       const currentCommit = checkpoints[0]?.commit_sha;
 
-      if (currentCommit === manifest.repository.commit) {
+      if (currentCommit === commit) {
         await refreshCodeAssetHashes(tx, manifest);
         // Reconcile on the unchanged path too: re-running sync at the same
         // commit is how a projection carrying orphans from an earlier release
@@ -934,7 +936,7 @@ export class PostgresContractSyncRepository
         return {
           outcome: "unchanged" as const,
           repository: manifest.repository.key,
-          commit: manifest.repository.commit,
+          commit,
           stories: counts.stories,
           acceptance_criteria: counts.acceptanceCriteria,
           retired_stories: 0,
@@ -959,7 +961,7 @@ export class PostgresContractSyncRepository
           await upsertCapability(
             tx,
             repositoryId,
-            manifest.repository.commit,
+            commit,
             capability
           )
         );
@@ -987,7 +989,7 @@ export class PostgresContractSyncRepository
             repositoryId,
             repositoryKey: manifest.repository.key,
             capabilityId,
-            commit: manifest.repository.commit,
+            commit,
             story,
             conflicts,
             claimedPlanningStories,
@@ -998,7 +1000,7 @@ export class PostgresContractSyncRepository
               repositoryId,
               repositoryKey: manifest.repository.key,
               storyId,
-              commit: manifest.repository.commit,
+              commit,
               criterion,
               claimedPlanningStories,
             });
@@ -1010,7 +1012,7 @@ export class PostgresContractSyncRepository
         update user_stories
         set lifecycle = 'retired',
             revision = revision + 1,
-            repository_commit = ${manifest.repository.commit}
+            repository_commit = ${commit}
         where repository_id = ${repositoryId}
           and authority = 'repository'
           and lifecycle <> 'retired'
@@ -1020,7 +1022,7 @@ export class PostgresContractSyncRepository
         await recordRevision(tx, "story", row.id, row.revision, {
           lifecycle: "retired",
           reason: "absent_from_repository_contract",
-          repository_commit: manifest.repository.commit,
+          repository_commit: commit,
         });
       }
 
@@ -1032,7 +1034,7 @@ export class PostgresContractSyncRepository
         set active = false,
             authority = 'repository',
             revision = revision + 1,
-            repository_commit = ${manifest.repository.commit}
+            repository_commit = ${commit}
         where repository_id = ${repositoryId}
           and (
             authority = 'repository'
@@ -1055,7 +1057,7 @@ export class PostgresContractSyncRepository
           {
             active: false,
             reason: "absent_from_repository_contract",
-            repository_commit: manifest.repository.commit,
+            repository_commit: commit,
           }
         );
       }
@@ -1087,7 +1089,7 @@ export class PostgresContractSyncRepository
         insert into repository_sync_checkpoints (
           repository_id, commit_sha, synced_at
         ) values (
-          ${repositoryId}, ${manifest.repository.commit}, now()
+          ${repositoryId}, ${commit}, now()
         )
         on conflict (repository_id) do update
           set commit_sha = excluded.commit_sha, synced_at = excluded.synced_at`;
@@ -1097,7 +1099,7 @@ export class PostgresContractSyncRepository
           'repository_contract_synced',
           ${jsonValue(tx, {
             repository: manifest.repository.key,
-            commit: manifest.repository.commit,
+            commit,
             stories: counts.stories,
             acceptance_criteria: counts.acceptanceCriteria,
             retired_stories: retiredStories.length,
@@ -1110,7 +1112,7 @@ export class PostgresContractSyncRepository
       return {
         outcome: "synced" as const,
         repository: manifest.repository.key,
-        commit: manifest.repository.commit,
+        commit,
         stories: counts.stories,
         acceptance_criteria: counts.acceptanceCriteria,
         retired_stories: retiredStories.length,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -473,7 +473,6 @@ function buildProgram(
       .description(description)
       .argument("[repository]", "repository path")
       .option("--repo <key>", "stable repository key")
-      .option("--commit <sha>", "commit recorded in the manifest")
       .option(
         "--output <path>",
         "review page file, or manifest directory for every other action"
@@ -554,10 +553,12 @@ function buildProgram(
         )
       );
     });
-  contractAction("sync", "Sync the reviewed manifest to the database").option(
-    "--expected-previous-commit <sha>",
-    "guard against concurrent syncs"
-  );
+  contractAction("sync", "Sync the reviewed manifest to the database")
+    .option("--commit <sha>", "repository commit recorded by this sync")
+    .option(
+      "--expected-previous-commit <sha>",
+      "guard against concurrent syncs"
+    );
   // `criteria` takes paths where the other actions take a repository, so it is
   // declared directly instead of through `contractAction`.
   contract

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -268,7 +268,6 @@ export async function runCheckCommand(
     const currentManifest = compileContractManifest({
       repositoryRoot: root,
       repositoryKey,
-      commit: manifest.repository.commit,
       specDirectory,
     });
     manifestCurrent =

--- a/src/commands/contract.ts
+++ b/src/commands/contract.ts
@@ -548,21 +548,16 @@ export async function runContractCommand(
         `Reviewed manifest repository '${reviewedManifest.repository.key}' does not match requested repository '${parsed.repositoryKey}'.`
       );
     }
+    const commit = parsed.commit ?? gitCommit(parsed.repositoryRoot);
     const manifest = attachCurrentArtifactHashes(
-      {
-        ...reviewedManifest,
-        repository: {
-          ...reviewedManifest.repository,
-          commit: parsed.commit ?? gitCommit(parsed.repositoryRoot),
-        },
-      },
+      reviewedManifest,
       parsed.repositoryRoot
     );
     try {
       const result = await syncContractManifest(
         new PostgresContractSyncRepository(getSyncSql()),
         manifest,
-        { expectedPreviousCommit: parsed.expectedPreviousCommit }
+        { commit, expectedPreviousCommit: parsed.expectedPreviousCommit }
       );
       const reads = new PostgresContractReadRepository(getSyncSql);
       const projected = await reads.queryContractStories({
@@ -629,7 +624,6 @@ export async function runContractCommand(
     compileContractManifestWithSources({
       repositoryRoot: parsed.repositoryRoot,
       repositoryKey: parsed.repositoryKey,
-      commit: parsed.commit ?? gitCommit(parsed.repositoryRoot),
       specDirectory: parsed.specDirectory,
       onUnhashableArtifact,
     });

--- a/src/contract/manifest.ts
+++ b/src/contract/manifest.ts
@@ -29,7 +29,7 @@ import type {
 } from "./schema.js";
 import { loadAcceptedContractWithSources } from "./load.js";
 
-export const CONTRACT_MANIFEST_VERSION = 1 as const;
+export const CONTRACT_MANIFEST_VERSION = 2 as const;
 
 export interface ManifestInput {
   path: string;
@@ -98,7 +98,6 @@ export interface ContractManifest {
   schema_version: typeof CONTRACT_MANIFEST_VERSION;
   repository: {
     key: string;
-    commit: string;
   };
   inputs: ManifestInput[];
   capabilities: ManifestCapability[];
@@ -183,7 +182,6 @@ export type UnhashableArtifactPolicy = "throw" | "omit_hash";
 export interface CompileContractManifestOptions {
   repositoryRoot: string;
   repositoryKey: string;
-  commit: string;
   specDirectory?: string;
   /**
    * Defaults to `throw`, so every caller that does not opt in keeps refusing to
@@ -401,7 +399,6 @@ const contractManifestIndexSchema = z
     repository: z
       .object({
         key: stableIdSchema,
-        commit: nonEmptyTextSchema,
       })
       .strict(),
   })
@@ -841,9 +838,7 @@ export function compileContractManifestWithSources(
 ): CompiledContractManifest {
   const root = resolve(options.repositoryRoot);
   const repositoryKey = options.repositoryKey.trim();
-  const commit = options.commit.trim();
   if (!repositoryKey) throw new ContractManifestError("Repository key cannot be empty.");
-  if (!commit) throw new ContractManifestError("Repository commit cannot be empty.");
 
   const loaded = loadAcceptedContractWithSources(root, options.specDirectory);
   // One document per source file, one capability per document: the accepted
@@ -880,7 +875,7 @@ export function compileContractManifestWithSources(
   return {
     manifest: {
       schema_version: CONTRACT_MANIFEST_VERSION,
-      repository: { key: repositoryKey, commit },
+      repository: { key: repositoryKey },
       inputs: [...sources.values()].sort((left, right) =>
         left.path.localeCompare(right.path)
       ),
@@ -910,6 +905,16 @@ export function serializeContractManifest(manifest: ContractManifest): string {
     ...manifest,
     capabilities: manifest.capabilities.map(reviewedCapability),
   });
+}
+
+/**
+ * Deterministic identity of the complete reviewed manifest assembled from its
+ * index and capability shards. The digest is computed when needed instead of
+ * being persisted in the shared index, so branch-local contract changes do not
+ * create an additional cross-capability conflict surface.
+ */
+export function manifestDigest(manifest: ContractManifest): string {
+  return sha256(serializeContractManifest(manifest));
 }
 
 function serializeManifestIndex(manifest: ContractManifest): string {

--- a/src/contract/path-criteria.ts
+++ b/src/contract/path-criteria.ts
@@ -15,7 +15,7 @@ import {
   type ReconciliationLinkScope,
   type ReconciliationRelation,
 } from "./reconciliation.js";
-import type { ContractManifest } from "./manifest.js";
+import { manifestDigest, type ContractManifest } from "./manifest.js";
 
 export interface PathCriterion {
   path: string;
@@ -50,8 +50,10 @@ export interface PathCriteriaResult {
 }
 
 export interface PathCriteriaReport {
-  /** The manifest state that answered the query. */
+  /** Stable repository identity recorded by the reviewed manifest. */
   repository: ContractManifest["repository"];
+  /** Content identity of the complete reviewed manifest that answered. */
+  manifest_digest: string;
   has_criteria_paths: number;
   no_criteria_paths: number;
   not_found_paths: number;
@@ -177,6 +179,7 @@ export function lookupPathCriteria(input: {
   });
   return {
     repository: { ...input.manifest.repository },
+    manifest_digest: manifestDigest(input.manifest),
     has_criteria_paths: results.filter(
       (result) => result.status === "has_criteria"
     ).length,
@@ -191,7 +194,7 @@ export function lookupPathCriteria(input: {
 
 export function renderPathCriteriaText(report: PathCriteriaReport): string {
   const lines = [
-    `Contract criteria in repository '${report.repository.key}' at manifest commit ${report.repository.commit}: ${report.has_criteria_paths} with criteria, ${report.no_criteria_paths} with no criteria, ${report.not_found_paths} not found of ${report.results.length} path(s).\n`,
+    `Contract criteria in repository '${report.repository.key}' from manifest ${report.manifest_digest}: ${report.has_criteria_paths} with criteria, ${report.no_criteria_paths} with no criteria, ${report.not_found_paths} not found of ${report.results.length} path(s).\n`,
   ];
   for (const result of report.results) {
     lines.push(`  ${result.status}  ${result.answer}\n`);

--- a/src/contract/sync.ts
+++ b/src/contract/sync.ts
@@ -8,6 +8,8 @@ export interface HandoffConflict {
 }
 
 export interface ContractSyncOptions {
+  /** Git revision whose repository projection is being synchronized. */
+  commit: string;
   expectedPreviousCommit?: string;
 }
 
@@ -30,7 +32,7 @@ export interface ContractSyncResult {
 export interface ContractSyncRepository {
   sync(
     manifest: ContractManifest,
-    options?: ContractSyncOptions
+    options: ContractSyncOptions
   ): Promise<ContractSyncResult>;
 }
 
@@ -51,7 +53,11 @@ export class ContractSyncCheckpointError extends Error {
 export async function syncContractManifest(
   repository: ContractSyncRepository,
   manifest: ContractManifest,
-  options: ContractSyncOptions = {}
+  options: ContractSyncOptions
 ): Promise<ContractSyncResult> {
-  return repository.sync(manifest, options);
+  const commit = options.commit.trim();
+  if (!commit) {
+    throw new Error("Repository sync commit cannot be empty.");
+  }
+  return repository.sync(manifest, { ...options, commit });
 }

--- a/src/domain/repository-sync-store.ts
+++ b/src/domain/repository-sync-store.ts
@@ -9,6 +9,6 @@ import type { ContractManifest } from "../contract/manifest.js";
 export interface RepositorySyncStore extends ContractSyncRepository {
   sync(
     manifest: ContractManifest,
-    options?: ContractSyncOptions
+    options: ContractSyncOptions
   ): Promise<ContractSyncResult>;
 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -244,7 +244,8 @@ export const getPathCriteriaSchema = z
   .strict();
 export type GetPathCriteriaInput = z.infer<typeof getPathCriteriaSchema>;
 export const getPathCriteriaOutputShape = {
-  repository: z.object({ key: z.string(), commit: z.string() }),
+  repository: z.object({ key: z.string() }),
+  manifest_digest: z.string().regex(/^[a-f0-9]{64}$/),
   has_criteria_paths: z.number(),
   no_criteria_paths: z.number(),
   not_found_paths: z.number(),

--- a/src/tieline/status.ts
+++ b/src/tieline/status.ts
@@ -1,8 +1,7 @@
 import { existsSync, readdirSync } from "node:fs";
-import { resolve } from "node:path";
 import type { EmbeddingProvider } from "../config.js";
 import { loadAcceptedContract } from "../contract/load.js";
-import { CONTRACT_MANIFEST_INDEX_FILE } from "../contract/manifest.js";
+import { readContractManifest } from "../contract/manifest.js";
 import {
   findTielineWorkspace,
   type TielineWorkspace,
@@ -41,6 +40,15 @@ function configured(value: string | undefined): boolean {
   return Boolean(value?.trim());
 }
 
+function readableManifest(directory: string): boolean {
+  try {
+    readContractManifest(directory);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function getTielineStatus(
   workspace: TielineWorkspace,
   env: NodeJS.ProcessEnv = process.env
@@ -73,11 +81,11 @@ export function getTielineStatus(
   const acceptanceCriteria = stories.flatMap(
     (story) => story.acceptance_criteria
   );
-  // The manifest is a directory, so its index is what says a manifest was
-  // actually compiled; an empty directory has nothing in it to read.
-  const manifestExists = existsSync(
-    resolve(workspace.manifestPath, CONTRACT_MANIFEST_INDEX_FILE)
-  );
+  // Presence alone is not availability: an interrupted compile, malformed
+  // shard, or legacy schema cannot answer manifest-backed reads. Status stays
+  // recoverable and sends each of those states through the existing compile
+  // action instead of throwing.
+  const manifestExists = readableManifest(workspace.manifestPath);
   const nextAction =
     stories.length === 0
       ? "Connect the MCP template, then invoke the `tieline_author` prompt (or use the bundled /tieline-author skill) to onboard the first Story and AC."

--- a/src/tools/path-criteria.ts
+++ b/src/tools/path-criteria.ts
@@ -26,7 +26,7 @@ const DESCRIPTION = `Deterministically list every Acceptance Criterion recorded 
 
 This answers "what is true": the accepted contract records that link these exact paths. Each result carries link_scope "direct" when the link is on the Acceptance Criterion itself and "story_fallback" when it is only on the owning Story. Use search_knowledge instead to answer "what is related": that tool ranks semantically related records and treats a path as a relevance signal, not an exact lookup key.
 
-Ask this before editing a file. A path with criteria returns has_criteria, an existing path with no contract link returns no_criteria, and a path that does not exist returns not_found. The manifest commit is returned so the caller knows which repository state answered.`;
+Ask this before editing a file. A path with criteria returns has_criteria, an existing path with no contract link returns no_criteria, and a path that does not exist returns not_found. A content-derived manifest_digest identifies the complete reviewed manifest that answered without coupling it to a Git commit.`;
 
 export type PathCriteriaResolution =
   | { status: "resolved"; report: PathCriteriaReport }
@@ -108,11 +108,7 @@ export function registerGetPathCriteria(server: McpServer): void {
         const { report } = resolved;
         const note = negativeResultNote(report);
         return jsonResult({
-          repository: report.repository,
-          has_criteria_paths: report.has_criteria_paths,
-          no_criteria_paths: report.no_criteria_paths,
-          not_found_paths: report.not_found_paths,
-          results: report.results,
+          ...report,
           ...(note ? { note } : {}),
         });
       } catch (error) {


### PR DESCRIPTION
## Summary

Continues the contract-integrity work after link provenance landed in #19. Compiled manifests no longer change only because `HEAD` changes, which removes the shared index conflict and the stale commit recorded as soon as that index was committed.

Reviewed contract content now has a content-derived `manifest_digest`. Git revision remains runtime provenance and enters only when `contract sync` projects the reviewed manifest into Postgres.

## Design decisions

- Manifest schema v2 keeps only the stable repository key in `index.json`. Compilation is now independent of Git.
- `contract sync` accepts an explicit `--commit` or derives `HEAD`, then uses that value for projection rows, checkpoint guards, results, retirements, and audit events.
- Exact path reads return the digest of the complete reviewed manifest, including capabilities unrelated to the requested path.
- `tieline status` treats legacy or unreadable manifests as unavailable and directs the user to recompile.
- Normal Git merging replaces the previous `.gitattributes -merge` rule.

## Compatibility

This is an intentional manifest/API version boundary with no database migration:

- Recompile schema-v1 manifests with `tieline contract compile .`.
- Remove `--commit` from `contract compile` automation; `contract sync --commit` remains supported.
- Read `manifest_digest` instead of `get_path_criteria.repository.commit` when attributing exact reads.

## Validation

- Contract validation: 15 Stories, 38 Acceptance Criteria, 0 warnings.
- Contract and manifest suites: 22 contract checks and 17 manifest checks, plus command, impact, plausibility, reconciliation, path-criteria, grading, contract-read, workspace/status, and baseline tests.
- Build and tracked-manifest freshness checks pass against `origin/main`; no broken links or unclaimed changes.
- Disposable Postgres integration proves explicit and Git-derived CLI commits reach sync results, projection records, checkpoints, retirements, and audit events. Empty commits are rejected at both sync boundaries.

## New concepts

### Reviewed content identity vs runtime provenance

These values answer different questions:

| Value | Question | Lifetime |
|---|---|---|
| `manifest_digest` | Which complete reviewed contract answered? | Stable while reviewed content is unchanged |
| sync commit | Which repository revision was projected? | Specific to one runtime synchronization |

Persisting the commit in the reviewed index mixed these lifetimes and made every branch edit the same generated file. This split is useful for immutable reviewed artifacts with deployment checkpoints. It is not a reason to replace operational revision guards with content hashes.

## Post-Deploy Monitoring & Validation

- Search logs and audit data for `repository_contract_synced`, `Repository sync commit cannot be empty`, and unreadable manifest/schema-version errors.
- Confirm each deployment's `repository_sync_checkpoints.commit_sha` and latest sync audit `detail.commit` match the deployed Git SHA.
- Healthy signals: syncs complete, exact reads return 64-character digests, and no workspace remains on a legacy manifest after recompilation.
- Failure signals: checkpoint/audit commit mismatch, repeated v1 manifest errors, or path reads missing `manifest_digest`.
- Rollback trigger: any projection provenance mismatch or client incompatibility that cannot be corrected by recompilation. Revert this PR and regenerate schema-v1 manifests with the reverted compiler.
- Validation window and owner: first deployment plus 24 hours, owned by Tieline maintainers.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
