### PR TITLE
fix(matching): admit strong lexical-only candidates

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -39,3 +39,4 @@ jobs:
           npx tsx scripts/test-contract-command.ts
           npx tsx scripts/test-impact.ts
           npx tsx scripts/test-grade.ts
+          npx tsx scripts/test-ranking.ts

--- a/.tieline/manifest/MATCHING.json
+++ b/.tieline/manifest/MATCHING.json
@@ -112,7 +112,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "5ced89ffc9675ef3210532f5cf0d72c768b64abe9f6c9d2b5c6d1a2d0f1f5a64",
+                "reviewed_content_hash": "53c35cd5b09b6f63a9ad5e2a8a018664427bf1ff1c5333c63fe851df515a417d",
                 "target": {
                   "kind": "code",
                   "path": "src/ranking.ts",
@@ -186,7 +186,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "f73ab70075032befa93734f30d0cbb2834d38752e9ce695436059ad22ddd0f97",
+                "reviewed_content_hash": "1c04f923b3e18cec73ec907ff2035d147b7574c66bb40ca9e5e8c0b18e935934",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -225,7 +225,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "286a32fce01b3ed27e560044ba75254decf897a2174ceeafcb5d72c89f263a31",
+                "reviewed_content_hash": "e3170f9d59b0083c35cb98ba4a198b52e869193293b310dab6f73e08d3f9fc9c",
                 "target": {
                   "kind": "code",
                   "path": "src/backlog-advisor.ts",
@@ -235,7 +235,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "adf23ebbe927ba6534bae791fd0de53a72a7996b8062a0bc647f00d699425595",
+                "reviewed_content_hash": "d4bd121c8a2453b2a7af26fc7920b92a6700ce26a2e1b8c12c6320dd244d586f",
                 "target": {
                   "kind": "code",
                   "path": "src/semantic-matching.ts",
@@ -281,13 +281,13 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "530c08f62c7123434e60b7d4d00f263a57c51a8bc1d24c82ecba53ab7b8d742f",
-            "criterion": "Tieline must withhold a semantic candidate whose vector, lexical, and alias signals all fall below an absolute magnitude floor, even when its blended rank-fusion score clears the presentation cutoff.",
+            "contract_hash": "ede5008a2c6ef59efd490bec06fa205926e3041bf4233c2b26ea562f0c9e40ae",
+            "criterion": "Tieline must use absolute vector, lexical, or exact-alias magnitude to decide whether a semantic candidate is admitted, and must use the blended rank-fusion score only to order admitted candidates.",
             "links": [
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "5ced89ffc9675ef3210532f5cf0d72c768b64abe9f6c9d2b5c6d1a2d0f1f5a64",
+                "reviewed_content_hash": "53c35cd5b09b6f63a9ad5e2a8a018664427bf1ff1c5333c63fe851df515a417d",
                 "target": {
                   "kind": "code",
                   "path": "src/ranking.ts",
@@ -297,7 +297,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "adf23ebbe927ba6534bae791fd0de53a72a7996b8062a0bc647f00d699425595",
+                "reviewed_content_hash": "d4bd121c8a2453b2a7af26fc7920b92a6700ce26a2e1b8c12c6320dd244d586f",
                 "target": {
                   "kind": "code",
                   "path": "src/semantic-matching.ts",
@@ -307,7 +307,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "f73ab70075032befa93734f30d0cbb2834d38752e9ce695436059ad22ddd0f97",
+                "reviewed_content_hash": "1c04f923b3e18cec73ec907ff2035d147b7574c66bb40ca9e5e8c0b18e935934",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -317,19 +317,26 @@
               }
             ],
             "position": 3,
-            "rationale": "The blended score is mostly reciprocal rank fusion, which measures a candidate's position inside the returned set rather than how well it matches, so the best member of a weak set scores almost exactly what the best member of a strong set scores. Only a floor on the raw comparable signals stops the least wrong available option from reading as a good match to a caller acting without human review.",
+            "rationale": "The blended score is mostly reciprocal rank fusion, which measures a candidate's position inside the returned set rather than how well it matches. A fixed blended-score cutoff both suppresses credible lexical-only candidates when embeddings are unavailable and can admit the least wrong member of a weak set. Raw comparable signals answer whether a candidate is credible; rank fusion answers which credible candidate should appear first.",
             "scenarios": [
               {
                 "given": "the only retrieved candidate carries 0.30 vector similarity and 0.20 lexical similarity",
                 "position": 0,
                 "stable_id": "MATCHING-001-AC4-S1",
-                "then": "the candidate must be withheld even though its blended score clears the presentation cutoff",
+                "then": "the candidate must be withheld even when its blended score ranks first",
+                "when": "Tieline assembles Observation match candidates or planning-create advice"
+              },
+              {
+                "given": "no embedding is available and a candidate carries lexical similarity above the absolute magnitude floor",
+                "position": 1,
+                "stable_id": "MATCHING-001-AC4-S2",
+                "then": "the candidate must be retained and its blended score must affect only its order among other admitted candidates",
                 "when": "Tieline assembles Observation match candidates or planning-create advice"
               },
               {
                 "given": "a candidate matches a recorded alias exactly but carries low vector and lexical similarity",
-                "position": 1,
-                "stable_id": "MATCHING-001-AC4-S2",
+                "position": 2,
+                "stable_id": "MATCHING-001-AC4-S3",
                 "then": "the candidate must be retained because an exact alias match is a deterministic identifier match rather than a fuzzy one",
                 "when": "Tieline applies the magnitude floor"
               }
@@ -360,6 +367,6 @@
   },
   "input": {
     "path": ".tieline/spec/matching.yaml",
-    "sha256": "84fcb2866f1fdfa8d93bed0850332f6f1583ea15e69e97bcd2aa9c2393d3436d"
+    "sha256": "351a98fc9ea9f7c6ee1167858e7e0397ec1df18a562b426d4d003b4e96fdf737"
   }
 }

--- a/.tieline/spec/matching.yaml
+++ b/.tieline/spec/matching.yaml
@@ -163,12 +163,15 @@ capability:
                 path: scripts/integration-evidence.ts
                 framework_hint: custom-script
         - key: MATCHING-001-AC4
-          criterion: Tieline must withhold a semantic candidate whose vector, lexical, and alias signals all fall below an absolute magnitude floor, even when its blended rank-fusion score clears the presentation cutoff.
-          rationale: The blended score is mostly reciprocal rank fusion, which measures a candidate's position inside the returned set rather than how well it matches, so the best member of a weak set scores almost exactly what the best member of a strong set scores. Only a floor on the raw comparable signals stops the least wrong available option from reading as a good match to a caller acting without human review.
+          criterion: Tieline must use absolute vector, lexical, or exact-alias magnitude to decide whether a semantic candidate is admitted, and must use the blended rank-fusion score only to order admitted candidates.
+          rationale: The blended score is mostly reciprocal rank fusion, which measures a candidate's position inside the returned set rather than how well it matches. A fixed blended-score cutoff both suppresses credible lexical-only candidates when embeddings are unavailable and can admit the least wrong member of a weak set. Raw comparable signals answer whether a candidate is credible; rank fusion answers which credible candidate should appear first.
           scenarios:
             - given: the only retrieved candidate carries 0.30 vector similarity and 0.20 lexical similarity
               when: Tieline assembles Observation match candidates or planning-create advice
-              then: the candidate must be withheld even though its blended score clears the presentation cutoff
+              then: the candidate must be withheld even when its blended score ranks first
+            - given: no embedding is available and a candidate carries lexical similarity above the absolute magnitude floor
+              when: Tieline assembles Observation match candidates or planning-create advice
+              then: the candidate must be retained and its blended score must affect only its order among other admitted candidates
             - given: a candidate matches a recorded alias exactly but carries low vector and lexical similarity
               when: Tieline applies the magnitude floor
               then: the candidate must be retained because an exact alias match is a deterministic identifier match rather than a fuzzy one

--- a/README.md
+++ b/README.md
@@ -219,7 +219,10 @@ planning writes are configured. Tool calls remain the operational check.
 
 Before creating planning work, machine matching searches existing Stories, ACs,
 Backlog Items, and similar Observations. It presents candidates and requires an
-explicit reuse-or-continue choice. Similarity never confirms a relationship.
+explicit reuse-or-continue choice. Each candidate reports its raw ranking
+features and the `admitted_by` signals that cleared the absolute magnitude
+floor; the blended score only orders admitted candidates. Similarity never
+confirms a relationship.
 Raw Observations remain append-only even when duplicate language is consolidated.
 In offline mode, authoring searches local YAML and the compiled manifest and
 explicitly reports that organization-wide duplicate checking was unavailable.
@@ -465,7 +468,10 @@ paths, selectors, and external help identifiers that stemming handles poorly.
 Vector similarity is added when an embedding provider is available. Reciprocal
 rank fusion combines the available lexical and vector rankings with exact alias,
 artifact-overlap, and confirmed graph-proximity signals, so a missing embedding
-backend does not turn search into an error.
+backend does not turn search into an error. Absolute vector, lexical, or exact
+alias magnitude determines whether a candidate is credible enough to present;
+the blended rank-fusion score orders those admitted candidates but does not
+filter them through a second fixed cutoff.
 
 Graph proximity traverses structural links, repository-declared relationships,
 and confirmed attributions up to three hops. The graph feature decays from

--- a/scripts/test-ranking.ts
+++ b/scripts/test-ranking.ts
@@ -6,9 +6,17 @@ import {
   rankSemanticDocuments,
 } from "../src/ranking.js";
 import {
-  SEMANTIC_MATCH_SCORE_FLOOR,
+  DefaultSemanticMatcher,
+  installSemanticAdvisors,
   isPresentableSemanticMatch,
+  setSemanticMatcher,
+  type SemanticMatcherRepository,
 } from "../src/semantic-matching.js";
+import {
+  adviseBacklogCreate,
+  setBacklogCreateAdvisor,
+} from "../src/backlog-advisor.js";
+import { getEmbedder, setEmbedder } from "../src/embeddings.js";
 import { narrowSemanticFilters } from "../src/adapters/postgres/semantic-repository.js";
 import { parseRetrievalProfileDefinition } from "../src/adapters/postgres/profile-repository.js";
 import {
@@ -20,6 +28,15 @@ import {
 let passed = 0;
 function test(name: string, run: () => void): void {
   run();
+  passed += 1;
+  console.log(`  ok  - ${name}`);
+}
+
+async function asyncTest(
+  name: string,
+  run: () => Promise<void>
+): Promise<void> {
+  await run();
   passed += 1;
   console.log(`  ok  - ${name}`);
 }
@@ -137,6 +154,179 @@ test("lexical-only candidates remain useful without an embedding", () => {
   assert.match(ranked[0]?.why.join(" ") ?? "", /lexical/i);
 });
 
+await asyncTest(
+  "planning advice admits a strong lexical-only candidate without an embedding",
+  async () => {
+    const previousEmbedder = getEmbedder();
+    try {
+      setEmbedder({
+        provider: "hash",
+        dim: 384,
+        async embed() {
+          throw new Error("embedding unavailable");
+        },
+      });
+      const repository: SemanticMatcherRepository = {
+        async resolveRetrievalProfile() {
+          return { key: "discovery", version: 1, definition: {} };
+        },
+        async searchSemantic(input) {
+          assert.equal(input.embedding, undefined);
+          return [
+            {
+              document_id: "lexical",
+              entity_kind: "acceptance_criterion",
+              entity_id: "ac-lexical",
+              canonical_text: "identifier-only match",
+              matched_level: "acceptance_criterion",
+              acceptance_criterion_id: "ac-lexical",
+              vector_score: 0,
+              lexical_score: 0.8,
+              alias_match: false,
+              artifact_overlap: 0,
+              graph_proximity: 0,
+              applicable: true,
+              metadata: {},
+            },
+          ];
+        },
+        async upsertEmbeddingDocument() {
+          throw new Error("not used by planning advice");
+        },
+        async saveAttributionSuggestion() {
+          throw new Error("not used by planning advice");
+        },
+      };
+      const matcher = new DefaultSemanticMatcher(repository);
+
+      const candidates = await matcher.advisePlanningCreate({
+        title: "Identifier-only match",
+        summary: "Find the acceptance criterion through full-text search.",
+      });
+
+      assert.equal(candidates.length, 1);
+      assert.equal(candidates[0]?.target_id, "ac-lexical");
+      assert.equal(candidates[0]?.features.vector, 0);
+      assert.deepEqual(candidates[0]?.admitted_by, ["lexical"]);
+
+      setSemanticMatcher(matcher);
+      installSemanticAdvisors();
+      const advice = await adviseBacklogCreate({
+        title: "Identifier-only match",
+        summary: "Find the acceptance criterion through full-text search.",
+      });
+      assert.deepEqual(advice?.candidates[0]?.admitted_by, ["lexical"]);
+      assert.equal(advice?.candidates[0]?.features.lexical, 0.8);
+      assert.match(advice?.candidates[0]?.reason ?? "", /admitted by lexical/);
+    } finally {
+      setBacklogCreateAdvisor(null);
+      setSemanticMatcher(null);
+      setEmbedder(previousEmbedder);
+    }
+  }
+);
+
+await asyncTest(
+  "an admissible lexical sibling survives same-criterion grouping",
+  async () => {
+    const previousEmbedder = getEmbedder();
+    try {
+      setEmbedder({
+        provider: "hash",
+        dim: 384,
+        async embed() {
+          return new Array<number>(384).fill(0);
+        },
+      });
+      const repository: SemanticMatcherRepository = {
+        async resolveRetrievalProfile() {
+          return { key: "discovery", version: 1, definition: {} };
+        },
+        async searchSemantic(input) {
+          assert.equal(input.embedding?.length, 384);
+          return [
+            {
+              document_id: "weak-scenario",
+              entity_kind: "scenario",
+              entity_id: "scenario-weak",
+              canonical_text: "two weak ranking signals",
+              matched_level: "scenario",
+              acceptance_criterion_id: "ac-shared",
+              acceptance_criterion_stable_id: "MATCHING-001-AC4",
+              vector_score: 0.49,
+              lexical_score: 0.49,
+              alias_match: false,
+              artifact_overlap: 0,
+              graph_proximity: 0,
+              applicable: true,
+              metadata: {},
+            },
+            {
+              document_id: "strong-criterion",
+              entity_kind: "acceptance_criterion",
+              entity_id: "ac-shared",
+              canonical_text: "strong full-text match",
+              matched_level: "acceptance_criterion",
+              acceptance_criterion_id: "ac-shared",
+              acceptance_criterion_stable_id: "MATCHING-001-AC4",
+              vector_score: 0,
+              lexical_score: 0.8,
+              alias_match: false,
+              artifact_overlap: 0,
+              graph_proximity: 0,
+              applicable: true,
+              metadata: {},
+            },
+          ];
+        },
+        async upsertEmbeddingDocument(document) {
+          return {
+            embedded: false,
+            document_id: `${document.entity_kind}:${document.entity_id}`,
+            embedding_status: "unavailable",
+          };
+        },
+        async saveAttributionSuggestion(input) {
+          return {
+            id: `suggestion:${input.target_id}`,
+            source_kind: input.source_kind,
+            source_id: input.source_id,
+            target_kind: input.target_kind,
+            target_id: input.target_id,
+            state: input.state,
+            method: input.method,
+            score: input.score ?? null,
+            rationale: input.rationale ?? {},
+          };
+        },
+      };
+      const matcher = new DefaultSemanticMatcher(repository);
+
+      const matches = await matcher.matchObservation({
+        id: "observation-1",
+        kind: "request",
+        schema_key: "request",
+        schema_version: 1,
+        summary: "Find the acceptance criterion through full-text search.",
+        source: "test",
+        external_id: null,
+        external_url: null,
+        observed_at: "2026-08-05T00:00:00.000Z",
+        recorded_at: "2026-08-05T00:00:00.000Z",
+        search_text: "strong full-text match",
+        supersedes_observation_id: null,
+        outcome: "created",
+      });
+
+      assert.equal(matches.length, 1);
+      assert.equal(matches[0]?.target_id, "ac-shared");
+      assert.equal(matches[0]?.features.lexical, 0.8);
+    } finally {
+      setEmbedder(previousEmbedder);
+    }
+  }
+);
+
 test("Scenario and AC hits collapse around the same AC", () => {
   const grouped = groupSemanticHitsAroundAcceptanceCriteria(
     rankSemanticDocuments([
@@ -168,7 +358,7 @@ test("Scenario and AC hits collapse around the same AC", () => {
   assert.equal(grouped[0]?.matched_level, "scenario");
 });
 
-test("a weak candidate alone is withheld despite clearing the blended cutoff", () => {
+test("a weak top-ranked candidate is withheld by raw magnitude", () => {
   const [weak] = rankSemanticDocuments([
     {
       document_id: "weak",
@@ -182,8 +372,6 @@ test("a weak candidate alone is withheld despite clearing the blended cutoff", (
       metadata: {},
     },
   ]);
-  // Rank fusion cannot see that this is the only, and a poor, option.
-  assert.ok((weak?.score ?? 0) >= SEMANTIC_MATCH_SCORE_FLOOR);
   assert.equal(clearsSemanticMagnitudeFloor(weak!.features), false);
   assert.equal(isPresentableSemanticMatch(weak!), false);
 });
@@ -230,13 +418,9 @@ test("a weak candidate stays withheld when ranked behind stronger ones", () => {
     presentable.map((hit) => hit.document_id),
     ["strong-a", "strong-b"]
   );
-  assert.ok(
-    ranked.find((hit) => hit.document_id === "weak")!.score >=
-      SEMANTIC_MATCH_SCORE_FLOOR
-  );
 });
 
-test("a strong candidate clears both admission gates", () => {
+test("a strong candidate clears raw-magnitude admission", () => {
   const [strong] = rankSemanticDocuments([
     {
       document_id: "strong",

--- a/src/backlog-advisor.ts
+++ b/src/backlog-advisor.ts
@@ -1,3 +1,8 @@
+import type {
+  SemanticAdmissionSignal,
+  SemanticRankingFeatures,
+} from "./ranking.js";
+
 export interface BacklogCandidate {
   suggestion_id: string;
   target_kind:
@@ -8,6 +13,8 @@ export interface BacklogCandidate {
   target_stable_id: string;
   repository?: string;
   score: number;
+  features: SemanticRankingFeatures;
+  admitted_by: SemanticAdmissionSignal[];
   reason: string;
 }
 

--- a/src/ranking.ts
+++ b/src/ranking.ts
@@ -172,6 +172,25 @@ export const SEMANTIC_MAGNITUDE_FLOOR = {
   lexical: 0.5,
 } as const;
 
+export type SemanticAdmissionSignal =
+  | "exact_alias"
+  | "vector"
+  | "lexical";
+
+export function semanticAdmissionSignals(
+  features: Pick<SemanticRankingFeatures, "vector" | "lexical" | "alias">
+): SemanticAdmissionSignal[] {
+  const signals: SemanticAdmissionSignal[] = [];
+  if (features.alias === 1) signals.push("exact_alias");
+  if (features.vector >= SEMANTIC_MAGNITUDE_FLOOR.vector) {
+    signals.push("vector");
+  }
+  if (features.lexical >= SEMANTIC_MAGNITUDE_FLOOR.lexical) {
+    signals.push("lexical");
+  }
+  return signals;
+}
+
 /**
  * True when a ranked candidate is strong enough on its own terms, independent of
  * how the rest of the result set happened to score.
@@ -184,14 +203,7 @@ export const SEMANTIC_MAGNITUDE_FLOOR = {
 export function clearsSemanticMagnitudeFloor(
   features: Pick<SemanticRankingFeatures, "vector" | "lexical" | "alias">
 ): boolean {
-  // An exact alias match is a deterministic identifier match, not a fuzzy one.
-  // Someone recorded that phrasing as naming this record, so it always survives
-  // however weak the similarity signals happen to be.
-  if (features.alias === 1) return true;
-  return (
-    features.vector >= SEMANTIC_MAGNITUDE_FLOOR.vector ||
-    features.lexical >= SEMANTIC_MAGNITUDE_FLOOR.lexical
-  );
+  return semanticAdmissionSignals(features).length > 0;
 }
 
 export function groupSemanticHitsAroundAcceptanceCriteria(

--- a/src/semantic-matching.ts
+++ b/src/semantic-matching.ts
@@ -14,6 +14,9 @@ import type {
 import type { ContractStoryRecord } from "./domain/contract-read-store.js";
 import type {
   AttributionSuggestionRecord,
+  AttributionSuggestionStore,
+  DerivedDocumentStore,
+  SemanticSearchStore,
   SemanticSearchFilters,
 } from "./domain/semantic-search-store.js";
 import {
@@ -24,7 +27,9 @@ import {
   clearsSemanticMagnitudeFloor,
   groupSemanticHitsAroundAcceptanceCriteria,
   rankSemanticDocuments,
+  semanticAdmissionSignals,
   type RankedSemanticDocument,
+  type SemanticAdmissionSignal,
   type SemanticRankingFeatures,
 } from "./ranking.js";
 
@@ -40,6 +45,7 @@ export interface MatchCandidate {
   score: number;
   method: string;
   features: SemanticRankingFeatures;
+  admitted_by: SemanticAdmissionSignal[];
 }
 
 export interface SemanticMatcher {
@@ -52,6 +58,12 @@ export interface SemanticMatcher {
   }): Promise<MatchCandidate[]>;
   indexBacklogItem(item: BacklogItemRecord): Promise<void>;
   indexPlanningStory(story: ContractStoryRecord): Promise<void>;
+}
+
+export interface SemanticMatcherRepository
+  extends SemanticSearchStore,
+    DerivedDocumentStore {
+  saveAttributionSuggestion: AttributionSuggestionStore["saveAttributionSuggestion"];
 }
 
 function candidateStableId(
@@ -72,37 +84,20 @@ function candidateStableId(
 }
 
 /**
- * Blended-score cutoff. Kept because the blended score is the correct ORDERING
- * signal — it is what decides which candidate is better than which.
- */
-export const SEMANTIC_MATCH_SCORE_FLOOR = 0.45;
-
-/**
- * Both gates must pass before a candidate is shown to a caller.
- *
- * The blended score answers "was this the best available?" — it is 65%
- * reciprocal rank fusion, which measures rank position rather than match
- * magnitude, so on its own it cannot tell a good match from the least wrong
- * option in a bad set (see SEMANTIC_MAGNITUDE_FLOOR). The magnitude floor
- * answers "was this actually good?" by reading the raw 0..1 similarity features,
- * which mean the same thing regardless of what else was retrieved.
- *
- * These candidates increasingly drive agent behavior rather than human review,
- * so "best of a bad set" must not reach a caller reading as "good". Prefer
- * returning nothing over returning a plausible wrong answer.
+ * Admission is based only on absolute signal magnitude. The blended score is a
+ * reciprocal-rank-fusion ordering signal, so applying a fixed cutoff to it would
+ * suppress strong lexical-only candidates while still admitting the top member
+ * of some weak result sets.
  */
 export function isPresentableSemanticMatch(
   hit: RankedSemanticDocument
 ): boolean {
-  return (
-    hit.score >= SEMANTIC_MATCH_SCORE_FLOOR &&
-    clearsSemanticMagnitudeFloor(hit.features)
-  );
+  return clearsSemanticMagnitudeFloor(hit.features);
 }
 
 export class DefaultSemanticMatcher implements SemanticMatcher {
   constructor(
-    private readonly repository = new PostgresSemanticRepository(
+    private readonly repository: SemanticMatcherRepository = new PostgresSemanticRepository(
       getWriteSql,
       getEmbedder
     )
@@ -125,8 +120,8 @@ export class DefaultSemanticMatcher implements SemanticMatcher {
     // Shared by matchObservation and advisePlanningCreate so both paths apply the
     // same admission rule.
     return groupSemanticHitsAroundAcceptanceCriteria(
-      rankSemanticDocuments(rows)
-    ).filter(isPresentableSemanticMatch);
+      rankSemanticDocuments(rows).filter(isPresentableSemanticMatch)
+    );
   }
 
   async matchObservation(
@@ -181,6 +176,7 @@ export class DefaultSemanticMatcher implements SemanticMatcher {
       score: hit.score,
       method: "semantic_similarity",
       features: hit.features,
+      admitted_by: semanticAdmissionSignals(hit.features),
     }));
   }
 
@@ -214,6 +210,7 @@ export class DefaultSemanticMatcher implements SemanticMatcher {
       score: hit.score,
       method: "semantic_similarity",
       features: hit.features,
+      admitted_by: semanticAdmissionSignals(hit.features),
     }));
   }
 
@@ -260,7 +257,11 @@ export function installSemanticAdvisors(): void {
             candidate.target_id,
           repository: candidate.repository,
           score: candidate.score,
-          reason: `${candidate.matched_level} match via ${candidate.method}`,
+          features: candidate.features,
+          admitted_by: candidate.admitted_by,
+          reason:
+            `${candidate.matched_level} match admitted by ` +
+            `${candidate.admitted_by.join(" + ")}; blended score orders admitted matches`,
         })),
         require_explicit_continue: true,
       };


### PR DESCRIPTION
## Summary

Closes the final open contract-integrity handoff decision after path criteria, grading, link provenance, and manifest identity fixes landed. Observation matching and planning-create advice now retain credible full-text or identifier matches when embeddings are unavailable. Raw vector, lexical, or exact-alias magnitude decides admission; the blended rank-fusion score only orders admitted candidates, so weak best-of-a-bad-set results remain hidden.

Admission now happens before same-criterion grouping, which prevents a higher-ranked weak Scenario from hiding a credible AC sibling. Agent-facing backlog advice also reports raw ranking features and explicit `admitted_by` signals so callers can understand why a candidate was shown.

## Validation

- `npm run test:ranking` - 16 passed, including no-embedding lexical admission and same-AC sibling grouping.
- `npm run test:contract` - all contract, manifest, impact, reconciliation, path-criteria, and grading suites passed.
- `npm run test:embeddings` - 19 passed.
- `npm run test:evidence`, `npm run test:smoke`, `npm run test:http`, `npm run test:contract-read`, `npm run test:baseline`, and `npm run test:tieline` passed.
- `contract validate`, `contract compile`, and `check --base origin/main` passed with a current manifest, no broken links, and no unclaimed changes.
- PostgreSQL baseline integration was not run because `DATABASE_URL_ADMIN` is unavailable in this workspace; the changed matcher path is covered offline with an injected repository.

## Post-Deploy Monitoring & Validation

- Window and owner: maintainers review matcher behavior for the first 7 days after release.
- Monitor: candidate counts and no-match rates for `record_observation`, `create_planning_story`, and `create_backlog_item`; inspect lexical-only results when embedding calls fail.
- Healthy: lexical-only candidates appear when embeddings are unavailable, weak candidates remain absent, and reuse selections do not show an increase in false matches.
- Failure signal: a sustained candidate-volume spike, weak-signal candidates reaching match review, or an increase in incorrect reuse selections.
- Rollback: revert this PR to restore the blended-score presentation cutoff while preserving the existing raw magnitude floor.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
