### PR TITLE
feat(init): make the onboarding next step a paste-ready agent prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,8 +307,9 @@ An empty `.tieline/spec/` immediately after init is intentional: init does not
 invent generic capabilities. The authoring skill validates the detected code
 scope against the repository before claiming coverage. While the spec has no Stories,
 `tieline status --json` exposes `onboarding.required`, the `tieline-author`
-skill name, the concise instruction `Use $tieline-author to onboard this
-repository.`, and `tieline init .` as the install command. `onboarding` becomes
+skill name, a paste-ready agent prompt (`Use the tieline-author skill to
+onboard this repository to Tieline.`), and `tieline init .` as the install
+command. `onboarding` becomes
 `null` after the first Story exists. Status also reports whether the local
 profile is ready and whether database-backed semantic matching and planning
 writes are configured. Tool calls remain the operational check.

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -401,7 +401,10 @@ try {
     interactive.output.join(""),
     /Skill: tieline-author installed for Codex and Claude Code \(project\)/
   );
-  assert.match(interactive.output.join(""), /use \$tieline-author/i);
+  assert.match(
+    interactive.output.join(""),
+    /paste this prompt to your agent to finish onboarding: "Use the tieline-author skill to onboard this repository to Tieline\."/
+  );
 
   const cancelledTarget = resolve(root, "Cancelled Checkout");
   mkdirSync(resolve(cancelledTarget, "src"), { recursive: true });
@@ -777,12 +780,13 @@ try {
   assert.equal(parsedStatus.contract.acceptance_criteria, 0);
   assert.equal(
     parsedStatus.next_action,
-    "Use $tieline-author to onboard this repository."
+    'Paste this prompt to your agent to finish onboarding: "Use the tieline-author skill to onboard this repository to Tieline."'
   );
   assert.deepEqual(parsedStatus.onboarding, {
     required: true,
     skill: "tieline-author",
-    instruction: "Use $tieline-author to onboard this repository.",
+    instruction:
+      "Use the tieline-author skill to onboard this repository to Tieline.",
     install_command: "tieline init .",
   });
   assert.equal("agent_onboarding_prompt" in parsedStatus, false);
@@ -796,7 +800,7 @@ try {
   );
   assert.match(
     humanStatus.output.join(""),
-    /Next: Use \$tieline-author to onboard this repository\./
+    /Next: Paste this prompt to your agent to finish onboarding: "Use the tieline-author skill to onboard this repository to Tieline\."/
   );
   assert.match(humanStatus.output.join(""), /Install skill: tieline init \./);
   assert.doesNotMatch(humanStatus.output.join(""), /Agent handoff prompt:/);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,6 +56,7 @@ import {
 } from "./tieline/skill-install.js";
 import {
   getTielineStatus,
+  ONBOARDING_AGENT_PROMPT,
   statusFromPath,
   type TielineStatus,
 } from "./tieline/status.js";
@@ -302,7 +303,7 @@ function renderInitSummary(
     ].join("; ");
     lines.push(
       `Skill: tieline-author ${skillState} (${skillScope})`,
-      `${ui.cyan("Next:")} Restart or reload ${joinLabels(labels)}, then use $tieline-author to onboard this repository.`
+      `${ui.cyan("Next:")} Restart or reload ${joinLabels(labels)}, then paste this prompt to your agent to finish onboarding: "${ONBOARDING_AGENT_PROMPT}"`
     );
   } else if (skill.status === "failed") {
     lines.push(

--- a/src/tieline/status.ts
+++ b/src/tieline/status.ts
@@ -37,9 +37,16 @@ export interface TielineStatus {
   onboarding: {
     required: true;
     skill: "tieline-author";
-    instruction: "Use $tieline-author to onboard this repository.";
+    instruction: typeof ONBOARDING_AGENT_PROMPT;
     install_command: "tieline init .";
   } | null;
+}
+
+export const ONBOARDING_AGENT_PROMPT =
+  "Use the tieline-author skill to onboard this repository to Tieline.";
+
+function onboardingPasteInstruction(): string {
+  return `Paste this prompt to your agent to finish onboarding: "${ONBOARDING_AGENT_PROMPT}"`;
 }
 
 function configured(value: string | undefined): boolean {
@@ -97,13 +104,13 @@ export function getTielineStatus(
       ? ({
           required: true,
           skill: "tieline-author",
-          instruction: "Use $tieline-author to onboard this repository.",
+          instruction: ONBOARDING_AGENT_PROMPT,
           install_command: "tieline init .",
         } as const)
       : null;
   const nextAction =
     onboarding
-      ? onboarding.instruction
+      ? onboardingPasteInstruction()
       : !manifestExists
         ? "Run `tieline contract compile .` and review the semantic diff."
         : "Use $tieline-author to reconcile branch work; the pull request is the approval boundary.";


### PR DESCRIPTION
## What

The `Next:` action after `tieline init` installs the skill — and `tieline status` while the contract is empty — is now a prompt the user can copy straight into their agent:

> **Next:** Restart or reload Claude Code, then paste this prompt to your agent to finish onboarding: "Use the tieline-author skill to onboard this repository to Tieline."

## How

- New `ONBOARDING_AGENT_PROMPT` constant in `src/tieline/status.ts` — the raw pastable text, quoted in output so it's obvious what to copy.
- `status --json` `onboarding.instruction` is now that raw prompt (agents consuming JSON get the prompt itself, no framing to strip); `next_action` and the human renderers wrap it with the "Paste this prompt…" framing.
- Deliberately does **not** reintroduce the removed `agent_onboarding_prompt` field or "Agent handoff prompt:" line (KTD7: status carries an instruction, not a workflow copy) — only the instruction's shape changed, from a description to a pastable prompt.

## Breaking

`onboarding.instruction` and `next_action` literal values in `status --json` change wording. No known consumers.

## Testing

`npm run test:tieline` (build + skill-install + workspace suites) passes; assertions updated to the new wording, including the guards that `agent_onboarding_prompt` stays absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)