### PR TITLE
feat(grade): put claim-side contract changes in the grading scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,11 +409,16 @@ tieline contract grade . --base <base-ref> --emit-scope --json
 tieline contract grade . --base <base-ref> --verify <verdicts.json>
 ```
 
-The first command deterministically emits every diff-scoped acceptance-
-criterion link to grade and the exact symbol citations allowed for it. The
-agent inspects the artifacts and assigns `supported`, `partial`, or
-`unsupported`; the second command verifies that every verdict belongs to the
-scope and that every claimed citation came from its allow-list. Tieline does
+The first command deterministically emits every changed acceptance-criterion
+link to grade and the exact symbol citations allowed for it. A link enters the
+scope when either of its sides changed against the base: the artifact side —
+the linked file was modified, added, renamed, or deleted — or the claim side —
+the link is new, belongs to a new criterion, or its criterion was re-worded,
+even when the linked file is untouched. A base with no manifest is the initial
+contract, so onboarding's links are all in scope as `link_added`. The agent
+inspects the artifacts and assigns `supported`, `partial`, or `unsupported`;
+the second command verifies that every verdict belongs to the scope and that
+every claimed citation came from its allow-list. Tieline does
 not call a model, database, or network for this workflow. Verification is
 advisory by default, including negative results; add `--strict` to the verify
 command only when unsupported evidence should fail the gate. The packaged
@@ -767,7 +772,7 @@ earlier model must be recreated rather than upgraded in place.
 | `migrations/` | PostgreSQL/pgvector schema and role baseline |
 | `scripts/` | Contract, retrieval, transport, and integration verification |
 | `skills/tieline-author/` | Packaged semantic authoring workflow |
-| `skills/tieline-grade/` | Packaged agent workflow for grading diff-scoped contract evidence |
+| `skills/tieline-grade/` | Packaged agent workflow for grading changed contract evidence |
 | `.tieline/` | This repository's own accepted contract and compiled manifest |
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tieline",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tieline",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tieline",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tieline",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tieline",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Living Story/AC contract and semantic graph grounded in code, tests, help content, and organizational evidence.",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tieline",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Living Story/AC contract and semantic graph grounded in code, tests, help content, and organizational evidence.",
   "license": "MIT",
   "repository": {

--- a/scripts/test-grade.ts
+++ b/scripts/test-grade.ts
@@ -3,6 +3,8 @@ import { execFileSync } from "node:child_process";
 import {
   mkdirSync,
   mkdtempSync,
+  readFileSync,
+  readdirSync,
   renameSync,
   rmSync,
   unlinkSync,
@@ -22,7 +24,9 @@ import {
 import {
   compileContractManifest,
   compileContractManifestWithSources,
+  parseContractManifestSnapshot,
   writeContractManifest,
+  type ContractManifest,
 } from "../src/contract/manifest.js";
 
 const REPOSITORY = "grade-fixture";
@@ -129,11 +133,15 @@ capability:
     repositoryKey: REPOSITORY,
     specDirectory: ".tieline/spec",
   });
-  const scopeFor = (changes: RepositoryPathChange[]) =>
+  const scopeFor = (
+    changes: RepositoryPathChange[],
+    baseManifest: ContractManifest | null = manifest
+  ) =>
     buildGradeScope({
       repositoryRoot: root,
       base: "HEAD",
       manifest,
+      baseManifest,
       changes,
       sourceRoots: ["src"],
       ignore: [".git", ".tieline"],
@@ -192,6 +200,67 @@ capability:
   assert.deepEqual(
     scopeFor([{ status: "modified", path: "src/unlinked.ts" }]).entries,
     []
+  );
+
+  // With no base manifest — the initial contract — every local link is a new
+  // claim, so onboarding is graded even though not one artifact changed.
+  const initial = scopeFor([], null);
+  assert.equal(initial.scoped_links, 7);
+  assert.equal(new Set(initial.entries.map((entry) => entry.id)).size, 7);
+  for (const entry of initial.entries) {
+    assert.equal(entry.reason, "link_added");
+    assert.equal(entry.previous_path, null);
+    assert.equal(entry.linked_path, entry.path);
+  }
+  assert.deepEqual(
+    initial.entries.map((entry) => [
+      entry.acceptance_criterion_stable_id,
+      entry.link_scope,
+      entry.path,
+    ]),
+    [
+      ["FEATURE-001-AC1", "direct", "src/feature.ts"],
+      ["FEATURE-001-AC1", "direct", "src/renamed.ts"],
+      ["FEATURE-001-AC1", "direct", "src/shared.ts"],
+      ["FEATURE-001-AC1", "story_fallback", "src/shared.ts"],
+      ["FEATURE-001-AC2", "direct", "src/deleted.ts"],
+      ["FEATURE-001-AC2", "direct", "src/notes.md"],
+      ["FEATURE-001-AC2", "story_fallback", "src/shared.ts"],
+    ]
+  );
+  assert.deepEqual(initial.entries[0]?.symbols, [
+    "const:featureLocal",
+    "function:computeFeature",
+  ]);
+
+  // A re-worded criterion re-opens every link it claims, including inherited
+  // story fallbacks, without touching any artifact. Grading judges the current
+  // sentence, so the entry carries it rather than the base's.
+  const rewordedBase = structuredClone(manifest);
+  rewordedBase.capabilities[0]!.stories[0]!.acceptance_criteria[0]!.criterion =
+    "Tieline must emit only relevant changed links.";
+  const reworded = scopeFor([], rewordedBase);
+  assert.equal(reworded.scoped_links, 4);
+  for (const entry of reworded.entries) {
+    assert.equal(entry.reason, "criterion_changed");
+    assert.equal(entry.acceptance_criterion_stable_id, "FEATURE-001-AC1");
+    assert.equal(
+      entry.acceptance_criterion,
+      "Tieline must emit every changed link without relevance filtering."
+    );
+  }
+
+  // A claim that is both diff-scoped and claim-side changed yields exactly one
+  // entry, carrying the diff's reason.
+  const overlapping = scopeFor(
+    [{ status: "modified", path: "src/feature.ts" }],
+    null
+  );
+  assert.equal(overlapping.scoped_links, 7);
+  assert.equal(
+    overlapping.entries.find((entry) => entry.path === "src/feature.ts")
+      ?.reason,
+    "modified"
   );
 
   unlinkSync(resolve(root, "src/deleted.ts"));
@@ -318,6 +387,46 @@ capability:
       specDirectory: ".tieline/spec",
     })
   );
+
+  // A snapshot parse of the directory just written yields the manifest the
+  // compiler produced, so a base-ref read compares like with like; and a
+  // snapshot that was never a compiled manifest is refused, not guessed at.
+  const manifestDirectory = resolve(root, ".tieline/manifest");
+  const snapshotFiles = readdirSync(manifestDirectory).map((name) => ({
+    name,
+    content: readFileSync(resolve(manifestDirectory, name), "utf8"),
+  }));
+  assert.deepEqual(
+    parseContractManifestSnapshot(snapshotFiles, "ref 'TEST'"),
+    manifest
+  );
+  assert.throws(
+    () =>
+      parseContractManifestSnapshot(
+        snapshotFiles.filter((file) => file.name !== "index.json"),
+        "ref 'TEST'"
+      ),
+    /has no 'index\.json'/
+  );
+  assert.throws(
+    () =>
+      parseContractManifestSnapshot(
+        snapshotFiles.filter((file) => file.name === "index.json"),
+        "ref 'TEST'"
+      ),
+    /index but no capabilities/
+  );
+  assert.throws(
+    () =>
+      parseContractManifestSnapshot(
+        snapshotFiles.map((file) =>
+          file.name === "index.json" ? file : { ...file, name: "WRONG.json" }
+        ),
+        "ref 'TEST'"
+      ),
+    /belongs in/
+  );
+
   execFileSync("git", ["init"], { cwd: root, stdio: "ignore" });
   execFileSync("git", ["config", "user.email", "test@example.test"], {
     cwd: root,
@@ -647,6 +756,83 @@ capability:
       {}
     ),
     /cannot be used with option '--verify(?: <verdicts\.json>)?'/
+  );
+
+  // Re-wording a criterion is claim-side scope over real git history; the
+  // artifact the branch also changed keeps its diff reason.
+  const specPath = resolve(root, ".tieline/spec/feature.yaml");
+  writeFileSync(
+    specPath,
+    readFileSync(specPath, "utf8").replace(
+      "Tieline must emit every changed link without relevance filtering.",
+      "Tieline must emit every changed link and every changed claim."
+    )
+  );
+  writeContractManifest(
+    resolve(root, ".tieline/manifest"),
+    compileContractManifestWithSources({
+      repositoryRoot: root,
+      repositoryKey: REPOSITORY,
+      specDirectory: ".tieline/spec",
+    })
+  );
+  output = "";
+  assert.equal(
+    await runCli(
+      ["contract", "grade", root, "--base", "HEAD", "--emit-scope", "--json"],
+      io,
+      {}
+    ),
+    0
+  );
+  const rewordedScope = JSON.parse(output) as GradeScope;
+  assert.equal(rewordedScope.scoped_links, 4);
+  assert.deepEqual(
+    rewordedScope.entries.map((entry) => [entry.path, entry.reason]),
+    [
+      ["src/feature.ts", "modified"],
+      ["src/renamed.ts", "criterion_changed"],
+      ["src/shared.ts", "criterion_changed"],
+      ["src/shared.ts", "criterion_changed"],
+    ]
+  );
+  for (const entry of rewordedScope.entries) {
+    assert.equal(entry.acceptance_criterion_stable_id, "FEATURE-001-AC1");
+    assert.equal(
+      entry.acceptance_criterion,
+      "Tieline must emit every changed link and every changed claim."
+    );
+  }
+  execFileSync("git", ["checkout", "--", ".tieline"], { cwd: root });
+
+  // An init-style base — no manifest at the ref — grades the entire contract:
+  // the changed artifact keeps its diff reason and every other link is a new
+  // claim.
+  execFileSync("git", ["rm", "-r", "--cached", "--quiet", ".tieline"], {
+    cwd: root,
+  });
+  execFileSync("git", ["commit", "-m", "untrack contract"], {
+    cwd: root,
+    stdio: "ignore",
+  });
+  output = "";
+  assert.equal(
+    await runCli(
+      ["contract", "grade", root, "--base", "HEAD", "--emit-scope", "--json"],
+      io,
+      {}
+    ),
+    0
+  );
+  const initScope = JSON.parse(output) as GradeScope;
+  assert.equal(initScope.scoped_links, 7);
+  assert.equal(
+    initScope.entries.filter((entry) => entry.reason === "link_added").length,
+    6
+  );
+  assert.equal(
+    initScope.entries.find((entry) => entry.path === "src/feature.ts")?.reason,
+    "modified"
   );
 
   rmSync(resolve(root, ".tieline/manifest"), {

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -401,9 +401,11 @@ try {
     interactive.output.join(""),
     /Skill: tieline-author installed for Codex and Claude Code \(project\)/
   );
+  // The onboarding prompt has to stand alone on its own line so it is
+  // obviously the thing to copy; keep it out of the surrounding prose.
   assert.match(
     interactive.output.join(""),
-    /paste this prompt to your agent to finish onboarding: "Use the tieline-author skill to onboard this repository to Tieline\."/
+    /Next steps\n {2}1\. Restart or reload your agent\.\n {2}2\. Copy the prompt below and paste it to your agent\.\n\n─+\nUse the tieline-author skill to onboard this repository to Tieline\.\n─+/
   );
 
   const cancelledTarget = resolve(root, "Cancelled Checkout");
@@ -553,7 +555,7 @@ try {
   assert.match(failedOutput, /installation incomplete/i);
   assert.match(
     failedOutput,
-    /Retry: tieline init .*Failed Install Checkout.*--yes --agent codex --skill-scope project/
+    /Retry the install by running:\n\n─+\ntieline init .*Failed Install Checkout.*--yes --agent codex --skill-scope project\n─+/
   );
   assert.doesNotMatch(failedOutput, /private nested output|Agent handoff prompt/);
 
@@ -634,7 +636,10 @@ try {
   assert.match(firstOutput, /code scope: src/i);
   assert.match(firstOutput, /optional capabilities:.*duplicate checks/i);
   assert.match(firstOutput, /skill: not installed/i);
-  assert.match(firstOutput, /install later: tieline init \./i);
+  assert.match(
+    firstOutput,
+    /Install the tieline-author skill by running:\n\n─+\ntieline init \.\n─+/
+  );
   assert.doesNotMatch(firstOutput, /Warning \[/);
   assert.doesNotMatch(firstOutput, /Agent handoff prompt:/);
   assert.doesNotMatch(firstOutput, /otherwise continue directly from this brief/i);
@@ -800,7 +805,11 @@ try {
   );
   assert.match(
     humanStatus.output.join(""),
-    /Next: Paste this prompt to your agent to finish onboarding: "Use the tieline-author skill to onboard this repository to Tieline\."/
+    /Next: Copy the prompt below and paste it to your agent to finish onboarding\./
+  );
+  assert.match(
+    humanStatus.output.join(""),
+    /─+\nUse the tieline-author skill to onboard this repository to Tieline\.\n─+/
   );
   assert.match(humanStatus.output.join(""), /Install skill: tieline init \./);
   assert.doesNotMatch(humanStatus.output.join(""), /Agent handoff prompt:/);

--- a/skills/tieline-author/SKILL.md
+++ b/skills/tieline-author/SKILL.md
@@ -109,8 +109,14 @@ from an Observation, Backlog Item, planning Story, existing AC, or branch diff.
    tieline check --base <base-ref>
    ```
 
