### PR TITLE
feat(init): hand semantic onboarding to coding agents

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -40,3 +40,6 @@ jobs:
           npx tsx scripts/test-impact.ts
           npx tsx scripts/test-grade.ts
           npx tsx scripts/test-ranking.ts
+
+      - name: Workspace onboarding tests
+        run: npm run test:tieline

--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -352,7 +352,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "7f4c267a3f6f579c0f58039402379667446dd9c80248e24a2cd3f122e2f15e79",
+                "reviewed_content_hash": "28232652dc138bbfdc4536db5453eec08c7842bdf3b50ca2b15b1f84ffeb46ce",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -566,7 +566,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "7f4c267a3f6f579c0f58039402379667446dd9c80248e24a2cd3f122e2f15e79",
+                "reviewed_content_hash": "28232652dc138bbfdc4536db5453eec08c7842bdf3b50ca2b15b1f84ffeb46ce",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -636,7 +636,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "1b762f556bad084ab381140f935c7ea06ead122d4881fca21c3d516c491f9882",
+                "reviewed_content_hash": "f211e32e32f7418500e42526c18c732590d739998a48933c0657f9c0406b9907",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -700,7 +700,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "bc1161a68f6d969f1228e0bdb4770a36566ed83cebffee7f7bcf56a81f60a4c6",
+                "reviewed_content_hash": "477686c481a5a8b7bbf2181da2ca8b63157cfb9e14624ca1a4e5681756010159",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -765,7 +765,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "7f4c267a3f6f579c0f58039402379667446dd9c80248e24a2cd3f122e2f15e79",
+                "reviewed_content_hash": "28232652dc138bbfdc4536db5453eec08c7842bdf3b50ca2b15b1f84ffeb46ce",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",

--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -636,7 +636,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "f211e32e32f7418500e42526c18c732590d739998a48933c0657f9c0406b9907",
+                "reviewed_content_hash": "ce723821ad57588ee22487bc80d400e71707a7d2d2d07b8c8e12167f7a311b5e",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -700,7 +700,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "477686c481a5a8b7bbf2181da2ca8b63157cfb9e14624ca1a4e5681756010159",
+                "reviewed_content_hash": "131e0a45a2101d224947d26ec4da54d38392b16d115d20722110b300da046c41",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/GRADING.json
+++ b/.tieline/manifest/GRADING.json
@@ -150,7 +150,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "7f4c267a3f6f579c0f58039402379667446dd9c80248e24a2cd3f122e2f15e79",
+                "reviewed_content_hash": "28232652dc138bbfdc4536db5453eec08c7842bdf3b50ca2b15b1f84ffeb46ce",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",

