### PR TITLE
fix(skill): onboarding is conversation-first — orient, settle setup, then work

### DIFF
--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -1496,16 +1496,10 @@ capability:
     ),
     "utf8"
   );
-  assert.match(provisioningReference, /Consent first/);
   assert.match(
     provisioningReference,
-    /Neon is a serverless Postgres provider with a free tier/,
-    "the consent script must explain what Neon is before asking"
-  );
-  assert.match(
-    provisioningReference,
-    /own it and can delete it at any time/,
-    "the consent script must state ownership and reversibility"
+    /Consent first, in one line/,
+    "consent stays brief; the option list already explained Neon"
   );
   assert.match(provisioningReference, /neonctl projects create/);
   assert.match(provisioningReference, /--provision-roles/);

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -1498,8 +1498,8 @@ capability:
   );
   assert.match(
     provisioningReference,
-    /Consent first, in one line/,
-    "consent stays brief; the option list already explained Neon"
+    /provision option in the database question is the consent/,
+    "picking the menu option is the consent; no double-ask"
   );
   assert.match(provisioningReference, /neonctl projects create/);
   assert.match(provisioningReference, /--provision-roles/);

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -1444,8 +1444,8 @@ capability:
   );
   assert.match(
     onboardingReference,
-    /Observations and[\s>]+credentials never land in your repository/,
-    "the locked phrasing must state observations are database-only"
+    /stored outside the repository in a Postgres database/,
+    "the orientation must state observations are database-only"
   );
   assert.match(
     onboardingReference,

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -1497,6 +1497,16 @@ capability:
     "utf8"
   );
   assert.match(provisioningReference, /Consent first/);
+  assert.match(
+    provisioningReference,
+    /Neon is a serverless Postgres provider with a free tier/,
+    "the consent script must explain what Neon is before asking"
+  );
+  assert.match(
+    provisioningReference,
+    /own it and can delete it at any time/,
+    "the consent script must state ownership and reversibility"
+  );
   assert.match(provisioningReference, /neonctl projects create/);
   assert.match(provisioningReference, /--provision-roles/);
   assert.match(

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -1394,6 +1394,21 @@ capability:
     /Set expectations first/,
     "onboarding must open by orienting the user before asking questions"
   );