-9. Summarize the semantic diff, impacted ACs, freshness warnings, coverage
-   delta, likely duplicates, unresolved conflicts, and unmapped source files.
+9. Grade the contract change with the tieline-grade skill. The grading scope
+   covers both sides of every link — artifacts the branch moved, and links or
+   criteria the branch added or re-worded against unchanged code. You authored
+   these links, so dispatch fresh subagents batched by artifact path and give
+   them only the emitted scope entries, never your authoring rationale.
+10. Summarize the semantic diff, impacted ACs, grade findings, freshness
+    warnings, coverage delta, likely duplicates, unresolved conflicts, and
+    unmapped source files.
 
 Do not mutate a repository-owned Story through MCP. Change its YAML on the
 branch and let normal PR review accept or reject it.

--- a/skills/tieline-author/references/onboarding.md
+++ b/skills/tieline-author/references/onboarding.md
@@ -21,6 +21,13 @@ first authoring pass, not a separate approval or handoff process.
    manifest plus organization-wide semantic matching when available.
 6. Author the initial capabilities, Stories, and ACs under `.tieline/spec/`.
    Never create generic starter content merely to make the directory non-empty.
-7. Validate and compile the contract, then summarize the sources used,
-   inferred semantic boundaries, likely duplicates, mapping gaps, and proposed
-   contract changes for normal pull-request review.
+7. Validate and compile the contract.
+8. Grade the initial contract with the tieline-grade skill. With no manifest
+   at the comparison base, every authored link enters the grading scope as
+   `link_added`. You authored every one of them, so dispatch fresh subagents
+   batched by artifact path, passing only the emitted scope entries and never
+   the authoring rationale; a link none of your reasoning can defend to a cold
+   reader should be graded down, not argued for.
+9. Summarize the sources used, inferred semantic boundaries, likely
+   duplicates, mapping gaps, grade findings, and proposed contract changes for
+   normal pull-request review.

