### PR TITLE
fix(init): quiet the final summary — relative path, Mode label, no premature callouts

### DIFF
--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -837,11 +837,19 @@ try {
   );
   const firstOutput = first.output.join("");
   assert.match(firstOutput, /MCP server: \.mcp\.json written/);
-  assert.match(firstOutput, /Review: open \.tieline\/review\.html/);
-  assert.match(firstOutput, /workspace: ready/i);
-  assert.match(firstOutput, /runtime: offline.*local contract authoring ready/i);
+  assert.match(firstOutput, /Workspace: ready at \.tieline\//);
+  assert.doesNotMatch(
+    firstOutput,
+    new RegExp(target.replaceAll("\\", "\\\\")),
+    "the summary must not print absolute paths"
+  );
+  assert.match(firstOutput, /Mode: offline.*local contract authoring ready/i);
   assert.match(firstOutput, /code scope: src/i);
-  assert.match(firstOutput, /optional capabilities:.*duplicate checks/i);
+  assert.doesNotMatch(
+    firstOutput,
+    /Optional capabilities|Review: open/,
+    "the summary leads to the paste prompt without optional-feature or review noise"
+  );
   assert.match(firstOutput, /skill: not installed/i);
   assert.match(
     firstOutput,
@@ -964,7 +972,7 @@ try {
   );
   assert.match(
     resumed.output.join(""),
-    /Runtime: offline.*local contract authoring ready/i
+    /Mode: offline.*local contract authoring ready/i
   );
   assert.ok(
     readWorkspaceProfile(workspace, {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,10 +50,7 @@ import {
   type CodexMcpOutcome,
   type McpConfigOutcome,
 } from "./tieline/mcp-config.js";
-import {
-  TIELINE_REVIEW_PAGE,
-  writeWorkspaceReviewPage,
-} from "./tieline/review.js";
+import { writeWorkspaceReviewPage } from "./tieline/review.js";
 import {
   detectRepositoryAgents,
   installTielineAuthor,
@@ -74,6 +71,7 @@ import {
 } from "./tieline/status.js";
 import {
   findTielineWorkspace,
+  TIELINE_DIRECTORY,
   type TielineWorkspace,
 } from "./tieline/workspace.js";
 
@@ -305,22 +303,10 @@ function renderInitSummary(
 ): void {
   const ui = paletteFor(io);
   const status = getTielineStatus(workspace, env);
-  const runtimeDescription =
+  const modeDescription =
     status.runtime.database_mode === "offline"
       ? "offline — local contract authoring ready"
       : `${databaseModeLabel(status.runtime.database_mode)} — ${status.runtime.setup_complete ? "setup complete" : "setup incomplete"}`;
-  const optional: string[] = [];
-  if (!status.capabilities.semantic_matching_configured) {
-    optional.push("organization-wide duplicate checks");
-  }
-  if (
-    preflight.some(
-      (check) =>
-        check.key === "embedding_provider" && check.status === "warning"
-    )
-  ) {
-    optional.push("semantic search");
-  }
   const notes: string[] = [];
   if (
     preflight.some(
@@ -330,17 +316,11 @@ function renderInitSummary(
     notes.push("Git metadata was not detected");
   }
   const lines = [
-    `${ui.green("Workspace:")} ready at ${workspace.directory}`,
-    `${ui.green("Runtime:")} ${runtimeDescription}`,
+    `${ui.green("Workspace:")} ready at ${TIELINE_DIRECTORY}/`,
+    `${ui.green("Mode:")} ${modeDescription}`,
     `Code scope: ${codeScopeLabel(workspace.config.repository.source_roots)}`,
     ...renderMcpSummary(mcp, codex, ui),
-    `Review: open ${TIELINE_REVIEW_PAGE} in a browser to browse capabilities as they are authored.`,
   ];
-  if (optional.length > 0) {
-    lines.push(
-      `Optional capabilities: ${joinLabels(optional)} ${optional.length === 1 ? "is" : "are"} not configured`
-    );
-  }
   if (notes.length > 0) lines.push(`Readiness notes: ${joinLabels(notes)}`);
 
   if (skill.status === "installed") {


### PR DESCRIPTION
## What

Screenshot review of a real init run showed the final phase was noisy and poorly ordered. Four changes, all in `renderInitSummary`:

- **`Workspace: ready at .tieline/`** — the absolute path is gone (it's always `<repo>/.tieline`, so the relative form says everything). A test asserts the summary contains no absolute path.
- **`Mode:` replaces `Runtime:`** — the line answers "which mode am I in" (offline / local Postgres / hosted), not "what process is running".
- **Review callout removed** — at init time the page is the empty stub; advertising it invited exactly the confusion seen in the first onboarding run. The skill's completion report (#33) owns the review link once there is something to review.
- **Optional-capabilities line removed** — preflight noise answering a question nobody asked yet.

`Readiness notes: Git metadata was not detected` stays, since it flags a real anomaly and never appears in normal git repos.

## After

```
Workspace: ready at .tieline/
Mode: offline — local contract authoring ready
Code scope: src
MCP server: .mcp.json written
MCP tools load when your client starts its next session; the tieline CLI works immediately.
Skill: tieline-author installed for Claude Code (project)

Next steps
  1. Restart or reload your agent.
  2. Copy the prompt below and paste it to your agent.
```

## Notes

- Cherry-picked off `main` (post-#32) as its own PR; the same commit was removed from #33's branch, so there's no overlap.
- Tests pin the removals with `doesNotMatch`; suite green on this exact base (built and run in a clean worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)