### PR TITLE
fix(release): align installed contract workflows

### DIFF
--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -861,7 +861,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "cf449a59d5a0abb879e6fb298c11c8557a0897edb0d546aefed506b1259c897e",
+                "reviewed_content_hash": "ea7de680a6b3be42fe07a562fce47e52f63f2b0958a0b4f0ccb3bfd84b4c2280",
                 "target": {
                   "kind": "code",
                   "path": "src/server.ts",

--- a/.tieline/manifest/GRADING.json
+++ b/.tieline/manifest/GRADING.json
@@ -378,7 +378,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "420d5666fdfc79256a163408fb0fc79c89cc8d2b24c9d8ab9403d71fdf1ee52e",
+                "reviewed_content_hash": "654234d4cbda25f3fdb818fea99afb11eec3fe64a197dfb73b8a08221e6bbbc2",
                 "target": {
                   "kind": "code",
                   "path": "skills/tieline-grade/SKILL.md",

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -257,7 +257,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "cf449a59d5a0abb879e6fb298c11c8557a0897edb0d546aefed506b1259c897e",
+                "reviewed_content_hash": "ea7de680a6b3be42fe07a562fce47e52f63f2b0958a0b4f0ccb3bfd84b4c2280",
                 "target": {
                   "kind": "code",
                   "path": "src/server.ts",
@@ -361,7 +361,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "0451f7da677c969573d5e0b444190b00807d1794ae3126123a3f5f9f79bea1e1",
+                "reviewed_content_hash": "7a690bbba97f5b53e6d1a5a612598e9702f734f72d16148e01877153b191331c",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -439,7 +439,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "cf449a59d5a0abb879e6fb298c11c8557a0897edb0d546aefed506b1259c897e",
+                "reviewed_content_hash": "ea7de680a6b3be42fe07a562fce47e52f63f2b0958a0b4f0ccb3bfd84b4c2280",
                 "target": {
                   "kind": "code",
                   "path": "src/server.ts",

--- a/README.md
+++ b/README.md
@@ -137,8 +137,15 @@ converges definitions without deleting history.
   Supabase Edge function, or the optional local runtime adds vector similarity;
   full-text and identifier search remain available without one.
 
-The architecture in this repository is newer than the package currently
-published to npm. To exercise this version, install it from source:
+Install the published CLI from npm:
+
+```bash
+npm install --global tieline
+tieline --help
+```
+
+Contributors, or users who specifically need the current `main` branch, can
+instead install from source:
 
 ```bash
 git clone https://github.com/knoxgraeme/tieline.git
@@ -149,9 +156,9 @@ npm link
 tieline --help
 ```
 
-`npm link` makes the repository's compiled `tieline` command available on the
+`npm link` makes that checkout's compiled `tieline` command available on the
 current machine. Without it, replace `tieline` in the examples below with
-`node dist/cli.js`.
+`node dist/cli.js` from the checkout.
 
 ## Initialize and onboard a repository
 
@@ -210,8 +217,9 @@ package. The handoff tells the agent to use the bundled `tieline-author` skill
 or load the equivalent `tieline_author` MCP prompt when either surface is
 available. The printed brief is also self-contained enough for an agent to
 continue directly: it includes the authoring shape, duplicate-search fallback,
-and exact validation commands. Those commands are agent instructions; the user
-still starts with only `tieline init`. That workflow can:
+and the validation sequence and comparison-base guidance. Those commands are
+agent instructions; the user still starts with only `tieline init`. That
+workflow can:
 
 - shape a planning Story/AC or Backlog Item in Postgres;
 - semantically onboard an empty spec from configured descriptions, local
@@ -319,6 +327,23 @@ asking for attention, not that the links are correct. Missing files are left to
 `tieline check` and are reported as skipped rather than scored. The command is
 advisory and exits zero.
 
+Ask an agent to judge the branch's contract evidence:
+
+```bash
+tieline contract grade . --base <base-ref> --emit-scope --json
+tieline contract grade . --base <base-ref> --verify <verdicts.json>
+```
+
+The first command deterministically emits every diff-scoped acceptance-
+criterion link to grade and the exact symbol citations allowed for it. The
+agent inspects the artifacts and assigns `supported`, `partial`, or
+`unsupported`; the second command verifies that every verdict belongs to the
+scope and that every claimed citation came from its allow-list. Tieline does
+not call a model, database, or network for this workflow. Verification is
+advisory by default, including negative results; add `--strict` to the verify
+command only when unsupported evidence should fail the gate. The packaged
+`tieline-grade` skill leads an agent through the full workflow.
+
 Generate a human-readable browser review of the accepted YAML:
 
 ```bash
@@ -330,27 +355,36 @@ navigation, Story and AC cards, scenario steps, evidence links, search,
 lifecycle filters, and a print layout. Open the file directly in a browser.
 Use `--output <path>` to write it elsewhere.
 
-CI can warn about affected ACs:
+CI can check affected ACs:
 
 ```bash
-tieline check --base origin/main .
+tieline check --base <base-ref> .
 ```
+
+Use the comparison ref supplied by the caller when available. Otherwise,
+agents should determine it from repository metadata, preferring the
+remote-tracking default branch, and ask only when it cannot be determined;
+do not assume every repository uses `origin/main`.
 
 The check compares changed, renamed, and deleted paths with manifest locators and
 reports each affected AC plus its freshness. It also sweeps every link for broken
 targets, whether or not the diff touched them, because a link can rot without the
-change under review going near it. Two kinds of finding are distinguished:
+change under review going near it. The check treats these integrity states
+differently:
 
-| Finding | Cause | Effect |
+| State | Cause | Effect |
 | --- | --- | --- |
 | stale | The linked file changed since it was reviewed, or was never reviewed against a recorded hash. Whether the AC still holds needs a human. | Warning, exit 0 |
 | broken | The linked path is missing, is not a file, or resolves outside the repository. | Error, exit 1 |
+| stale manifest | The committed manifest differs from what the current contract compiles to. | Error, exit 1 |
 
 Broken links fail the check because deciding they are wrong needs no judgement:
-the manifest points at evidence that is not there. Everything else stays
-warn-only. Pass `--no-fail-on-broken` to downgrade broken links to warnings and
-exit zero. Invalid YAML or an unreadable manifest fails because no trustworthy
-result can be computed. See
+the manifest points at evidence that is not there. Pass `--no-fail-on-broken`
+to downgrade broken links to warnings and exit zero. A stale manifest also
+fails by default: run `tieline contract compile .`, review the semantic diff,
+and commit the result. Use `--no-fail-on-stale-manifest` only when intentionally
+downgrading that integrity gate to a warning. Invalid YAML or an unreadable
+manifest fails because no trustworthy result can be computed. See
 [the GitHub Actions example](docs/examples/tieline-check.yml).
 
 After merge, run:
@@ -657,6 +691,7 @@ earlier model must be recreated rather than upgraded in place.
 | `migrations/` | PostgreSQL/pgvector schema and role baseline |
 | `scripts/` | Contract, retrieval, transport, and integration verification |
 | `skills/tieline-author/` | Packaged semantic authoring workflow |
+| `skills/tieline-grade/` | Packaged agent workflow for grading diff-scoped contract evidence |
 | `.tieline/` | This repository's own accepted contract and compiled manifest |
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tieline",
-  "version": "0.1.2",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tieline",
-      "version": "0.1.2",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",
@@ -28,7 +28,7 @@
         "typescript": "^5.7.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.12"
       }
     },
     "node_modules/@clack/core": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tieline",
-  "version": "0.1.2",
+  "version": "0.1.5",
   "description": "Living Story/AC contract and semantic graph grounded in code, tests, help content, and organizational evidence.",
   "license": "MIT",
   "repository": {
@@ -20,6 +20,7 @@
     "dist",
     "migrations",
     "skills",
+    "assets",
     "README.md",
     "LICENSE"
   ],

--- a/scripts/test-http.ts
+++ b/scripts/test-http.ts
@@ -1,6 +1,19 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { loadConfig } from "../src/config.js";
 import { createHttpApp, isAllowedMcpOrigin } from "../src/http.js";
+import { SERVER_VERSION } from "../src/server.js";
+
+const packageVersion = (
+  JSON.parse(
+    readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), "../package.json"),
+      "utf8"
+    )
+  ) as { version: string }
+).version;
 
 let passed = 0;
 function test(name: string, fn: () => void): void {
@@ -31,6 +44,9 @@ test("health route remains outside MCP origin middleware", () => {
   const stack = (createHttpApp() as unknown as { _router: { stack: Array<{ route?: { path?: string } }> } })
     ._router.stack;
   assert.equal(stack.some((layer) => layer.route?.path === "/health"), true);
+});
+test("server metadata reports the package version", () => {
+  assert.equal(SERVER_VERSION, packageVersion);
 });
 test("remote bind needs both gateway acknowledgement and origins", () => {
   assert.throws(() => loadConfig({ HTTP_HOST: "0.0.0.0" }), /Refusing non-loopback/);

--- a/skills/tieline-grade/SKILL.md
+++ b/skills/tieline-grade/SKILL.md
@@ -10,10 +10,12 @@ citations. Supply the semantic judgment the deterministic tooling cannot make.
 
 ## Emit the work list
 
-Use the caller's base ref, or `origin/main` when none was supplied:
+Use the caller's base ref when supplied. Otherwise, determine the comparison
+ref from repository metadata, preferring the remote-tracking default branch.
+Ask the caller only when it cannot be determined; do not assume a branch name.
 
 ```sh
-tieline contract grade . --base origin/main --emit-scope --json
+tieline contract grade . --base <base-ref> --emit-scope --json
 ```
 
 This command is offline and database-free. Each entry contains:
@@ -90,7 +92,7 @@ path, and link scope.
 Use the same base ref that produced the scope:
 
 ```sh
-tieline contract grade . --base origin/main --verify <verdicts.json>
+tieline contract grade . --base <base-ref> --verify <verdicts.json>
 ```
 
 Add `--strict` only when the caller explicitly requested a gate. Advisory mode

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,9 @@
  * server per request.
  */
 
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerFindRelated } from "./tools/find_related.js";
 import { registerQueryStories } from "./tools/query_stories.js";
@@ -21,7 +24,14 @@ import { registerPrompts } from "./prompts.js";
 import { registerHandoffConflictTools } from "./tools/handoff-conflicts.js";
 
 export const SERVER_NAME = "tieline";
-export const SERVER_VERSION = "0.1.2";
+export const SERVER_VERSION = (
+  JSON.parse(
+    readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), "../package.json"),
+      "utf8"
+    )
+  ) as { version: string }
+).version;
 
 export function createServer(): McpServer {
   installSemanticAdvisors();


### PR DESCRIPTION
## Summary

The documented install and onboarding path now matches how Tieline is shipped: users install the npm CLI, run `tieline init`, and hand the generated prompt to an agent for semantic onboarding.

Contract-integrity guidance now covers agent evidence grading, portable comparison-base discovery, and the stale-manifest failure gate. The next publishable patch also includes the README logo and both packaged skills. MCP and health metadata now derive their version from `package.json`, which removes the duplicate version source that had drifted.

## Validation

- Contract YAML validated and the committed manifest was regenerated.
- Contract, onboarding, HTTP, and semantic-ranking test suites passed.
- `tieline check --base origin/main .` reported a current manifest and no broken links.
- `npm pack --dry-run --json` confirmed version `0.1.5`, the logo, and both packaged skills.
- Focused correctness, API-contract, and agent-native review passes reported no remaining blockers.

## Post-Deploy Monitoring & Validation

- Owner: release maintainer for the first `0.1.5` publish.
- Window: during publish and for 24 hours after the npm dist-tag moves.
- Logs and metadata: inspect the release workflow output and `npm view tieline version`; no long-running service metric changes are expected.
- Healthy signal: npm reports `0.1.5`, the registry tarball contains `assets/tieline-logo.png` and both skill directories, and CLI/MCP version surfaces report `0.1.5`.
- Failure signal: a mismatched version, missing packaged file, failed install, or stale `latest` dist-tag.
- Mitigation: stop promotion, keep `0.1.4` as `latest` when possible, correct the package inputs, and publish a new patch because npm versions are immutable.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