--- a/skills/tieline-grade/SKILL.md
+++ b/skills/tieline-grade/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tieline-grade
-description: Judge whether the Tieline acceptance-criterion links touched by a branch are supported by their artifacts, then verify every judgment against a deterministic citation fence. Use when asked to grade, judge, audit, or check the evidence quality of changed Tieline contract links, or to confirm that linked code and tests still support their criteria before a pull request merges.
+description: Judge whether the Tieline acceptance-criterion links touched by a branch — artifacts that moved, links that were added, criteria that were re-worded, or an entire initial contract — are supported by their artifacts, then verify every judgment against a deterministic citation fence. Use when asked to grade, judge, audit, or check the evidence quality of changed Tieline contract links, to grade a freshly onboarded contract, or to confirm that linked code and tests still support their criteria before a pull request merges.
 ---
 
 # Tieline grade
@@ -24,11 +24,17 @@ This command is offline and database-free. Each entry contains:
 - the acceptance-criterion ID and exact `acceptance_criterion` text;
 - `relation`, `linked_path`, and `link_scope`, describing the contract link;
 - `path`, the current artifact to inspect;
-- `reason` and `previous_path`, describing the diff; and
+- `reason` and `previous_path`, describing why the link is in scope: a diff
+  status when the artifact side moved, or `link_added` / `criterion_changed`
+  when the claim side is new or re-worded against the base manifest; and
 - `symbols`, the complete allow-list of citations for that artifact.
 