--- a/.tieline/manifest/RETRIEVAL.json
+++ b/.tieline/manifest/RETRIEVAL.json
@@ -129,7 +129,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "dde55e5cdad297b87f27f86cabe62d90838b07e9b5b594aba168ea28f031a677",
+                "reviewed_content_hash": "7f05a15a496aad3502029e5dae59a90ee0790dd9f3a8a06be64c6c06b89c1f11",
                 "target": {
                   "kind": "code",
                   "path": "src/resources.ts",

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -18,7 +18,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "7f4c267a3f6f579c0f58039402379667446dd9c80248e24a2cd3f122e2f15e79",
+                "reviewed_content_hash": "28232652dc138bbfdc4536db5453eec08c7842bdf3b50ca2b15b1f84ffeb46ce",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -38,7 +38,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "1b762f556bad084ab381140f935c7ea06ead122d4881fca21c3d516c491f9882",
+                "reviewed_content_hash": "f211e32e32f7418500e42526c18c732590d739998a48933c0657f9c0406b9907",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -58,7 +58,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "bc1161a68f6d969f1228e0bdb4770a36566ed83cebffee7f7bcf56a81f60a4c6",
+                "reviewed_content_hash": "477686c481a5a8b7bbf2181da2ca8b63157cfb9e14624ca1a4e5681756010159",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -102,7 +102,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "1b762f556bad084ab381140f935c7ea06ead122d4881fca21c3d516c491f9882",
+                "reviewed_content_hash": "f211e32e32f7418500e42526c18c732590d739998a48933c0657f9c0406b9907",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -112,7 +112,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "bc1161a68f6d969f1228e0bdb4770a36566ed83cebffee7f7bcf56a81f60a4c6",
+                "reviewed_content_hash": "477686c481a5a8b7bbf2181da2ca8b63157cfb9e14624ca1a4e5681756010159",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -130,13 +130,23 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "7a48cb595945ad2f25ff5740b143f657877eb11de5154e2ad39d123932c53c72",
-            "criterion": "Tieline must surface detected source roots and preflight warnings while leaving the specification empty until repository-specific semantic onboarding.",
+            "contract_hash": "507e92cdc113aa316bb916b586e4ac150c3b51482feaf1ba9967af59953207f2",
+            "criterion": "Tieline must surface detected source roots and preflight warnings, leave the specification empty until repository-specific semantic onboarding, and end initialization with a copyable, self-contained prompt that hands that onboarding to an agent.",
             "links": [
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "7f4c267a3f6f579c0f58039402379667446dd9c80248e24a2cd3f122e2f15e79",
+                "reviewed_content_hash": "7965b76ff44651cad97f0d2ad685382fe5944ae81736069f941e6960988881ff",
+                "target": {
+                  "kind": "code",
+                  "path": "skills/tieline-author/SKILL.md",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "28232652dc138bbfdc4536db5453eec08c7842bdf3b50ca2b15b1f84ffeb46ce",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -155,8 +165,18 @@
               },
               {
                 "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "f211e32e32f7418500e42526c18c732590d739998a48933c0657f9c0406b9907",
+                "target": {
+                  "kind": "code",
+                  "path": "src/tieline/status.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "bc1161a68f6d969f1228e0bdb4770a36566ed83cebffee7f7bcf56a81f60a4c6",
+                "reviewed_content_hash": "477686c481a5a8b7bbf2181da2ca8b63157cfb9e14624ca1a4e5681756010159",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -166,7 +186,7 @@
               }
             ],
             "position": 2,
-            "rationale": null,
+            "rationale": "Deterministic setup belongs in the CLI, while interpreting repository context and proposing semantic boundaries belongs with an agent and normal pull-request review.",
             "scenarios": [],
             "stable_id": "RUNTIME-001-AC3",
             "supersedes": null
@@ -399,7 +419,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "84b74d5650baad503a10fb6d223e1186a015daf6af9ccb9a4e7a707043c7dfeb",
+                "reviewed_content_hash": "7965b76ff44651cad97f0d2ad685382fe5944ae81736069f941e6960988881ff",
                 "target": {
                   "kind": "code",
                   "path": "skills/tieline-author/SKILL.md",
@@ -440,7 +460,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "bc1161a68f6d969f1228e0bdb4770a36566ed83cebffee7f7bcf56a81f60a4c6",
+                "reviewed_content_hash": "477686c481a5a8b7bbf2181da2ca8b63157cfb9e14624ca1a4e5681756010159",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -527,6 +547,6 @@
   },
   "input": {
     "path": ".tieline/spec/runtime.yaml",
-    "sha256": "e3fd93045805b511324228a7fccd8bae26a1c63f1f06f8737b3570adabb5f53d"
+    "sha256": "6e3d178d2cd7b512c455cb9d3c5cf3930c11be8c6683c95ad1f3c906284286bb"
   }
 }

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -38,7 +38,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "f211e32e32f7418500e42526c18c732590d739998a48933c0657f9c0406b9907",
+                "reviewed_content_hash": "ce723821ad57588ee22487bc80d400e71707a7d2d2d07b8c8e12167f7a311b5e",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -58,7 +58,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "477686c481a5a8b7bbf2181da2ca8b63157cfb9e14624ca1a4e5681756010159",
+                "reviewed_content_hash": "131e0a45a2101d224947d26ec4da54d38392b16d115d20722110b300da046c41",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -102,7 +102,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "f211e32e32f7418500e42526c18c732590d739998a48933c0657f9c0406b9907",
+                "reviewed_content_hash": "ce723821ad57588ee22487bc80d400e71707a7d2d2d07b8c8e12167f7a311b5e",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -112,7 +112,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "477686c481a5a8b7bbf2181da2ca8b63157cfb9e14624ca1a4e5681756010159",
+                "reviewed_content_hash": "131e0a45a2101d224947d26ec4da54d38392b16d115d20722110b300da046c41",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -136,7 +136,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "7965b76ff44651cad97f0d2ad685382fe5944ae81736069f941e6960988881ff",
+                "reviewed_content_hash": "e86c82bbe044a74d39d7e356335e365df4bafd7765edc16d10cdb427bfb82b49",
                 "target": {
                   "kind": "code",
                   "path": "skills/tieline-author/SKILL.md",
@@ -166,7 +166,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "f211e32e32f7418500e42526c18c732590d739998a48933c0657f9c0406b9907",
+                "reviewed_content_hash": "ce723821ad57588ee22487bc80d400e71707a7d2d2d07b8c8e12167f7a311b5e",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -176,7 +176,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "477686c481a5a8b7bbf2181da2ca8b63157cfb9e14624ca1a4e5681756010159",
+                "reviewed_content_hash": "131e0a45a2101d224947d26ec4da54d38392b16d115d20722110b300da046c41",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -419,7 +419,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "7965b76ff44651cad97f0d2ad685382fe5944ae81736069f941e6960988881ff",
+                "reviewed_content_hash": "e86c82bbe044a74d39d7e356335e365df4bafd7765edc16d10cdb427bfb82b49",
                 "target": {
                   "kind": "code",
                   "path": "skills/tieline-author/SKILL.md",
@@ -460,7 +460,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "477686c481a5a8b7bbf2181da2ca8b63157cfb9e14624ca1a4e5681756010159",
+                "reviewed_content_hash": "131e0a45a2101d224947d26ec4da54d38392b16d115d20722110b300da046c41",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/spec/runtime.yaml
+++ b/.tieline/spec/runtime.yaml
@@ -75,7 +75,8 @@ capability:
                 path: scripts/test-tieline.ts
                 framework_hint: custom-script
         - key: RUNTIME-001-AC3
-          criterion: Tieline must surface detected source roots and preflight warnings while leaving the specification empty until repository-specific semantic onboarding.
+          criterion: Tieline must surface detected source roots and preflight warnings, leave the specification empty until repository-specific semantic onboarding, and end initialization with a copyable, self-contained prompt that hands that onboarding to an agent.
+          rationale: Deterministic setup belongs in the CLI, while interpreting repository context and proposing semantic boundaries belongs with an agent and normal pull-request review.
           links:
             - relation: implements
               provenance: authored
@@ -89,6 +90,18 @@ capability:
                 kind: code
                 repository: tieline
                 path: src/tieline/init.ts
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/tieline/status.ts
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: skills/tieline-author/SKILL.md
             - relation: tests
               provenance: authored
               target:

--- a/README.md
+++ b/README.md
@@ -196,11 +196,22 @@ defaults to `.tieline/config.json`. Clone-local setup state and credentials live
 in a private profile outside the repository, so a new clone completes its own
 runtime setup instead of inheriting another machine's "ready" state.
 
+On a new repository, the only Tieline command a user needs to begin onboarding
+is `tieline init`. It captures the deterministic product, repository, context,
+source-root, and runtime setup, then ends with an **Agent handoff prompt**. Paste
+that prompt into a coding agent working in the repository; the agent takes over
+the semantic work of discovering and authoring the first repository-specific
+contract. Tieline does not auto-run an agent or invent generic starter content.
+
 The generated `.tieline/mcp.json` is a portable, repository-relative template.
-Register it with your MCP host and ensure the `tieline` command resolves this
-package, then invoke the `tieline_author` MCP prompt. The bundled
-`/tieline-author` skill provides the same workflow in hosts that load package
-skills directly:
+Register it with your MCP host when the host does not load repository MCP
+configuration automatically, and ensure the `tieline` command resolves this
+package. The handoff tells the agent to use the bundled `tieline-author` skill
+or load the equivalent `tieline_author` MCP prompt when either surface is
+available. The printed brief is also self-contained enough for an agent to
+continue directly: it includes the authoring shape, duplicate-search fallback,
+and exact validation commands. Those commands are agent instructions; the user
+still starts with only `tieline init`. That workflow can:
 
 - shape a planning Story/AC or Backlog Item in Postgres;
 - semantically onboard an empty spec from configured descriptions, local
@@ -213,9 +224,12 @@ skills directly:
 
 An empty `.tieline/spec/` immediately after init is intentional: init does not
 invent generic capabilities. Review the detected `repository.source_roots`
-before onboarding or claiming coverage. `tieline status --json` reports whether
-the local profile is ready and whether database-backed semantic matching and
-planning writes are configured. Tool calls remain the operational check.
+before onboarding or claiming coverage. While the spec has no Stories,
+`tieline status --json` exposes the same copyable handoff as
+`agent_onboarding_prompt`; after onboarding it becomes `null`. Status also
+reports whether the local profile is ready and whether database-backed semantic
+matching and planning writes are configured. Tool calls remain the operational
+check.
 
 Before creating planning work, machine matching searches existing Stories, ACs,
 Backlog Items, and similar Observations. It presents candidates and requires an

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -262,6 +262,12 @@ try {
   assert.match(parsedStatus.agent_onboarding_prompt, /tieline-author/);
   assert.match(parsedStatus.agent_onboarding_prompt, /tieline_author/);
   assert.match(parsedStatus.agent_onboarding_prompt, /\.tieline\/config\.json/);
+  assert.match(
+    parsedStatus.agent_onboarding_prompt,
+    /remote-tracking default branch/
+  );
+  assert.match(parsedStatus.agent_onboarding_prompt, /<base-ref>/);
+  assert.doesNotMatch(parsedStatus.agent_onboarding_prompt, /origin\/main/);
   assert.equal(parsedStatus.agent_onboarding_prompt, renderedAgentPrompt);
 
   const humanStatus = io();

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -22,6 +22,7 @@ import {
   readWorkspaceProfile,
 } from "../src/tieline/profile.js";
 import { configureWorkspaceRuntime } from "../src/tieline/setup.js";
+import type { TielineStatus } from "../src/tieline/status.js";
 import {
   findTielineWorkspace,
   type TielineWorkspace,
@@ -139,10 +140,24 @@ try {
       },
     }
   );
-  assert.match(first.output.join(""), /source scope: src/i);
-  assert.match(first.output.join(""), /warning.*duplicate checks/i);
-  assert.match(first.output.join(""), /MCP prompt `tieline_author`/);
-  assert.match(first.output.join(""), /semantic onboarding has not started/i);
+  const firstOutput = first.output.join("");
+  assert.match(firstOutput, /source scope: src/i);
+  assert.match(firstOutput, /warning.*duplicate checks/i);
+  assert.match(firstOutput, /MCP prompt `tieline_author`/);
+  assert.match(firstOutput, /semantic onboarding has not started/i);
+  assert.match(firstOutput, /Agent handoff prompt:/);
+  assert.match(firstOutput, /bundled `tieline-author` skill/);
+  assert.match(firstOutput, /otherwise continue directly from this brief/i);
+  assert.match(firstOutput, /read `.tieline\/config\.json`/i);
+  assert.match(firstOutput, /do not add generic starter content/i);
+  assert.match(firstOutput, /strict YAML under `.tieline\/spec\/`/i);
+  assert.match(firstOutput, /tieline contract validate \./);
+  const handoffMarker = "Agent handoff prompt:\n";
+  const handoffStart = firstOutput.lastIndexOf(handoffMarker);
+  assert.notEqual(handoffStart, -1);
+  const renderedAgentPrompt = firstOutput
+    .slice(handoffStart + handoffMarker.length)
+    .trimEnd();
 
   const stored = readWorkspaceProfile(workspace, {
     TIELINE_CONFIG_HOME: configHome,
@@ -230,15 +245,9 @@ try {
     }),
     0
   );
-  const parsedStatus = JSON.parse(status.output.join("")) as {
-    runtime: { profile_present: boolean; setup_complete: boolean };
-    capabilities: {
-      semantic_matching_configured: boolean;
-      planning_writes_configured: boolean;
-    };
-    contract: { stories: number; acceptance_criteria: number };
-    next_action: string;
-  };
+  const parsedStatus = JSON.parse(
+    status.output.join("")
+  ) as TielineStatus;
   assert.equal(parsedStatus.runtime.profile_present, true);
   assert.equal(parsedStatus.runtime.setup_complete, true);
   assert.equal(
@@ -248,7 +257,27 @@ try {
   assert.equal(parsedStatus.capabilities.planning_writes_configured, false);
   assert.equal(parsedStatus.contract.stories, 0);
   assert.equal(parsedStatus.contract.acceptance_criteria, 0);
-  assert.match(parsedStatus.next_action, /tieline_author/);
+  assert.match(parsedStatus.next_action, /agent_onboarding_prompt/);
+  assert.ok(parsedStatus.agent_onboarding_prompt);
+  assert.match(parsedStatus.agent_onboarding_prompt, /tieline-author/);
+  assert.match(parsedStatus.agent_onboarding_prompt, /tieline_author/);
+  assert.match(parsedStatus.agent_onboarding_prompt, /\.tieline\/config\.json/);
+  assert.equal(parsedStatus.agent_onboarding_prompt, renderedAgentPrompt);
+
+  const humanStatus = io();
+  assert.equal(
+    await runCli(["status", target], humanStatus.adapter, {
+      TIELINE_CONFIG_HOME: configHome,
+    }),
+    0
+  );
+  assert.match(humanStatus.output.join(""), /Agent handoff prompt:/);
+  assert.ok(
+    humanStatus.output
+      .join("")
+      .trimEnd()
+      .endsWith(renderedAgentPrompt)
+  );
 
   writeFileSync(
     resolve(workspace.specDirectoryPath, "status.yaml"),
@@ -292,16 +321,26 @@ capability:
   );
   const parsedLegacyManifestStatus = JSON.parse(
     legacyManifestStatus.output.join("")
-  ) as {
-    contract: { manifest_exists: boolean };
-    next_action: string;
-  };
+  ) as TielineStatus;
   assert.equal(parsedLegacyManifestStatus.contract.manifest_exists, false);
+  assert.equal(parsedLegacyManifestStatus.agent_onboarding_prompt, null);
   assert.match(
     parsedLegacyManifestStatus.next_action,
     /tieline contract compile \./
   );
   assert.equal(readFileSync(legacyIndexPath, "utf8"), legacyIndex);
+
+  const onboardedHumanStatus = io();
+  assert.equal(
+    await runCli(["status", target], onboardedHumanStatus.adapter, {
+      TIELINE_CONFIG_HOME: configHome,
+    }),
+    0
+  );
+  assert.doesNotMatch(
+    onboardedHumanStatus.output.join(""),
+    /Agent handoff prompt:/
+  );
 
   const environmentStatus = io();
   assert.equal(
@@ -449,6 +488,8 @@ capability:
   assert.match(authorSkill, /allow_external_fetch/);
   assert.match(authorSkill, /local YAML.*manifest/i);
   assert.match(authorSkill, /semantic matching.*unavailable/i);
+  assert.match(authorSkill, /after `tieline init`/i);
+  assert.match(authorSkill, /semantic onboarding/i);
 
   for (const removed of ["merge", "review", "import", "context"]) {
     await assert.rejects(

--- a/skills/tieline-author/SKILL.md
+++ b/skills/tieline-author/SKILL.md
@@ -81,7 +81,11 @@ from an Observation, Backlog Item, planning Story, existing AC, or branch diff.
 
 ## Materialize or reconcile repository behavior
 
-1. Run `tieline contract reconcile . --base origin/main --json` and work from its
+1. Determine an available comparison base from repository metadata, preferring
+   the remote-tracking default branch. Ask the user only if repository metadata
+   cannot identify a usable base. Replace `<base-ref>` below with the selected
+   reference.
+2. Run `tieline contract reconcile . --base <base-ref> --json` and work from its
    output. `claimed_changes` names the ACs whose evidence moved; re-read those
    definitions first. `unclaimed_changes` names changed source files no link
    targets; treat each as a question about whether behavior changed, not as a
@@ -89,27 +93,27 @@ from an Observation, Backlog Item, planning Story, existing AC, or branch diff.
    need no new AC. Never author an AC to drive that count to zero.
    `excluded_changes` records paths the command set aside and why. Inspect the
    diff itself for anything the output leaves unresolved.
-2. Call `list_handoff_conflicts` for the Story being materialized or
+3. Call `list_handoff_conflicts` for the Story being materialized or
    reconciled. Resolve the later planning definition explicitly rather than
    silently overwriting it.
-3. When materializing a planning Story, preserve its Story and AC stable IDs
+4. When materializing a planning Story, preserve its Story and AC stable IDs
    and add `planning_origin.record_id` plus its current `revision`.
-4. Put implementation, test, and help locators on the most specific AC. Use a
+5. Put implementation, test, and help locators on the most specific AC. Use a
    Story-level link only as a shared or coarse fallback.
-5. Preserve Backlog Item and Observation IDs only as `motivated_by` pointers;
+6. Preserve Backlog Item and Observation IDs only as `motivated_by` pointers;
    never copy their payloads into YAML.
-6. Write strict YAML under `.tieline/spec/`.
-7. Run:
+7. Write strict YAML under `.tieline/spec/`.
+8. Run:
 
    ```sh
    tieline contract validate .
    tieline contract compile .
    tieline contract coverage .
-   tieline contract reconcile . --base origin/main
-   tieline check --base origin/main
+   tieline contract reconcile . --base <base-ref>
+   tieline check --base <base-ref>
    ```
 
-8. Summarize the semantic diff, impacted ACs, freshness warnings, coverage
+9. Summarize the semantic diff, impacted ACs, freshness warnings, coverage
    delta, likely duplicates, unresolved conflicts, and unmapped source files.
 
 Do not mutate a repository-owned Story through MCP. Change its YAML on the

--- a/skills/tieline-author/SKILL.md
+++ b/skills/tieline-author/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tieline-author
-description: Author, plan, implement, or reconcile Tieline User Stories and Acceptance Criteria. Use for requests to create or refine planning Stories/ACs or Backlog Items in Postgres, materialize planning records into repository YAML, connect branch work to product behavior, resolve likely duplicate definitions, or prepare a semantic contract change for pull-request review.
+description: Semantically onboard an initialized Tieline repository, or author, plan, implement, and reconcile Tieline User Stories and Acceptance Criteria. Use after `tieline init` to inspect configured context and create the first repository-specific capabilities, Stories, and ACs; also use to refine planning Stories/ACs or Backlog Items in Postgres, materialize planning records into repository YAML, connect branch work to product behavior, resolve likely duplicate definitions, or prepare a semantic contract change for pull-request review.
 ---
 
 # Tieline author
@@ -9,6 +9,11 @@ Treat the pull request as the proposal and merge as approval. Never create a
 separate draft, proposal, or semantic-approval record.
 
 Read [contract.md](references/contract.md) before editing contract YAML.
+
+When invoked from the agent handoff printed by `tieline init`, start with
+semantic onboarding below. The CLI has already captured deterministic setup;
+do not ask the user to repeat product, repository, source-root, or context
+answers that are present in `.tieline/config.json`.
 
 ## Orient to this repository
 

--- a/skills/tieline-author/agents/openai.yaml
+++ b/skills/tieline-author/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Tieline Author"
-  short_description: "Author and reconcile Tieline product contracts"
-  default_prompt: "Use $tieline-author to reconcile this work with the product contract."
+  short_description: "Onboard, author, and reconcile Tieline contracts"
+  default_prompt: "Use $tieline-author to semantically onboard this repository from its configured context, or reconcile existing contract behavior."

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,10 +99,19 @@ function withoutDatabaseEnvironment(
   return isolated;
 }
 
+function renderAgentHandoff(
+  status: TielineStatus,
+  ui: Palette
+): string | null {
+  return status.agent_onboarding_prompt
+    ? `${ui.cyan("Agent handoff prompt:")}\n${status.agent_onboarding_prompt}`
+    : null;
+}
+
 function renderStatus(status: TielineStatus, ui: Palette): string {
   const state = (ok: boolean, good: string, bad: string): string =>
     ok ? ui.green(good) : ui.yellow(bad);
-  return [
+  const lines = [
     ui.bold(`Tieline: ${status.product} (${status.repo})`),
     `  root: ${status.root}`,
     `  runtime: profile=${state(status.runtime.profile_present, "present", "missing")}, database=${status.runtime.database_mode}, embedding=${status.runtime.embedding_provider}, setup=${state(status.runtime.setup_complete, "complete", "incomplete")}`,
@@ -110,7 +119,10 @@ function renderStatus(status: TielineStatus, ui: Palette): string {
     `  integration: mcp_template=${state(status.integration.mcp_template_present, "present", "missing")}`,
     `  contract: ${status.contract.stories} Stories, ${status.contract.acceptance_criteria} ACs, manifest=${state(status.contract.manifest_exists, "present", "missing")}`,
     `${ui.cyan("Next:")} ${status.next_action}`,
-  ].join("\n");
+  ];
+  const handoff = renderAgentHandoff(status, ui);
+  if (handoff) lines.push("", handoff);
+  return lines.join("\n");
 }
 
 function renderInitSummary(
@@ -147,9 +159,9 @@ function renderInitSummary(
   io.write(
     "MCP template: register `.tieline/mcp.json` with your host and ensure its `tieline` command resolves this package.\n"
   );
-  io.write(
-    `${ui.cyan("Next:")} invoke MCP prompt \`tieline_author\` (or the bundled /tieline-author skill) to onboard or reconcile behavior.\n`
-  );
+  io.write(`${ui.cyan("Next:")} ${status.next_action}\n`);
+  const handoff = renderAgentHandoff(status, ui);
+  if (handoff) io.write(`\n${handoff}\n`);
 }
 
 function firstPositional(
@@ -379,7 +391,7 @@ function buildProgram(
     .addHelpText("before", () => `${renderBanner(paletteFor(io))}\n\n`)
     .addHelpText(
       "after",
-      "\nUse /tieline-author for planning Story/AC writes, implementation, and branch reconciliation."
+      "\nRun `tieline init` for deterministic setup and a copyable agent handoff. Use /tieline-author for onboarding, planning Story/AC writes, implementation, and branch reconciliation."
     );
 
   program

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -64,6 +64,10 @@ Invoke the MCP \`tieline_author\` prompt (or use the bundled
 \`/tieline-author\` skill) to onboard repository behavior, materialize planning
 definitions, reconcile branch changes, validate/compile YAML, and review the
 semantic diff. Normal pull-request merge is the semantic approval event.
+After deterministic setup, \`tieline init\` prints a copyable agent handoff for
+this workflow; while the spec has no Stories, \`tieline status --json\` exposes
+the same text as \`agent_onboarding_prompt\`. The handoff includes a direct
+fallback for hosts that expose neither package skills nor MCP prompts.
 
 Coverage describes whether every AC has direct implementation, test, or help
 links. Freshness separately describes whether linked repository content still

--- a/src/tieline/status.ts
+++ b/src/tieline/status.ts
@@ -34,7 +34,19 @@ export interface TielineStatus {
     manifest_exists: boolean;
   };
   next_action: string;
+  agent_onboarding_prompt: string | null;
 }
+
+const TIELINE_AGENT_ONBOARDING_PROMPT = [
+  "Onboard this repository with Tieline.",
+  "Use the bundled `tieline-author` skill or load the MCP prompt `tieline_author` when available; otherwise continue directly from this brief.",
+  "Read `.tieline/config.json` and every configured context source, then inspect the configured source roots, README and product documentation, public code entry points, and tests.",
+  "Run `tieline status --json`; before creating stable IDs, search local YAML and the compiled manifest for IDs, aliases, and related criteria, and disclose when database-backed organization-wide duplicate checking is unavailable.",
+  "If `.tieline/spec/` is empty, author strict YAML under `.tieline/spec/` using repository-specific capabilities and Stories with separate actor, goal, and benefit fields; write each acceptance criterion as one observable `<subject> must <outcome>` and put code, test, or help links on the most specific criterion.",
+  "Do not add generic starter content.",
+  "Run `tieline contract validate .`, `tieline contract compile .`, `tieline contract coverage .`, `tieline contract reconcile . --base origin/main`, and `tieline check --base origin/main`.",
+  "Summarize the sources used, proposed semantic boundaries, likely duplicates, mapping gaps, and changes for pull-request review.",
+].join(" ");
 
 function configured(value: string | undefined): boolean {
   return Boolean(value?.trim());
@@ -86,9 +98,11 @@ export function getTielineStatus(
   // recoverable and sends each of those states through the existing compile
   // action instead of throwing.
   const manifestExists = readableManifest(workspace.manifestPath);
+  const agentOnboardingPrompt =
+    stories.length === 0 ? TIELINE_AGENT_ONBOARDING_PROMPT : null;
   const nextAction =
-    stories.length === 0
-      ? "Connect the MCP template, then invoke the `tieline_author` prompt (or use the bundled /tieline-author skill) to onboard the first Story and AC."
+    agentOnboardingPrompt
+      ? "Register `.tieline/mcp.json` if your agent host does not load repository MCP configuration automatically, then give `agent_onboarding_prompt` to your coding agent."
       : !manifestExists
         ? "Run `tieline contract compile .` and review the semantic diff."
         : "Use /tieline-author to reconcile branch work; the pull request is the approval boundary.";
@@ -121,6 +135,7 @@ export function getTielineStatus(
       manifest_exists: manifestExists,
     },
     next_action: nextAction,
+    agent_onboarding_prompt: agentOnboardingPrompt,
   };
 }
 

--- a/src/tieline/status.ts
+++ b/src/tieline/status.ts
@@ -44,7 +44,8 @@ const TIELINE_AGENT_ONBOARDING_PROMPT = [
   "Run `tieline status --json`; before creating stable IDs, search local YAML and the compiled manifest for IDs, aliases, and related criteria, and disclose when database-backed organization-wide duplicate checking is unavailable.",
   "If `.tieline/spec/` is empty, author strict YAML under `.tieline/spec/` using repository-specific capabilities and Stories with separate actor, goal, and benefit fields; write each acceptance criterion as one observable `<subject> must <outcome>` and put code, test, or help links on the most specific criterion.",
   "Do not add generic starter content.",
-  "Run `tieline contract validate .`, `tieline contract compile .`, `tieline contract coverage .`, `tieline contract reconcile . --base origin/main`, and `tieline check --base origin/main`.",
+  "Determine an available comparison base from repository metadata, preferring the remote-tracking default branch; ask the user only if repository metadata cannot identify a usable base, then replace `<base-ref>` in the commands below.",
+  "Run `tieline contract validate .`, `tieline contract compile .`, `tieline contract coverage .`, `tieline contract reconcile . --base <base-ref>`, and `tieline check --base <base-ref>`.",
   "Summarize the sources used, proposed semantic boundaries, likely duplicates, mapping gaps, and changes for pull-request review.",
 ].join(" ");
 


### PR DESCRIPTION
## Summary

`tieline init` now completes deterministic repository setup and ends with a self-contained prompt that hands semantic onboarding to a coding agent. The user still runs one command; the agent receives the captured context, contract-authoring shape, duplicate-search fallback, portable comparison-base guidance, validation commands, and pull-request review boundary.

The existing `tieline-author` skill and `tieline_author` MCP prompt remain the richer workflow when a host exposes them. The printed brief also works directly when neither surface is discoverable. `tieline status --json` returns the same `agent_onboarding_prompt` until the first Story exists, then returns `null` and resumes normal compile or reconciliation guidance.

## Design decisions

- Keep deterministic product, repository, source-root, context, and runtime capture in the CLI.
- Leave `.tieline/spec/` empty until an agent has enough repository context to propose real semantic boundaries.
- Reuse the existing authoring skill instead of adding a second onboarding skill or command.
- Resolve the comparison base from repository metadata instead of assuming `origin/main`; ask the user only when no usable base can be determined.
- Put onboarding instructions in CI through the real built CLI path, including the pre-Story and post-Story status boundary.

## Validation

- `npm run test:tieline`
- `npm run test:contract`
- `npm run test:smoke`
- Tieline author skill validator
- `tieline contract validate .`
- `tieline check . --base origin/main` (`manifest=current`, zero broken links, zero changes to consider)
- Full CI-equivalent validation after the base-ref review fix
- `git diff --check`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This changes offline CLI output, packaged agent instructions, and CI coverage; it does not add a running service or production data path. The next package smoke test should run `tieline init` in an empty repository and confirm the final prompt can be pasted into an agent. A missing prompt, a non-null prompt after the first Story, a hard-coded comparison base, or a stale-manifest check is the rollback trigger; the maintainer owns that validation through the next release window.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
