### PR TITLE
feat(onboarding): agent-driven Neon provisioning for the database question

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,11 @@ deployment, choose `local`, `openai`, or `supabase-edge`. In `existing`
 (hosted / remote) mode, the baseline defines the least-privilege roles as
 `NOLOGIN`. Before init, provide URLs for operator-managed login roles that
 inherit `tieline_reader`, `tieline_planning_writer`, and
-`tieline_repository_sync`; init does not create or rotate passwords.
+`tieline_repository_sync`; init does not create or rotate passwords unless
+`--provision-roles` explicitly asks it to. That flag assigns generated login
+passwords to the tieline roles directly, which is how the agent-driven
+provisioning path (a freshly created Neon project, for example) reaches a
+working setup from `DATABASE_URL_ADMIN` alone.
 Tieline is provider-neutral: a local Postgres installation, Neon, Supabase,
 RDS, or any other managed Postgres with pgvector enabled works. It reads
 `DATABASE_URL_ADMIN` from the environment or a local `.env`; credentials are

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ What lives where:
 | Location | Contents |
 | --- | --- |
 | `.tieline/` in the repository (committed, PR-reviewed) | Product identity and context (`config.json`), the contract YAML (`spec/`), the compiled manifest (`manifest/`) |
-| PostgreSQL (optional: local Docker, existing, or provisioned) | Observations, Backlog Items, planning Stories and revisions, semantic search embeddings |
+| PostgreSQL (optional: local Docker, existing, or provisioned) | A synced, queryable copy of the accepted contract, plus Observations (feature requests, ideas, bugs), Backlog Items, planning Stories and revisions, and semantic search embeddings |
 | Private profile outside the repository (`~/.config/tieline/`) | Database credentials and clone-local setup state — never committed, never shared through git |
 | `local` | Creates or reuses a dedicated Docker PostgreSQL + pgvector database and stores clone-local credentials privately |
 | `existing` (hosted / remote) | Connects a hosted or remote Postgres 16 + pgvector database identified by `DATABASE_URL_ADMIN`; no Docker container is required |

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Choose the database mode based on the workflow:
 
 | Mode | Behavior |
 | --- | --- |
-| `offline` | Writes the workspace and supports local YAML/manifest authoring without organization-wide matching |
+| `offline` | Writes the workspace and supports local YAML/manifest authoring; Observations, Backlog Items, planning Stories, and organization-wide matching need a database |
 | `local` | Creates or reuses a dedicated Docker PostgreSQL + pgvector database and stores clone-local credentials privately |
 | `existing` (hosted / remote) | Connects a hosted or remote Postgres 16 + pgvector database identified by `DATABASE_URL_ADMIN`; no Docker container is required |
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,15 @@ Choose the database mode based on the workflow:
 
 | Mode | Behavior |
 | --- | --- |