-An empty scope is a stated answer: report that no changed path is claimed by a
-contract evidence link, then stop.
+A base ref with no contract manifest — the initial contract — puts every link
+in scope as `link_added`, so onboarding is graded by this same workflow.
+
+An empty scope is a stated answer: report that no contract link changed
+against the base — no claimed artifact moved and no link or criterion is new
+or re-worded — then stop.
 
 ## Judge every entry
 
@@ -36,7 +42,9 @@ Read the artifact and relevant diff for every scope entry. For a rename,
 `linked_path` is the exact old-path or new-path target named by the contract;
 read the current `path` and use `previous_path` for context. For a deletion,
 inspect the diff or base version; its empty symbol list means it cannot receive
-`supported`.
+`supported`. For `link_added` and `criterion_changed`, the artifact may be
+untouched by the branch and there may be no diff hunk to lean on; judge the
+artifact as it stands against the entry's criterion sentence.
 
 Choose exactly one grade per entry:
 
@@ -57,6 +65,28 @@ Apply these rules:
    `partial` or `unsupported`. Do not stretch the nearest plausible name.
 5. Treat `unsupported` as useful evidence, not a failed grading run. Never omit
    a difficult entry; omission is normalized to `unsupported`.
+
+## Dispatch fresh subagents for self-authored or bulk scopes
+
+When the scope contains links authored in this session — onboarding grades the
+entire initial contract this way — or is too large to judge in one context, do
+not judge the entries yourself. A context holding the rationale that produced
+a link cannot judge that link independently; what makes a grade independent is
+what the judge cannot see.
+
+1. Group the scope entries by `path`, one batch per artifact.
+2. Dispatch one subagent per batch. Give it only the batch's scope entries —
+   `id`, `acceptance_criterion`, `relation`, `linked_path`, `path`, `reason`,
+   and `symbols` — plus the judgment rules above, and have it read the
+   artifact and return exactly one verdict per entry. Never pass authoring
+   notes, rationale, or surrounding conversation.
+3. Collect the returned verdicts into the single verdicts document yourself,
+   then verify as below.
+
+The fence extends the subagents no trust: a fabricated citation is downgraded
+and an unreturned verdict is normalized to `unsupported` either way. When
+grading self-authored links directly instead, disclose in the report that the
+grades are author-graded.
 
 ## Show the judgment before verification
 

--- a/src/cli-ui.ts
+++ b/src/cli-ui.ts
@@ -45,6 +45,18 @@ export function renderBanner(ui: Palette): string {
   }).join("\n");
 }
 