+  assert.match(
+    onboardingReference,
+    /send it before\s+reading repository files or running commands/,
+    "the orientation must precede repository work, not follow it"
+  );
+  assert.match(
+    onboardingReference,
+    /handoff so the coming silence is expected/,
+    "setup must end with a handoff into the autonomous phase"
+  );
+  assert.match(
+    authorSkill,
+    /starts with a\s+conversation, not with repository reading/,
+    "the skill dispatch must order conversation before orientation steps"
+  );
   assert.match(onboardingReference, /merge\s+is the approval/);
   assert.match(
     onboardingReference,

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -1417,23 +1417,30 @@ capability:
   );
   assert.match(
     onboardingReference,
-    /source of truth for what's in[\s>]+production/,
-    "the locked phrasing explains the model before asking"
+    /Great — let's get you set up with Tieline\./,
+    "the orientation script is locked verbatim"
+  );
+  assert.match(
+    onboardingReference,
+    /production source of[\s>]+truth lives in this repository/,
+    "the orientation explains the model before any question"
   );
   assert.ok(
-    onboardingReference.indexOf("source of truth") <
+    onboardingReference.indexOf(
+      "Great — let's get you set up with Tieline."
+    ) <
       onboardingReference.indexOf(
         "Where should Tieline keep your Observations?"
       ) &&
       onboardingReference.includes(
         "Where should Tieline keep your Observations?"
       ),
-    "explanation must come before the question"
+    "orientation must come before the database question"
   );
   assert.match(
     onboardingReference,
-    /Production Stories sync to that database/,
-    "the locked phrasing must explain the contract syncs to the database"
+    /production Stories synced alongside/,
+    "the orientation must explain the contract syncs to the database"
   );
   assert.match(
     onboardingReference,

--- a/skills/tieline-author/SKILL.md
+++ b/skills/tieline-author/SKILL.md
@@ -19,7 +19,12 @@ works through the CLI (`npx -y tieline <command>`).
 When invoked after `tieline init` as an installed skill or MCP prompt, inspect
 `.tieline/spec/`. If it has no YAML, read
 [onboarding.md](references/onboarding.md) and perform semantic onboarding
-before choosing a normal authoring flow. Init records auto-detected values, so
+before choosing a normal authoring flow. Onboarding starts with a
+conversation, not with repository reading: after the silent checks that
+choose this flow (`.tieline/spec/` and `.tieline/config.json`), the first
+visible action is the orientation and setup exchange in onboarding.md — the
+"Orient to this repository" steps below run after that conversation ends,
+not before it. Init records auto-detected values, so
 verify rather than interrogate: confirm detected identity with the user and
 correct `.tieline/config.json` when a detection is wrong, but never ask for
 anything the repository can answer.

--- a/skills/tieline-author/references/onboarding.md
+++ b/skills/tieline-author/references/onboarding.md
@@ -7,18 +7,26 @@ first authoring pass, not a separate approval or handoff process.
 
 The orientation is the first visible thing that happens: send it before
 reading repository files or running commands, and do not narrate loading
-the skill or inspecting configuration first — the user just pasted
-a prompt and may not know what Tieline is or what happens next. In one short
-paragraph: Tieline maintains a living contract of the product's user Stories
-and acceptance criteria, grounded in this repository's code and tests, and —
-once a database is connected — carries requests from Observation to planning
-Story to production behavior. Then
-the plan: confirm a few detected settings, ask one or two questions, author
-the initial capabilities, Stories, and ACs from repository evidence, and
-finish with a browsable review page on a branch for normal pull-request
-review. State plainly that nothing is accepted without their review — merge
-is the approval. Keep it to that one paragraph, not a feature tour, and move
-straight into the first confirmation.
+the skill or inspecting configuration first. Use this script verbatim:
+
+> Great — let's get you set up with Tieline.
+>
+> Tieline builds a structured graph of your product's user Stories and
+> acceptance criteria, grounded in this codebase. The production source of
+> truth lives in this repository at `.tieline/` — after we create the
+> initial Stories today, future features and updates ship through normal
+> pull requests. Tieline can also track Observations — feature requests,
+> ideas, and bugs — stored outside the repository in a Postgres database
+> your agents can query, with your production Stories synced alongside so
+> you can follow a feature from request to production.
+>
+> Next: a few quick setup questions, then I'll kick off the initial Story
+> generation.
+
+Do not expand the script into a feature tour; move straight into the first
+confirmation. The trust anchor — nothing is accepted without review; merge
+is the approval — belongs at the end, when opening the pull request, not
+here.
 
 ## Gather and verify configuration
 
@@ -34,19 +42,12 @@ a human first sees them. Verify, do not re-ask.
    with the user, and record it in `.tieline/config.json` under
    `context.sources` as
    `{ "id": "source-<n>", "type": "description", "location": null, "content": "<text>", "allow_external_fetch": false }`.
-3. Explain the model first, then ask — use this phrasing verbatim, only
-   dropping an option the machine rules out (for example local without
-   Docker):
+3. The orientation already explained the model, so ask directly — use this
+   phrasing verbatim, only dropping an option the machine rules out (for
+   example local without Docker):
 
-   > Your `.tieline/` directory is the source of truth for what's in
-   > production: capabilities, Stories, and acceptance criteria as YAML.
-   > New Stories and changes to existing ones are managed through pull
-   > requests. Beyond mapping production, Tieline can track Observations —
-   > feature requests, ideas, bug reports — outside the repository in a
-   > Postgres database, letting you follow a feature from request to
-   > production. Production Stories sync to that database, and agents can
-   > query it for planning, investigation, and research. Observations and
-   > credentials never land in your repository.
+   > Observations and credentials never land in your repository — this
+   > choice is only about where the database lives.
    >
    > **Where should Tieline keep your Observations?**
    >

--- a/skills/tieline-author/references/onboarding.md
+++ b/skills/tieline-author/references/onboarding.md
@@ -5,7 +5,9 @@ first authoring pass, not a separate approval or handoff process.
 
 ## Set expectations first
 
-Open with a short orientation before asking anything — the user just pasted
+The orientation is the first visible thing that happens: send it before
+reading repository files or running commands, and do not narrate loading
+the skill or inspecting configuration first — the user just pasted
 a prompt and may not know what Tieline is or what happens next. In one short
 paragraph: Tieline maintains a living contract of the product's user Stories
 and acceptance criteria, grounded in this repository's code and tests, and —
@@ -68,6 +70,11 @@ a human first sees them. Verify, do not re-ask.
    `npm install --save-dev tieline` so the team shares one version and
    `npx tieline` resolves locally. Skip this for non-Node repositories; `npx`
    alone is sufficient.
+5. Close the conversation with a handoff so the coming silence is expected:
+   setup is complete, the rest runs without input, and the next thing the
+   user sees is the completion report with the review page. Everything after
+   this point is autonomous — do not ask further questions unless unresolved
+   product meaning materially changes a capability boundary.
 
 ## Author the initial contract
 

--- a/skills/tieline-author/references/onboarding.md
+++ b/skills/tieline-author/references/onboarding.md
@@ -46,9 +46,6 @@ a human first sees them. Verify, do not re-ask.
    phrasing verbatim, only dropping an option the machine rules out (for
    example local without Docker):
 
-   > Observations and credentials never land in your repository — this
-   > choice is only about where the database lives.
-   >
    > **Where should Tieline keep your Observations?**
    >
    > 1. **Start offline** — contract only for now; connect a database any

--- a/skills/tieline-author/references/provisioning.md
+++ b/skills/tieline-author/references/provisioning.md
@@ -7,10 +7,11 @@ connection strings in any tracked or untracked repository file. The
 repository records only `default_database_mode`; credentials live in
 Tieline's private profile outside the checkout.
 
-1. Consent first, in one line: confirm creating a free-tier Neon project
-   in the user's own account (they own it and can delete it anytime; a
-   missing Neon account is created during the browser sign-in). Do not
-   create billable infrastructure without an explicit yes.
+1. Choosing the provision option in the database question is the consent —
+   its menu line already names the provider, the free tier, the user's own
+   account, and the browser approval, so do not ask again. Anything beyond
+   that scope needs its own explicit yes: a plan other than the free tier,
+   or any other billable change.
 2. Check authentication with `npx -y neonctl me --output json`. If it
    fails, stop and ask the user to either run `npx -y neonctl auth` (it
    finishes in their browser) or provide `NEON_API_KEY`. Never work around