-| `offline` | Writes the workspace and supports local YAML/manifest authoring; Observations, Backlog Items, planning Stories, and organization-wide matching need a database |
+| `offline` | Writes the workspace and supports local YAML/manifest authoring; Observations, Backlog Items, planning Stories, and semantic matching need a database |
+
+What lives where:
+
+| Location | Contents |
+| --- | --- |
+| `.tieline/` in the repository (committed, PR-reviewed) | Product identity and context (`config.json`), the contract YAML (`spec/`), the compiled manifest (`manifest/`) |
+| PostgreSQL (optional: local Docker, existing, or provisioned) | Observations, Backlog Items, planning Stories and revisions, semantic search embeddings |
+| Private profile outside the repository (`~/.config/tieline/`) | Database credentials and clone-local setup state — never committed, never shared through git |
 | `local` | Creates or reuses a dedicated Docker PostgreSQL + pgvector database and stores clone-local credentials privately |
 | `existing` (hosted / remote) | Connects a hosted or remote Postgres 16 + pgvector database identified by `DATABASE_URL_ADMIN`; no Docker container is required |
 

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -1402,17 +1402,24 @@ capability:
   );
   assert.match(
     onboardingReference,
-    /Where should Tieline keep its planning data\?/,
-    "the database question phrasing is locked; agents must not rewrite it"
+    /source of truth for what's in[\s>]+production/,
+    "the locked phrasing explains the model before asking"
+  );
+  assert.ok(
+    onboardingReference.indexOf("source of truth") <
+      onboardingReference.indexOf(
+        "Where should Tieline keep this planning data?"
+      ),
+    "explanation must come before the question"
   );
   assert.match(
     onboardingReference,
-    /that contract also syncs to Postgres/,
+    /Production Stories sync to that database/,
     "the locked phrasing must explain the contract syncs to the database"
   );
   assert.match(
     onboardingReference,
-    /Observations[\s>]+never land in your repository/,
+    /Observations and[\s>]+credentials never land in your repository/,
     "the locked phrasing must state observations are database-only"
   );
   assert.match(
@@ -1422,7 +1429,7 @@ capability:
   );
   assert.match(
     onboardingReference,
-    /from capture to shipped behavior/,
+    /from request to[\s>]+production/,
     "the pitch is solo-first, not org-first"
   );
   assert.doesNotMatch(

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -1397,6 +1397,11 @@ capability:
   assert.match(onboardingReference, /merge\s+is the approval/);
   assert.match(
     onboardingReference,
+    /start here, connect later.*never\s+as the whole product/s,
+    "the database question must sell what the database unlocks, not settle for offline"
+  );
+  assert.match(
+    onboardingReference,
     /Do not enumerate the authored\s+Stories or acceptance\s+criteria inline/,
     "onboarding must deliver the review page, not an inline listing"
   );

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -1397,8 +1397,33 @@ capability:
   assert.match(onboardingReference, /merge\s+is the approval/);
   assert.match(
     onboardingReference,
-    /start here, connect later.*never\s+as the whole product/s,
+    /start here, connect later.*never as the whole\s+product/s,
     "the database question must sell what the database unlocks, not settle for offline"
+  );
+  assert.match(
+    onboardingReference,
+    /Where should Tieline keep its planning data\?/,
+    "the database question phrasing is locked; agents must not rewrite it"
+  );
+  assert.match(
+    onboardingReference,
+    /No[\s>]+database content or credentials ever land in the repository/,
+    "the locked phrasing must state the repo/database boundary"
+  );
+  assert.match(
+    onboardingReference,
+    /\*\*Local Postgres\*\*/,
+    "local Docker Postgres is a first-class answer"
+  );
+  assert.match(
+    onboardingReference,
+    /from capture to shipped behavior/,
+    "the pitch is solo-first, not org-first"
+  );
+  assert.doesNotMatch(
+    onboardingReference,
+    /teammates|organization-wide/i,
+    "onboarding phrasing must not assume a team"
   );
   assert.match(
     onboardingReference,

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -1407,8 +1407,13 @@ capability:
   );
   assert.match(
     onboardingReference,
-    /No[\s>]+database content or credentials ever land in the repository/,
-    "the locked phrasing must state the repo/database boundary"
+    /that contract also syncs to Postgres/,
+    "the locked phrasing must explain the contract syncs to the database"
+  );
+  assert.match(
+    onboardingReference,
+    /Observations[\s>]+never land in your repository/,
+    "the locked phrasing must state observations are database-only"
   );
   assert.match(
     onboardingReference,

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -216,6 +216,15 @@ try {
   mkdirSync(resolve(validationTarget, "src"), { recursive: true });
   await assert.rejects(
     runCli(
+      ["init", validationTarget, "--yes", "--provision-roles"],
+      io().adapter,
+      { TIELINE_CONFIG_HOME: resolve(root, "validation-config") }
+    ),
+    /--provision-roles requires --database existing/
+  );
+  assert.equal(existsSync(resolve(validationTarget, ".tieline")), false);
+  await assert.rejects(
+    runCli(
       ["init", validationTarget, "--yes", "--skill-scope", "project"],
       io().adapter,
       { TIELINE_CONFIG_HOME: resolve(root, "validation-config") }
@@ -1154,7 +1163,7 @@ capability:
     migrateDatabase: async () => {
       calls.push("migrate");
     },
-    provisionLocalRoles: async () => {
+    provisionDatabaseRoles: async () => {
       calls.push("roles");
       return {
         DATABASE_URL:
@@ -1290,6 +1299,54 @@ capability:
       TIELINE_CONFIG_HOME: configHome,
     })?.profile.runtime.setup_completed_at
   );
+
+  const provisionCalls: string[] = [];
+  const provisionConfigHome = resolve(root, "provision-config-home");
+  await configureWorkspaceRuntime({
+    workspace: workspace as TielineWorkspace,
+    databaseMode: "existing",
+    embeddingProvider: "hash",
+    installLocalEmbedder: false,
+    skipMigrate: false,
+    provisionRoles: true,
+    env: {
+      TIELINE_CONFIG_HOME: provisionConfigHome,
+      DATABASE_URL_ADMIN:
+        "postgresql://neon-owner:private@example.neon.tech/neondb",
+    },
+    io: { write: () => undefined },
+    dependencies: {
+      migrateDatabase: async () => {
+        provisionCalls.push("migrate");
+      },
+      provisionDatabaseRoles: async (ownerUrl: string) => {
+        provisionCalls.push(`roles:${ownerUrl}`);
+        return {
+          DATABASE_URL:
+            "postgresql://reader:private@example.neon.tech/neondb",
+          DATABASE_URL_WRITE:
+            "postgresql://writer:private@example.neon.tech/neondb",
+        };
+      },
+    },
+  });
+  assert.deepEqual(
+    provisionCalls,
+    [
+      "migrate",
+      "roles:postgresql://neon-owner:private@example.neon.tech/neondb",
+    ],
+    "existing mode with --provision-roles must provision after migrating"
+  );
+  const provisionedProfile = readWorkspaceProfile(workspace, {
+    TIELINE_CONFIG_HOME: provisionConfigHome,
+  });
+  assert.ok(provisionedProfile?.profile.runtime.setup_completed_at);
+  assert.match(provisionedProfile?.profile.env.DATABASE_URL ?? "", /reader/);
+  assert.match(
+    provisionedProfile?.profile.env.DATABASE_URL_WRITE ?? "",
+    /writer/
+  );
   const serveEnv: NodeJS.ProcessEnv = {
     TIELINE_CONFIG_HOME: configHome,
     DATABASE_URL_SYNC: "postgresql://explicit-sync@example.test/tieline",
@@ -1359,6 +1416,22 @@ capability:
   assert.match(reportReference, /pull-request body/);
   assert.match(authorSkill, /references\/report\.md/);
   assert.match(onboardingReference, /references\/report\.md/);
+  const provisioningReference = readFileSync(
+    resolve(
+      process.cwd(),
+      "skills/tieline-author/references/provisioning.md"
+    ),
+    "utf8"
+  );
+  assert.match(provisioningReference, /Consent first/);
+  assert.match(provisioningReference, /neonctl projects create/);
+  assert.match(provisioningReference, /--provision-roles/);
+  assert.match(
+    provisioningReference,
+    /never write it into any\s+repository file/,
+    "provisioning must keep provider artifacts out of the repository"
+  );
+  assert.match(onboardingReference, /provisioning\.md/);
   assert.doesNotMatch(authorSkill, /agent handoff printed/i);
 
   const readme = readFileSync(resolve(process.cwd(), "README.md"), "utf8");

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -1391,6 +1391,12 @@ capability:
   assert.match(onboardingReference, /Ask focused questions only/);
   assert.match(
     onboardingReference,
+    /Set expectations first/,
+    "onboarding must open by orienting the user before asking questions"
+  );
+  assert.match(onboardingReference, /merge\s+is the approval/);
+  assert.match(
+    onboardingReference,
     /Do not enumerate the authored\s+Stories or acceptance\s+criteria inline/,
     "onboarding must deliver the review page, not an inline listing"
   );
@@ -1430,6 +1436,11 @@ capability:
     provisioningReference,
     /never write it into any\s+repository file/,
     "provisioning must keep provider artifacts out of the repository"
+  );
+  assert.match(
+    provisioningReference,
+    /at most once per database/,
+    "provisioning must warn about credential rotation on re-run"
   );
   assert.match(onboardingReference, /provisioning\.md/);
   assert.doesNotMatch(authorSkill, /agent handoff printed/i);

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -1408,7 +1408,10 @@ capability:
   assert.ok(
     onboardingReference.indexOf("source of truth") <
       onboardingReference.indexOf(
-        "Where should Tieline keep this planning data?"
+        "Where should Tieline keep your Observations?"
+      ) &&
+      onboardingReference.includes(
+        "Where should Tieline keep your Observations?"
       ),
     "explanation must come before the question"
   );

--- a/skills/tieline-author/references/onboarding.md
+++ b/skills/tieline-author/references/onboarding.md
@@ -35,13 +35,14 @@ a human first sees them. Verify, do not re-ask.
 3. Ask the setup question with this phrasing — do not rewrite it, only drop
    an option the machine rules out (for example local without Docker):
 
-   > **Where should Tieline keep its planning data?** Your repository holds
-   > the reviewed contract — capabilities, Stories, and acceptance criteria
-   > as YAML that ships through pull requests. A Postgres database adds the
-   > live half: your bug reports and feature ideas become Observations and
-   > planning Stories you can follow from capture to shipped behavior, with
-   > semantic duplicate checking against everything already defined. No
-   > database content or credentials ever land in the repository.
+   > **Where should Tieline keep its planning data?** Capabilities for your
+   > production codebase — Stories and acceptance criteria as YAML — are
+   > defined in `.tieline/` and ship through pull requests. With a database
+   > connected, that contract also syncs to Postgres, where it is stored
+   > and queryable alongside Observations: feature requests, ideas, and bug
+   > reports you can follow from capture to shipped behavior. Observations
+   > never land in your repository — they live only in the database — and
+   > no credentials are stored in the repository either.
    >
    > 1. **Start offline** — contract only for now; connect a database any
    >    time

--- a/skills/tieline-author/references/onboarding.md
+++ b/skills/tieline-author/references/onboarding.md
@@ -46,7 +46,7 @@ a human first sees them. Verify, do not re-ask.
    > query it for planning, investigation, and research. Observations and
    > credentials never land in your repository.
    >
-   > **Where should Tieline keep this planning data?**
+   > **Where should Tieline keep your Observations?**
    >
    > 1. **Start offline** — contract only for now; connect a database any
    >    time

--- a/skills/tieline-author/references/onboarding.md
+++ b/skills/tieline-author/references/onboarding.md
@@ -8,7 +8,9 @@ first authoring pass, not a separate approval or handoff process.
 Open with a short orientation before asking anything — the user just pasted
 a prompt and may not know what Tieline is or what happens next. In one short
 paragraph: Tieline maintains a living contract of the product's user Stories
-and acceptance criteria, grounded in this repository's code and tests. Then
+and acceptance criteria, grounded in this repository's code and tests, and —
+once a database is connected — carries requests from Observation to planning
+Story to production behavior. Then
 the plan: confirm a few detected settings, ask one or two questions, author
 the initial capabilities, Stories, and ACs from repository evidence, and
 finish with a browsable review page on a branch for normal pull-request
@@ -30,10 +32,15 @@ a human first sees them. Verify, do not re-ask.
    with the user, and record it in `.tieline/config.json` under
    `context.sources` as
    `{ "id": "source-<n>", "type": "description", "location": null, "content": "<text>", "allow_external_fetch": false }`.
-3. Ask at most one setup question, with three answers: stay in the default
-   offline mode, connect an existing PostgreSQL, or provision a new hosted
-   database now. Offline is a complete answer for repository-local
-   authoring — do not present it as a degraded mode.
+3. Ask at most one setup question, with three answers: stay offline for
+   now, connect an existing PostgreSQL, or provision a new hosted database.
+   Frame the choice by what the database unlocks: it is where Observations
+   (bug reports, feature requests), Backlog Items, and planning Stories
+   live, so a request can be captured and followed from planning to
+   production, and it powers organization-wide duplicate checking across
+   repositories. Offline authors, validates, and reviews the repository
+   contract completely — present it as "start here, connect later", never
+   as the whole product.
    - Existing: requires `DATABASE_URL_ADMIN` in the environment; run
      `npx -y tieline init . --yes --database existing`. Docker users can
      choose `--database local` instead.

--- a/skills/tieline-author/references/onboarding.md
+++ b/skills/tieline-author/references/onboarding.md
@@ -32,20 +32,33 @@ a human first sees them. Verify, do not re-ask.
    with the user, and record it in `.tieline/config.json` under
    `context.sources` as
    `{ "id": "source-<n>", "type": "description", "location": null, "content": "<text>", "allow_external_fetch": false }`.
-3. Ask at most one setup question, with three answers: stay offline for
-   now, connect an existing PostgreSQL, or provision a new hosted database.
-   Frame the choice by what the database unlocks: it is where Observations
-   (bug reports, feature requests), Backlog Items, and planning Stories
-   live, so a request can be captured and followed from planning to
-   production, and it powers organization-wide duplicate checking across
-   repositories. Offline authors, validates, and reviews the repository
-   contract completely — present it as "start here, connect later", never
-   as the whole product.
-   - Existing: requires `DATABASE_URL_ADMIN` in the environment; run
-     `npx -y tieline init . --yes --database existing`. Docker users can
-     choose `--database local` instead.
-   - Provision new: follow [provisioning.md](provisioning.md) to create a
-     Neon Postgres in the user's own account and connect it.
+3. Ask the setup question with this phrasing — do not rewrite it, only drop
+   an option the machine rules out (for example local without Docker):
+
+   > **Where should Tieline keep its planning data?** Your repository holds
+   > the reviewed contract — capabilities, Stories, and acceptance criteria
+   > as YAML that ships through pull requests. A Postgres database adds the
+   > live half: your bug reports and feature ideas become Observations and
+   > planning Stories you can follow from capture to shipped behavior, with
+   > semantic duplicate checking against everything already defined. No
+   > database content or credentials ever land in the repository.
+   >
+   > 1. **Start offline** — contract only for now; connect a database any
+   >    time
+   > 2. **Local Postgres** — the full planning loop on this machine, via
+   >    Docker, no accounts
+   > 3. **Connect an existing Postgres** — you provide `DATABASE_URL_ADMIN`
+   > 4. **Provision a hosted Postgres** — a free-tier Neon project in your
+   >    own account; needs a one-time browser approval
+
+   Present offline as "start here, connect later", never as the whole
+   product. Map the answers to commands:
+   - Local: `npx -y tieline init . --yes --database local` (requires a
+     running Docker daemon).
+   - Existing: with `DATABASE_URL_ADMIN` in the environment, run
+     `npx -y tieline init . --yes --database existing`.
+   - Provision: follow [provisioning.md](provisioning.md) to create a Neon
+     Postgres in the user's own account and connect it.
 4. In a repository with a `package.json`, offer to pin the CLI with
    `npm install --save-dev tieline` so the team shares one version and
    `npx tieline` resolves locally. Skip this for non-Node repositories; `npx`
@@ -68,7 +81,7 @@ a human first sees them. Verify, do not re-ask.
    change a capability boundary or acceptance criterion. Do not ask for context
    that can be discovered from the repository.
 5. Search for likely duplicate IDs and behavior using the local YAML and
-   manifest plus organization-wide semantic matching when available.
+   manifest plus database-backed semantic matching when available.
 6. Author the initial capabilities, Stories, and ACs under `.tieline/spec/`.
    Never create generic starter content merely to make the directory non-empty.
 7. Validate and compile the contract.

--- a/skills/tieline-author/references/onboarding.md
+++ b/skills/tieline-author/references/onboarding.md
@@ -3,6 +3,19 @@
 Use this workflow only when `.tieline/spec/` has no YAML. Onboarding is the
 first authoring pass, not a separate approval or handoff process.
 
+## Set expectations first
+
+Open with a short orientation before asking anything — the user just pasted
+a prompt and may not know what Tieline is or what happens next. In one short
+paragraph: Tieline maintains a living contract of the product's user Stories
+and acceptance criteria, grounded in this repository's code and tests. Then
+the plan: confirm a few detected settings, ask one or two questions, author
+the initial capabilities, Stories, and ACs from repository evidence, and
+finish with a browsable review page on a branch for normal pull-request
+review. State plainly that nothing is accepted without their review — merge
+is the approval. Keep it to that one paragraph, not a feature tour, and move
+straight into the first confirmation.
+
 ## Gather and verify configuration
 
 Init writes auto-detected values without asking questions; this phase is where

--- a/skills/tieline-author/references/onboarding.md
+++ b/skills/tieline-author/references/onboarding.md
@@ -17,12 +17,15 @@ a human first sees them. Verify, do not re-ask.
    with the user, and record it in `.tieline/config.json` under
    `context.sources` as
    `{ "id": "source-<n>", "type": "description", "location": null, "content": "<text>", "allow_external_fetch": false }`.
-3. Ask at most one setup question: stay in the default offline mode, or
-   connect PostgreSQL now. On request run
-   `npx -y tieline init . --yes --database local` (Docker) or
-   `npx -y tieline init . --yes --database existing` (hosted; requires
-   `DATABASE_URL_ADMIN` in the environment). Offline is a complete answer for
-   repository-local authoring — do not present it as a degraded mode.
+3. Ask at most one setup question, with three answers: stay in the default
+   offline mode, connect an existing PostgreSQL, or provision a new hosted
+   database now. Offline is a complete answer for repository-local
+   authoring — do not present it as a degraded mode.
+   - Existing: requires `DATABASE_URL_ADMIN` in the environment; run
+     `npx -y tieline init . --yes --database existing`. Docker users can
+     choose `--database local` instead.
+   - Provision new: follow [provisioning.md](provisioning.md) to create a
+     Neon Postgres in the user's own account and connect it.
 4. In a repository with a `package.json`, offer to pin the CLI with
    `npm install --save-dev tieline` so the team shares one version and
    `npx tieline` resolves locally. Skip this for non-Node repositories; `npx`

--- a/skills/tieline-author/references/onboarding.md
+++ b/skills/tieline-author/references/onboarding.md
@@ -32,17 +32,21 @@ a human first sees them. Verify, do not re-ask.
    with the user, and record it in `.tieline/config.json` under
    `context.sources` as
    `{ "id": "source-<n>", "type": "description", "location": null, "content": "<text>", "allow_external_fetch": false }`.
-3. Ask the setup question with this phrasing — do not rewrite it, only drop
-   an option the machine rules out (for example local without Docker):
+3. Explain the model first, then ask — use this phrasing verbatim, only
+   dropping an option the machine rules out (for example local without
+   Docker):
 
-   > **Where should Tieline keep its planning data?** Capabilities for your
-   > production codebase — Stories and acceptance criteria as YAML — are
-   > defined in `.tieline/` and ship through pull requests. With a database
-   > connected, that contract also syncs to Postgres, where it is stored
-   > and queryable alongside Observations: feature requests, ideas, and bug
-   > reports you can follow from capture to shipped behavior. Observations
-   > never land in your repository — they live only in the database — and
-   > no credentials are stored in the repository either.
+   > Your `.tieline/` directory is the source of truth for what's in
+   > production: capabilities, Stories, and acceptance criteria as YAML.
+   > New Stories and changes to existing ones are managed through pull
+   > requests. Beyond mapping production, Tieline can track Observations —
+   > feature requests, ideas, bug reports — outside the repository in a
+   > Postgres database, letting you follow a feature from request to
+   > production. Production Stories sync to that database, and agents can
+   > query it for planning, investigation, and research. Observations and
+   > credentials never land in your repository.
+   >
+   > **Where should Tieline keep this planning data?**
    >
    > 1. **Start offline** — contract only for now; connect a database any
    >    time

--- a/skills/tieline-author/references/provisioning.md
+++ b/skills/tieline-author/references/provisioning.md
@@ -39,7 +39,9 @@ Tieline's private profile outside the checkout.
    must be true and the capability flags should report semantic matching
    and planning writes configured. On any provider failure, report the
    error and continue in offline mode — the workspace stays fully usable.
-6. Teammates connect without admin access: share the reader and planning
-   writer URLs from this machine's private Tieline profile through the
-   organization's secret manager, and each teammate sets `DATABASE_URL` and
-   `DATABASE_URL_WRITE` in their environment.
+6. If others work in this repository, they connect without admin access:
+   share the reader and planning writer URLs from this machine's private
+   Tieline profile through a secret manager, and each person sets
+   `DATABASE_URL` and `DATABASE_URL_WRITE` in their environment. A solo
+   user needs none of this — the profile on this machine already holds
+   everything.

--- a/skills/tieline-author/references/provisioning.md
+++ b/skills/tieline-author/references/provisioning.md
@@ -1,0 +1,42 @@
+# Provision a hosted database
+
+The Tieline database is organization infrastructure shared across
+repositories, not part of any one application. Keep every provider artifact
+out of the repository: no provider project files, no `.env` entries, no
+connection strings in any tracked or untracked repository file. The
+repository records only `default_database_mode`; credentials live in
+Tieline's private profile outside the checkout.
+
+1. Consent first. Name the provider and plan (Neon's free tier unless the
+   user chooses otherwise) and state that the project is created in the
+   user's own Neon account. Do not create billable infrastructure without
+   an explicit yes.
+2. Check authentication with `npx -y neonctl me --output json`. If it
+   fails, stop and ask the user to either run `npx -y neonctl auth` (it
+   finishes in their browser) or provide `NEON_API_KEY`. Never work around
+   missing authentication.
+3. Create the project and capture the connection URI:
+
+   ```sh
+   npx -y neonctl projects create --name tieline-<repo_name> --output json
+   ```
+
+   Read `connection_uris[0].connection_uri` from the output. Treat it as a
+   secret: never print it back and never write it into any repository file.
+4. Run setup with the URI scoped to this single command:
+
+   ```sh
+   DATABASE_URL_ADMIN=<uri> npx -y tieline init . --yes --database existing --provision-roles
+   ```
+
+   `--provision-roles` assigns login credentials to the migration-created
+   tieline roles so semantic matching and planning writes work immediately.
+   Omit it only when the organization manages database login roles itself.
+5. Verify with `npx -y tieline status --json`: `runtime.setup_complete`
+   must be true and the capability flags should report semantic matching
+   and planning writes configured. On any provider failure, report the
+   error and continue in offline mode — the workspace stays fully usable.
+6. Teammates connect without admin access: share the reader and planning
+   writer URLs from this machine's private Tieline profile through the
+   organization's secret manager, and each teammate sets `DATABASE_URL` and
+   `DATABASE_URL_WRITE` in their environment.

--- a/skills/tieline-author/references/provisioning.md
+++ b/skills/tieline-author/references/provisioning.md
@@ -32,6 +32,9 @@ Tieline's private profile outside the checkout.
    `--provision-roles` assigns login credentials to the migration-created
    tieline roles so semantic matching and planning writes work immediately.
    Omit it only when the organization manages database login roles itself.
+   Run it at most once per database: re-running rotates the generated
+   passwords and invalidates the credentials every other clone's profile
+   already holds.
 5. Verify with `npx -y tieline status --json`: `runtime.setup_complete`
    must be true and the capability flags should report semantic matching
    and planning writes configured. On any provider failure, report the

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -137,6 +137,7 @@ interface InitOptions {
   yes: boolean;
   skipMigrate: boolean;
   installLocalEmbedder: boolean;
+  provisionRoles: boolean;
   agents: string[];
   skillScope?: SkillInstallScope;
   skipSkillInstall: boolean;
@@ -464,6 +465,12 @@ async function runInit(
   if (parsed.skillScope && parsed.agents.length === 0) {
     throw new Error("--skill-scope requires at least one --agent.");
   }
+  if (
+    parsed.provisionRoles &&
+    !(parsed.databaseExplicit && parsed.database === "existing")
+  ) {
+    throw new Error("--provision-roles requires --database existing.");
+  }
   if (parsed.agents.length > 0) normalizeSkillAgentIds(parsed.agents);
 
   const existing = findTielineWorkspace(parsed.target);
@@ -511,6 +518,7 @@ async function runInit(
         embeddingProvider,
         installLocalEmbedder: parsed.installLocalEmbedder,
         skipMigrate: parsed.skipMigrate,
+        provisionRoles: parsed.provisionRoles,
         env,
         io,
       });
@@ -634,6 +642,7 @@ async function runInit(
     embeddingProvider: embedding,
     installLocalEmbedder: parsed.installLocalEmbedder,
     skipMigrate: parsed.skipMigrate,
+    provisionRoles: parsed.provisionRoles,
     env,
     io,
   });
@@ -868,6 +877,10 @@ function buildProgram(
       "--install-local-embedder",
       "install the optional local embedding runtime"
     )
+    .option(
+      "--provision-roles",
+      "assign generated login passwords to the tieline database roles (requires --database existing)"
+    )
     .action(async (repository: string, opts) => {
       setExit(
         await runInit(
@@ -890,6 +903,7 @@ function buildProgram(
             yes: Boolean(opts.yes),
             skipMigrate: Boolean(opts.skipMigrate),
             installLocalEmbedder: Boolean(opts.installLocalEmbedder),
+            provisionRoles: Boolean(opts.provisionRoles),
             agents: opts.agent,
             skillScope: opts.skillScope as SkillInstallScope | undefined,
             skipSkillInstall: Boolean(opts.skipSkillInstall),

--- a/src/tieline/setup.ts
+++ b/src/tieline/setup.ts
@@ -28,6 +28,12 @@ export interface SetupOptions {
   embeddingProvider: EmbeddingProvider;
   installLocalEmbedder: boolean;
   skipMigrate: boolean;
+  /**
+   * In existing mode, assign generated login passwords to the
+   * migration-created tieline roles instead of expecting operator-managed
+   * login roles. Local mode always provisions its own roles.
+   */
+  provisionRoles?: boolean;
   env: NodeJS.ProcessEnv;
   io: SetupIO;
   dependencies?: Partial<SetupDependencies>;
@@ -47,7 +53,7 @@ export interface SetupDependencies {
     io: SetupIO
   ): Promise<LocalDatabase>;
   migrateDatabase(dbUrl: string): Promise<void>;
-  provisionLocalRoles(ownerUrl: string): Promise<Record<string, string>>;
+  provisionDatabaseRoles(ownerUrl: string): Promise<Record<string, string>>;
 }
 
 interface ProcessResult {
@@ -122,7 +128,7 @@ async function waitForPostgres(url: string): Promise<void> {
   );
 }
 
-async function provisionLocalRoles(ownerUrl: string): Promise<Record<string, string>> {
+async function provisionDatabaseRoles(ownerUrl: string): Promise<Record<string, string>> {
   const reader = credential();
   const writer = credential();
   const sync = credential();
@@ -264,7 +270,7 @@ export async function configureWorkspaceRuntime(options: SetupOptions): Promise<
     installLocalEmbedder,
     startLocalDatabase,
     migrateDatabase: (dbUrl) => migrateDatabase(dbUrl),
-    provisionLocalRoles,
+    provisionDatabaseRoles,
     ...options.dependencies,
   };
   env.EMBEDDING_PROVIDER = options.embeddingProvider;
@@ -292,6 +298,13 @@ export async function configureWorkspaceRuntime(options: SetupOptions): Promise<
     if (!options.skipMigrate) {
       io.write("Applying packaged Tieline migrations to the configured database...\n");
       await dependencies.migrateDatabase(env.DATABASE_URL_ADMIN);
+      if (options.provisionRoles) {
+        io.write("Assigning login credentials to the tieline database roles...\n");
+        Object.assign(
+          env,
+          await dependencies.provisionDatabaseRoles(env.DATABASE_URL_ADMIN)
+        );
+      }
     }
   } else if (options.databaseMode === "local") {
     const local = await dependencies.startLocalDatabase(workspace, env, io);
@@ -304,7 +317,7 @@ export async function configureWorkspaceRuntime(options: SetupOptions): Promise<
     if (!options.skipMigrate) {
       io.write("Applying packaged Tieline migrations to the local database...\n");
       await dependencies.migrateDatabase(local.ownerUrl);
-      Object.assign(env, await dependencies.provisionLocalRoles(local.ownerUrl));
+      Object.assign(env, await dependencies.provisionDatabaseRoles(local.ownerUrl));
     } else {
       env.DATABASE_URL_ADMIN = local.ownerUrl;
     }


### PR DESCRIPTION
## What

The onboarding database question gains its third answer. It was "stay offline" or "connect an existing Postgres (bring `DATABASE_URL_ADMIN`)"; now it's also **"provision one for me"** — and the agent can run the whole flow with one browser click and one explicit yes from the user.

### Skill: `references/provisioning.md`

Drives the agent through the Neon CLI directly (no Stripe Projects — for a single DB it added an account requirement, a directory anchor, and `.env`-sync hazards while using none of its multi-service value):

1. **Consent first** — provider, plan, "created in your own Neon account"; no billable infrastructure without an explicit yes.
2. **Auth check** (`neonctl me --output json`) — on failure, stop and ask for the one-time `neonctl auth` browser approval or `NEON_API_KEY`; never work around missing auth.
3. `neonctl projects create --name tieline-<repo> --output json` → parse `connection_uris[0].connection_uri`, treat as secret.
4. `DATABASE_URL_ADMIN=<uri> npx -y tieline init . --yes --database existing --provision-roles` — the URI is scoped to the single command.
5. Verify via `tieline status --json`; on provider failure, report and continue offline (workspace stays usable).
6. Teammates get reader/writer URLs via the org's secret manager — no admin distribution.

Hard rule throughout: **no provider artifacts in the repository** — the DB is org infrastructure; the repo records only the mode flag.

### CLI: `--provision-roles`

`existing` mode required operator-managed login roles, so a fresh Neon owner URL couldn't reach a working setup alone (migrations create the tieline roles `NOLOGIN`; only local mode gave them credentials). The new flag — valid only with `--database existing` — reuses the same provisioning path after migration: generated login passwords for reader/planning-writer/sync, URLs landing in the private out-of-repo profile. Default behavior is unchanged; the operator-managed model stays the default and the README documents both. `SetupDependencies.provisionLocalRoles` is renamed `provisionDatabaseRoles` to match its widened scope.

## Testing

- Setup-level: existing mode with `provisionRoles` provisions after migrate with the admin URL, profile captures reader/writer URLs and completes setup; without the flag, behavior unchanged.
- CLI: `--provision-roles` without `--database existing` rejects before any writes.
- Skill content pinned: consent rule, neonctl commands, no-repo-artifacts rule, onboarding route-through.
- Full tieline suite, skill-install, MCP smoke green; `tsc` clean.

## Residual risk (flagged, not blocking)

Role provisioning on a live Neon project assumes the default owner connection can `ALTER ROLE` the migration-created roles (Postgres 16 CREATEROLE-admin semantics say yes, since the same connection creates them). The skill's verify step surfaces any real-world failure and falls back to offline; worth one live Neon smoke test before announcing the flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)