+const CALLOUT_MAX_WIDTH = 72;
+
+/**
+ * Sets a copy-me value apart from the report around it. The value sits alone
+ * on its own line between rules so a triple-click selects exactly the text to
+ * paste — a prefix, indent, or box border would be selected along with it.
+ */
+export function renderCopyCallout(ui: Palette, value: string): string[] {
+  const rule = ui.dim("─".repeat(Math.min(value.length, CALLOUT_MAX_WIDTH)));
+  return [rule, ui.bold(ui.cyan(value)), rule];
+}
+
 /**
  * Ask for a single value with a default. Uses a Clack prompt on an
  * interactive terminal and falls back to the injected io.question

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ import {
   outro,
   paletteFor,
   renderBanner,
+  renderCopyCallout,
   selectChoice,
   showNote,
 } from "./cli-ui.js";
@@ -235,10 +236,16 @@ function renderStatus(status: TielineStatus, ui: Palette): string {
     `  optional capabilities: organization_matching=${state(status.capabilities.semantic_matching_configured, "configured", "not configured")}, planning_writes=${state(status.capabilities.planning_writes_configured, "configured", "not configured")}`,
     `  integration: mcp_template=${state(status.integration.mcp_template_present, "present", "missing")}`,
     `  contract: ${status.contract.stories} Stories, ${status.contract.acceptance_criteria} ACs, manifest=${state(status.contract.manifest_exists, "present", "missing")}`,
-    `${ui.cyan("Next:")} ${status.next_action}`,
   ];
   if (status.onboarding) {
-    lines.push(`${ui.cyan("Install skill:")} ${status.onboarding.install_command}`);
+    lines.push(
+      `${ui.cyan("Next:")} Copy the prompt below and paste it to your agent to finish onboarding.`,
+      `${ui.cyan("Install skill:")} ${status.onboarding.install_command}`,
+      "",
+      ...renderCopyCallout(ui, status.onboarding.instruction)
+    );
+  } else {
+    lines.push(`${ui.cyan("Next:")} ${status.next_action}`);
   }
   return lines.join("\n");
 }
@@ -290,7 +297,6 @@ function renderInitSummary(
   if (notes.length > 0) lines.push(`Readiness notes: ${joinLabels(notes)}`);
 
   if (skill.status === "installed") {
-    const labels = skill.requestedAgents.map(agentLabel);
     const installed = skill.installedAgents.map(agentLabel);
     const alreadyPresent = skill.alreadyPresentAgents.map(agentLabel);
     const skillState = [
@@ -303,18 +309,31 @@ function renderInitSummary(
     ].join("; ");
     lines.push(
       `Skill: tieline-author ${skillState} (${skillScope})`,
-      `${ui.cyan("Next:")} Restart or reload ${joinLabels(labels)}, then paste this prompt to your agent to finish onboarding: "${ONBOARDING_AGENT_PROMPT}"`
+      "",
+      ui.bold("Next steps"),
+      "  1. Restart or reload your agent.",
+      "  2. Copy the prompt below and paste it to your agent.",
+      "",
+      ...renderCopyCallout(ui, ONBOARDING_AGENT_PROMPT)
     );
   } else if (skill.status === "failed") {
     lines.push(
       ui.yellow("Skill: tieline-author installation incomplete"),
       `Reason: ${skill.reason}`,
-      `${ui.cyan("Retry:")} ${skill.retryCommand}`
+      "",
+      ui.bold("Next step"),
+      "  Retry the install by running:",
+      "",
+      ...renderCopyCallout(ui, skill.retryCommand ?? "tieline init .")
     );
   } else {
     lines.push(
       "Skill: not installed",
-      `${ui.cyan("Install later:")} tieline init .`
+      "",
+      ui.bold("Next step"),
+      "  Install the tieline-author skill by running:",
+      "",
+      ...renderCopyCallout(ui, "tieline init .")
     );
   }
   io.write(`${lines.join("\n")}\n`);
@@ -606,6 +625,9 @@ async function runInit(
     env,
     dependencies
   );
+  // Close the Clack flow before the summary so the paste-ready prompt is the
+  // last thing on screen rather than trailing into the flow's end cap.
+  if (richInteractive) await outro(io, "Tieline workspace ready");
   renderInitSummary(
     result.workspace,
     runInitPreflight(result.workspace.root, embedding, initEnv),
@@ -614,7 +636,6 @@ async function runInit(
     io,
     env
   );
-  if (richInteractive) await outro(io, "Tieline workspace ready");
   return skill.status === "failed" ? 1 : 0;
 }
 

--- a/src/commands/contract.ts
+++ b/src/commands/contract.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { basename, dirname, isAbsolute, resolve } from "node:path";
+import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { PostgresContractSyncRepository } from "../adapters/postgres/contract-sync-repository.js";
 import { PostgresContractReadRepository } from "../adapters/postgres/contract-read-repository.js";
 import { PostgresSemanticRepository } from "../adapters/postgres/semantic-repository.js";
@@ -11,6 +11,7 @@ import {
 import {
   attachCurrentArtifactHashes,
   compileContractManifestWithSources,
+  parseContractManifestSnapshot,
   readContractManifest,
   writeContractManifest,
   CONTRACT_MANIFEST_INDEX_FILE,
@@ -196,6 +197,11 @@ function runGrade(
     repositoryRoot: parsed.repositoryRoot,
     base: parsed.base,
     manifest,
+    baseManifest: manifestAtBase(
+      parsed.repositoryRoot,
+      parsed.base,
+      parsed.manifestPath
+    ),
     changes: changesSince(parsed.repositoryRoot, parsed.base),
     sourceRoots: parsed.sourceRoots,
     ignore: parsed.ignore,
@@ -243,6 +249,51 @@ function changesSince(repositoryRoot: string, base: string) {
       ["diff", "--name-status", "--find-renames", base],
       { cwd: repositoryRoot, encoding: "utf8" }
     )
+  );
+}
+
+/**
+ * The manifest as committed at `base`, or null when that ref carries none —
+ * the initial contract, whose every link is then claim-side grading scope.
+ *
+ * Only a manifest inside the repository can have a version at a ref, so a
+ * manifest configured elsewhere is refused: treating it as absent would grade
+ * the whole contract as newly claimed, which is a fabricated scope.
+ */
+function manifestAtBase(
+  repositoryRoot: string,
+  base: string,
+  manifestPath: string
+): ContractManifest | null {
+  const directory = relative(resolve(repositoryRoot), resolve(manifestPath))
+    .split(sep)
+    .join("/");
+  if (
+    directory === ".." ||
+    directory.startsWith("../") ||
+    isAbsolute(directory)
+  ) {
+    throw new Error(
+      `Cannot derive claim-side grading scope: the manifest at '${manifestPath}' is outside the repository, so '${base}' cannot hold a version of it.`
+    );
+  }
+  const names = execFileSync(
+    "git",
+    ["ls-tree", "-r", "--name-only", base, "--", directory],
+    { cwd: repositoryRoot, encoding: "utf8" }
+  )
+    .split("\n")
+    .filter(Boolean);
+  if (names.length === 0) return null;
+  return parseContractManifestSnapshot(
+    names.map((name) => ({
+      name: name.slice(`${directory}/`.length),
+      content: execFileSync("git", ["show", `${base}:${name}`], {
+        cwd: repositoryRoot,
+        encoding: "utf8",
+      }),
+    })),
+    `ref '${base}'`
   );
 }
 