--- a/skills/tieline-author/references/provisioning.md
+++ b/skills/tieline-author/references/provisioning.md
@@ -7,10 +7,16 @@ connection strings in any tracked or untracked repository file. The
 repository records only `default_database_mode`; credentials live in
 Tieline's private profile outside the checkout.
 
-1. Consent first. Name the provider and plan (Neon's free tier unless the
-   user chooses otherwise) and state that the project is created in the
-   user's own Neon account. Do not create billable infrastructure without
-   an explicit yes.
+1. Consent first — use this script verbatim, then wait for an explicit
+   yes. Do not create billable infrastructure without one.
+
+   > Neon is a serverless Postgres provider with a free tier, which is
+   > what I'll use unless you'd rather pick a paid plan. I'll create a new
+   > project called `tieline-<repo_name>` in your own Neon account — you
+   > own it and can delete it at any time, and the credentials go into
+   > Tieline's private profile outside this repository. If you don't have
+   > a Neon account yet, the browser sign-in step creates one. Shall I go
+   > ahead?
 2. Check authentication with `npx -y neonctl me --output json`. If it
    fails, stop and ask the user to either run `npx -y neonctl auth` (it
    finishes in their browser) or provide `NEON_API_KEY`. Never work around

--- a/skills/tieline-author/references/provisioning.md
+++ b/skills/tieline-author/references/provisioning.md
@@ -7,16 +7,10 @@ connection strings in any tracked or untracked repository file. The
 repository records only `default_database_mode`; credentials live in
 Tieline's private profile outside the checkout.
 
-1. Consent first — use this script verbatim, then wait for an explicit
-   yes. Do not create billable infrastructure without one.
-
-   > Neon is a serverless Postgres provider with a free tier, which is
-   > what I'll use unless you'd rather pick a paid plan. I'll create a new
-   > project called `tieline-<repo_name>` in your own Neon account — you
-   > own it and can delete it at any time, and the credentials go into
-   > Tieline's private profile outside this repository. If you don't have
-   > a Neon account yet, the browser sign-in step creates one. Shall I go
-   > ahead?
+1. Consent first, in one line: confirm creating a free-tier Neon project
+   in the user's own account (they own it and can delete it anytime; a
+   missing Neon account is created during the browser sign-in). Do not
+   create billable infrastructure without an explicit yes.
 2. Check authentication with `npx -y neonctl me --output json`. If it
    fails, stop and ask the user to either run `npx -y neonctl auth` (it
    finishes in their browser) or provide `NEON_API_KEY`. Never work around


### PR DESCRIPTION
## What

A real onboarding run opened with *"I'll start by orienting to the repository. Let me read the Tieline config…"* — silent tool work before the user learned anything. This PR makes onboarding **conversation-first with locked scripts**, iterated to its final shape over six commits.

### The locked conversation

1. **Orientation** — first visible output, verbatim script: "Great — let's get you set up with Tieline." + the model (structured graph of Stories/ACs grounded in the codebase; `.tieline/` is the production source of truth, changes ship through PRs; Observations — feature requests, ideas, bugs — live outside the repo in a Postgres database agents can query, production Stories synced alongside, request → production) + "Next: a few quick setup questions, then I'll kick off the initial Story generation." No file reads or narrated tool work before it.
2. **Confirmations** — detected identity + proposed description; verify, don't interrogate.
3. **The database question** — exactly the question and four answers, nothing else (the orientation already explained the model):
   *Where should Tieline keep your Observations?* — Start offline / Local Postgres (Docker) / Connect existing (`DATABASE_URL_ADMIN`) / Provision hosted (free-tier Neon, own account, one browser approval).
4. **Picking the provision option is the consent** — the menu line names provider, tier, ownership, and the browser step, so there's no double-ask; only out-of-scope changes (e.g. a paid plan) need a fresh explicit yes.
5. **Handoff** — setup complete, the rest runs without input, next thing is the completion report with the review page — so the autonomous silence is expected.

### Enforcement

`SKILL.md` dispatch orders conversation before the "Orient to this repository" steps; the orientation script, its position before the question, the bare four-option question, the no-double-ask rule, and the handoff are all pinned by test assertions, so agent paraphrasing or reordering fails CI.

Skill-text only: no CLI/npm impact; live for new onboardings on merge (skillfish installs from the default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)