--- a/src/contract/grade.ts
+++ b/src/contract/grade.ts
@@ -2,8 +2,18 @@
  * Deterministic scaffolding for a semantic judgment Tieline does not make.
  *
  * The host agent decides whether an artifact supports an acceptance criterion.
- * Tieline owns the complete diff scope and the closed citation vocabulary, so a
+ * Tieline owns the complete scope and the closed citation vocabulary, so a
  * grader may refuse support but cannot silently skip work or invent evidence.
+ *
+ * A contract link is a claim with two sides, and the scope covers a change to
+ * either one. The artifact side comes from the branch diff: a linked file that
+ * moved re-opens the claim over it. The claim side comes from comparing the
+ * branch manifest against the base ref's manifest: a link the base does not
+ * carry verbatim — new, inherited by a new criterion, or belonging to a
+ * re-worded criterion — is a judgment nobody has made yet, even when its
+ * artifact is untouched. The initial contract is the degenerate case: with no
+ * manifest at the base, every link is claim-side scope, so onboarding is
+ * graded by the same mechanism as drift.
  */
 
 import { createHash } from "node:crypto";
@@ -14,6 +24,7 @@ import type { RepositoryPathChange } from "./impact.js";
 import type { ContractManifest } from "./manifest.js";
 import {
   analyzeContractReconciliation,
+  buildContractClaimIndex,
   type ClaimingCriterion,
   type ReconciliationChangeStatus,
   type ReconciliationLinkScope,
@@ -27,6 +38,18 @@ import {
 } from "./selector.js";
 
 const BINARY_SNIFF_BYTES = 8_000;
+
+/**
+ * Why a link is in the grading scope. A diff status means the artifact side
+ * moved. `link_added` means the base manifest does not carry this claim at
+ * all; `criterion_changed` means it does, but under a different
+ * acceptance-criterion sentence, so the judgment on record was made against
+ * prose that no longer exists.
+ */
+export type GradeScopeReason =
+  | ReconciliationChangeStatus
+  | "link_added"
+  | "criterion_changed";
 
 export interface GradeScopeEntry {
   /** Opaque identity the verdict must echo exactly. */
@@ -45,7 +68,7 @@ export interface GradeScopeEntry {
   path: string;
   /** The path before a rename, otherwise null. */
   previous_path: string | null;
-  reason: ReconciliationChangeStatus;
+  reason: GradeScopeReason;
   /** Complete, sorted allow-list for a supported verdict's citation. */
   symbols: string[];
 }
@@ -71,6 +94,14 @@ export interface BuildGradeScopeInput {
   repositoryRoot: string;
   base: string;
   manifest: ContractManifest;
+  /**
+   * The manifest as committed at `base`, or null when that ref carries none —
+   * the initial contract, whose every link is then claim-side scope. Required
+   * rather than defaulted: a caller must state what the base said, because
+   * omitting it would silently drop claim-side work from the scope, and the
+   * scope may never be narrowed.
+   */
+  baseManifest: ContractManifest | null;
   changes: RepositoryPathChange[];
   sourceRoots: string[];
   ignore?: string[];
@@ -135,6 +166,57 @@ function scopeId(input: {
   return `grade:${createHash("sha256").update(identity).digest("hex")}`;
 }
 
+/**
+ * The fields that make two claims the same assertion. Criterion text is
+ * deliberately absent — a re-worded criterion is the same claim with a
+ * changed sentence, which is its own scope reason rather than a new claim.
+ */
+function claimIdentity(claim: ClaimingCriterion): string {
+  return [
+    claim.acceptance_criterion_stable_id,
+    claim.relation,
+    claim.linked_path,
+    claim.link_scope,
+  ].join("\0");
+}
+
+type ClaimChangeReason = Extract<
+  GradeScopeReason,
+  "link_added" | "criterion_changed"
+>;
+
+/**
+ * Claims the current manifest carries that the base manifest does not carry
+ * verbatim. Removal has no entry on purpose: a deleted link leaves no claim to
+ * judge, and a deleted criterion takes its links with it.
+ */
+function changedContractClaims(
+  manifest: ContractManifest,
+  baseManifest: ContractManifest | null
+): Array<{ claim: ClaimingCriterion; reason: ClaimChangeReason }> {
+  const baseClaims = new Map<string, ClaimingCriterion>();
+  if (baseManifest) {
+    for (const claims of buildContractClaimIndex(baseManifest).values()) {
+      for (const claim of claims) baseClaims.set(claimIdentity(claim), claim);
+    }
+  }
+  const changed: Array<{
+    claim: ClaimingCriterion;
+    reason: ClaimChangeReason;
+  }> = [];
+  for (const claims of buildContractClaimIndex(manifest).values()) {
+    for (const claim of claims) {
+      const base = baseClaims.get(claimIdentity(claim));
+      if (!base) {
+        changed.push({ claim, reason: "link_added" });
+      } else if (base.acceptance_criterion !== claim.acceptance_criterion) {
+        changed.push({ claim, reason: "criterion_changed" });
+      }
+    }
+  }
+  return changed;
+}
+
 function compareEntries(left: GradeScopeEntry, right: GradeScopeEntry): number {
   return (
     left.acceptance_criterion_stable_id.localeCompare(
@@ -149,7 +231,8 @@ function compareEntries(left: GradeScopeEntry, right: GradeScopeEntry): number {
 
 /**
  * Derives the grading work list from reconciliation's shared contract-claim
- * index. Every changed local claim survives; relevance scores never participate.
+ * index plus a claim diff against the base manifest. Every changed local claim
+ * survives, whichever side of it changed; relevance scores never participate.
  */
 export function buildGradeScope(input: BuildGradeScopeInput): GradeScope {
   const reconciliation = analyzeContractReconciliation({
@@ -161,15 +244,21 @@ export function buildGradeScope(input: BuildGradeScopeInput): GradeScope {
     specDirectory: input.specDirectory,
   });
   const symbolCache = new Map<string, string[]>();
+  const symbolsFor = (path: string): string[] => {
+    let symbols = symbolCache.get(path);
+    if (!symbols) {
+      symbols = citableSymbolsForPath(input.repositoryRoot, path);
+      symbolCache.set(path, symbols);
+    }
+    return symbols;
+  };
   const entries = new Map<string, GradeScopeEntry>();
+  const diffScopedClaims = new Set<string>();
 
   for (const change of reconciliation.claimed_changes) {
-    let symbols = symbolCache.get(change.path);
-    if (!symbols) {
-      symbols = citableSymbolsForPath(input.repositoryRoot, change.path);
-      symbolCache.set(change.path, symbols);
-    }
+    const symbols = symbolsFor(change.path);
     for (const claim of change.claimed_by) {
+      diffScopedClaims.add(claimIdentity(claim));
       const id = scopeId({
         acceptanceCriterionStableId: claim.acceptance_criterion_stable_id,
         relation: claim.relation,
@@ -198,6 +287,39 @@ export function buildGradeScope(input: BuildGradeScopeInput): GradeScope {
     }
   }
 
+  // A claim both diff-scoped and claim-side changed yields the diff entry: it
+  // carries the change status and rename lineage a claim-side reason cannot.
+  for (const { claim, reason } of changedContractClaims(
+    input.manifest,
+    input.baseManifest
+  )) {
+    if (diffScopedClaims.has(claimIdentity(claim))) continue;
+    const id = scopeId({
+      acceptanceCriterionStableId: claim.acceptance_criterion_stable_id,
+      relation: claim.relation,
+      linkedPath: claim.linked_path,
+      path: claim.linked_path,
+      linkScope: claim.link_scope,
+    });
+    if (entries.has(id)) continue;
+    entries.set(id, {
+      id,
+      capability_stable_id: claim.capability_stable_id,
+      story_stable_id: claim.story_stable_id,
+      story_title: claim.story_title,
+      acceptance_criterion_stable_id: claim.acceptance_criterion_stable_id,
+      acceptance_criterion: claim.acceptance_criterion,
+      relation: claim.relation,
+      provenance: claim.provenance,
+      link_scope: claim.link_scope,
+      linked_path: claim.linked_path,
+      path: claim.linked_path,
+      previous_path: null,
+      reason,
+      symbols: [...symbolsFor(claim.linked_path)],
+    });
+  }
+
   const ordered = [...entries.values()].sort(compareEntries);
   return {
     base: input.base,
@@ -212,7 +334,9 @@ export function renderGradeScopeText(scope: GradeScope): string {
     `Grading scope: ${scope.scoped_links} changed contract link(s) against ${scope.base}.\n`,
   ];
   if (scope.entries.length === 0) {
-    lines.push("  No changed path is claimed by a contract evidence link.\n");
+    lines.push(
+      "  No contract link changed: no changed path is claimed by an evidence link, and no link or criterion is new or re-worded against the base.\n"
+    );
     return lines.join("");
   }
   for (const entry of scope.entries) {

--- a/src/contract/manifest.ts
+++ b/src/contract/manifest.ts
@@ -590,6 +590,102 @@ export function readContractManifest(directory: string): ContractManifest {
   };
 }
 
+/** A manifest file from somewhere other than the working tree: its name within the manifest directory and its raw JSON content. */
+export interface ContractManifestSnapshotFile {
+  name: string;
+  content: string;
+}
+
+/**
+ * Reassembles a manifest from file contents rather than from disk, applying
+ * the same structural checks as `readContractManifest`.
+ *
+ * This exists for readers holding a historical manifest — grading reads the
+ * base ref's manifest out of git to learn which contract links the branch
+ * added or re-worded. History cannot be recompiled, so unlike the disk
+ * reader the errors name the snapshot's origin instead of advising a
+ * regeneration: a snapshot failing these checks was never something a
+ * compilation wrote, and the caller must surface that rather than guess.
+ *
+ * `origin` is a human description of where the files came from, e.g.
+ * `ref 'main'`.
+ */
+export function parseContractManifestSnapshot(
+  files: ContractManifestSnapshotFile[],
+  origin: string
+): ContractManifest {
+  const parseJson = (file: ContractManifestSnapshotFile): unknown => {
+    try {
+      return JSON.parse(file.content);
+    } catch (error) {
+      throw new ContractManifestError(
+        `Cannot parse the contract manifest file '${file.name}' at ${origin}: ${describeError(error)}`
+      );
+    }
+  };
+  const index = files.find(
+    (file) => file.name === CONTRACT_MANIFEST_INDEX_FILE
+  );
+  if (!index) {
+    throw new ContractManifestError(
+      `The contract manifest at ${origin} has no '${CONTRACT_MANIFEST_INDEX_FILE}'.`
+    );
+  }
+  const parsedIndex = parseManifestPart(
+    contractManifestIndexSchema,
+    parseJson(index),
+    "The contract manifest index",
+    `${index.name} (${origin})`
+  );
+
+  const inputs: ManifestInput[] = [];
+  const capabilities: ManifestCapability[] = [];
+  const claimedInputs = new Map<string, string>();
+  const shards = files
+    .filter(
+      (file) =>
+        file.name !== CONTRACT_MANIFEST_INDEX_FILE &&
+        file.name.endsWith(SHARD_EXTENSION)
+    )
+    .sort((left, right) => left.name.localeCompare(right.name));
+  for (const file of shards) {
+    const shard = parseManifestPart(
+      contractManifestShardSchema,
+      parseJson(file),
+      "The contract manifest capability",
+      `${file.name} (${origin})`
+    ) as ContractManifestShard;
+    const expected = shardFileName(shard.capability.stable_id);
+    if (file.name !== expected) {
+      throw new ContractManifestError(
+        `The contract manifest file '${file.name}' at ${origin} holds capability '${shard.capability.stable_id}', which belongs in '${expected}'.`
+      );
+    }
+    const claimedBy = claimedInputs.get(shard.input.path);
+    if (claimedBy) {
+      throw new ContractManifestError(
+        `The contract manifest at ${origin} records spec file '${shard.input.path}' under capabilities '${claimedBy}' and '${shard.capability.stable_id}'. Each spec file declares exactly one capability.`
+      );
+    }
+    claimedInputs.set(shard.input.path, shard.capability.stable_id);
+    inputs.push(shard.input);
+    capabilities.push(shard.capability);
+  }
+  if (capabilities.length === 0) {
+    throw new ContractManifestError(
+      `The contract manifest at ${origin} has an index but no capabilities.`
+    );
+  }
+  return {
+    schema_version: parsedIndex.schema_version,
+    repository: parsedIndex.repository,
+    inputs: inputs.sort((left, right) => left.path.localeCompare(right.path)),
+    capabilities: capabilities.sort((left, right) =>
+      left.stable_id.localeCompare(right.stable_id)
+    ),
+  };
+}
+
 /**
  * Writes the manifest directory and returns what it did.
  *


### PR DESCRIPTION
## Summary

A contract link is a claim with two sides, but grading only ever triggered when the artifact side moved. A link authored against unchanged code, a re-worded criterion, and — the extreme case — the entire initial contract all merged with zero semantic grading. `tieline contract grade` now also diffs the branch manifest against the base ref's manifest, so claim-side changes enter the scope: new links as `link_added`, re-worded criteria as `criterion_changed`. A base with no manifest is the initial contract, which puts every link in scope — onboarding is graded by the same mechanism as drift, with no special init mode.

The skills close the trust gap this opens: an author grading its own links is anchored by its own rationale, so `tieline-grade` now instructs dispatching fresh subagents for self-authored or bulk scopes — batched by artifact path, given only the scope entries, never the authoring notes — and the authoring/onboarding flows grade the contract before summarizing. The citation fence extends the judges no trust either way: fabricated citations and missing verdicts still downgrade to `unsupported`.

## Design notes

- The scope may never be narrowed, so `buildGradeScope` requires `baseManifest` (null means the ref has no manifest) rather than defaulting it, and a corrupt base manifest fails loudly instead of being read as absent — absence would fabricate an all-new scope.
- A claim that is both diff-scoped and claim-side changed yields one entry carrying the diff reason, preserving change status and rename lineage.
- New `parseContractManifestSnapshot` reassembles a manifest from git file contents with the same structural checks as the disk reader; its errors name the ref instead of advising a recompile, since history cannot be regenerated.

**Breaking:** `BuildGradeScopeInput` gains a required `baseManifest` field, and grade output can now carry the two new `reason` values.

## Also in this PR

- `tieline init` and `tieline status` render copy-ready prompts and commands as standalone callouts between rules, so a triple-click selects exactly the text to paste.
- Version bumps 0.1.8 → 0.1.9 to get past a failed npm publish.

## Test plan

`npm run test:contract` passes with new coverage: an init-style base scopes every link as `link_added`, a re-worded criterion re-opens its direct and story-fallback links, overlap dedupes to the diff reason, the snapshot parser round-trips and refuses corrupt snapshots, and the CLI is exercised over real git history for both cases.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
