### PR TITLE
fix(init): make onboarding a one-choice handoff

### DIFF
--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -680,7 +680,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -680,7 +680,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -58,7 +58,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -102,7 +102,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -156,7 +156,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -200,7 +200,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -255,7 +255,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -299,7 +299,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -343,7 +343,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -398,7 +398,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -442,7 +442,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -486,7 +486,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -780,7 +780,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -58,7 +58,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -102,7 +102,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -156,7 +156,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -174,8 +174,8 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "6241bd3c8f2f191b1a3e5325432769d651013bc161c17d7ee306d492c6a18084",
-            "criterion": "Tieline initialization must persist user-confirmed deterministic repository and runtime inputs without generating semantic contract content.",
+            "contract_hash": "1f1ac7fd498b9a12342148ff6b33e7293d84135c135e6443b1a90fe811f638a3",
+            "criterion": "Tieline initialization must persist deterministic repository and runtime inputs from explicit flags and auto-detection without generating semantic contract content.",
             "links": [
               {
                 "provenance": "authored",
@@ -200,7 +200,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -218,8 +218,8 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "685fb657cc388ca2fea42b4c549125cb388b36ac4615f92d210d4a75e1b2d638",
-            "criterion": "Tieline initialization must install the tieline-author skill through Skillfish only for explicitly selected supported agents and scope.",
+            "contract_hash": "16bebe62c37b7376e6120433c66dd0b6ea40cf5f9fad9266fad7eb2ad375d8cc",
+            "criterion": "Tieline initialization must prepare explicitly selected project-agent targets and install the tieline-author skill through Skillfish only for those supported agents and scope.",
             "links": [
               {
                 "provenance": "authored",
@@ -234,7 +234,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "526c9b8879cd1a0d3a180de09619833041226e94855b3b3fad9008f35b17ae0c",
+                "reviewed_content_hash": "c57f7df103b479e9f7070b670e5e0ae2edc841bba78e7b95523249e9316ace28",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/skill-install.ts",
@@ -244,7 +244,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "94d56128fec8a8d33b83d3ff5d2918319d8c0ae88efaf26a0cfcce17af670e18",
+                "reviewed_content_hash": "66fecf45d896687bc08b6593ff432ba33e7547f0fd1fb8e44419bbe78869a2bf",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -255,7 +255,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -273,8 +273,8 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "96fb2484f79a468ff4b54b695bc9f4303f78884915e4b4546e5e724a431e32d6",
-            "criterion": "Tieline must preserve a ready workspace when requested skill installation fails.",
+            "contract_hash": "62557624443b4845f5c36a00a08cdb8e19c45de6d54f4167e03c5f6d83416413",
+            "criterion": "Tieline must preserve a ready workspace and report a structured installer error when requested skill installation fails.",
             "links": [
               {
                 "provenance": "authored",
@@ -289,7 +289,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "526c9b8879cd1a0d3a180de09619833041226e94855b3b3fad9008f35b17ae0c",
+                "reviewed_content_hash": "c57f7df103b479e9f7070b670e5e0ae2edc841bba78e7b95523249e9316ace28",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/skill-install.ts",
@@ -299,7 +299,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -343,7 +343,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -377,7 +377,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "526c9b8879cd1a0d3a180de09619833041226e94855b3b3fad9008f35b17ae0c",
+                "reviewed_content_hash": "c57f7df103b479e9f7070b670e5e0ae2edc841bba78e7b95523249e9316ace28",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/skill-install.ts",
@@ -387,7 +387,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "94d56128fec8a8d33b83d3ff5d2918319d8c0ae88efaf26a0cfcce17af670e18",
+                "reviewed_content_hash": "66fecf45d896687bc08b6593ff432ba33e7547f0fd1fb8e44419bbe78869a2bf",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -398,7 +398,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -442,7 +442,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -460,8 +460,8 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "3bd91d37fd117d257524572bcf9c70daf84f4bc60384fd6ad6d098d6a4df9dd7",
-            "criterion": "Tieline interactive initialization must auto-detect code scope and defer product description and context discovery to semantic onboarding while retaining explicit CLI overrides.",
+            "contract_hash": "28707c526d98ff9f720db80e12e67e0652885420ef315e8cfac2ad61d9433187",
+            "criterion": "Tieline interactive initialization must use agent selection as setup consent, auto-detect code scope, and defer product description and context discovery to semantic onboarding while retaining explicit CLI overrides.",
             "links": [
               {
                 "provenance": "authored",
@@ -486,7 +486,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -780,7 +780,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -867,6 +867,6 @@
   },
   "input": {
     "path": ".tieline/spec/runtime.yaml",
-    "sha256": "8076dd685a32622eb15a21b2ca8d9e0f2d91e7de6012d728455a15702989cf03"
+    "sha256": "3c89abec67a3177db70b4a95c910156fe36cb4f7601ac674d04028f7895bd326"
   }
 }

--- a/.tieline/spec/runtime.yaml
+++ b/.tieline/spec/runtime.yaml
@@ -75,7 +75,7 @@ capability:
                 path: scripts/test-tieline.ts
                 framework_hint: custom-script
         - key: RUNTIME-001-AC3
-          criterion: Tieline initialization must persist user-confirmed deterministic repository and runtime inputs without generating semantic contract content.
+          criterion: Tieline initialization must persist deterministic repository and runtime inputs from explicit flags and auto-detection without generating semantic contract content.
           rationale: Deterministic setup belongs in the CLI, while interpreting repository context and proposing semantic boundaries belongs with an agent and normal pull-request review.
           links:
             - relation: implements
@@ -98,7 +98,7 @@ capability:
                 path: scripts/test-tieline.ts
                 framework_hint: custom-script
         - key: RUNTIME-001-AC4
-          criterion: Tieline initialization must install the tieline-author skill through Skillfish only for explicitly selected supported agents and scope.
+          criterion: Tieline initialization must prepare explicitly selected project-agent targets and install the tieline-author skill through Skillfish only for those supported agents and scope.
           links:
             - relation: implements
               provenance: authored
@@ -127,7 +127,7 @@ capability:
                 path: scripts/test-tieline.ts
                 framework_hint: custom-script
         - key: RUNTIME-001-AC5
-          criterion: Tieline must preserve a ready workspace when requested skill installation fails.
+          criterion: Tieline must preserve a ready workspace and report a structured installer error when requested skill installation fails.
           links:
             - relation: implements
               provenance: authored
@@ -222,7 +222,7 @@ capability:
                 path: scripts/test-tieline.ts
                 framework_hint: custom-script
         - key: RUNTIME-001-AC9
-          criterion: Tieline interactive initialization must auto-detect code scope and defer product description and context discovery to semantic onboarding while retaining explicit CLI overrides.
+          criterion: Tieline interactive initialization must use agent selection as setup consent, auto-detect code scope, and defer product description and context discovery to semantic onboarding while retaining explicit CLI overrides.
           links:
             - relation: implements
               provenance: authored

--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ name, and code scope, defaults the runtime to offline, and asks one question:
 which coding agents should receive the onboarding skill. Agents the
 repository already shows evidence of (`.claude/`, `.agents/`, `.cursor/`, and
 similar), or the agent whose session is running init, arrive preselected;
-nothing else does. Everything else — product description,
+nothing else does. Selecting the agents is the confirmation: init applies the
+setup immediately without repeating detected defaults in a second review
+screen. Everything else — product description,
 context sources, database upgrades — is gathered conversationally by the
 agent during semantic onboarding, where it can read the repository first and
 verify instead of interrogate:
@@ -225,7 +227,7 @@ terms, invariants, and glossary entries. It should describe the business, not
 ideas, feature requests, or a second backlog.
 
 Tieline also auto-detects the code directories used for mapping coverage and
-shows them as the **Code scope**—for example, `apps` and `packages`. Most users
+records them as the **Code scope**—for example, `apps` and `packages`. Most users
 do not need to configure this. Use a repeatable `--source-root` only when the
 repository uses code directories Tieline did not detect. The stored
 configuration name for this code scope is `repository.source_roots`.
@@ -308,10 +310,11 @@ installation.
 | `opencode` | OpenCode |
 | `windsurf` | Windsurf |
 
-Tieline delegates native agent-directory handling to Skillfish. It invokes the
-latest installer through `npx`, against Tieline's public default branch and
-without adding Skillfish as a package dependency. A single-target project
-invocation has this shape:
+For a project-scoped install, Tieline creates the selected agent's project
+marker when the repository is fresh, then delegates skill installation to
+Skillfish. It invokes the latest installer through `npx`, against Tieline's
+public default branch and without adding Skillfish as a package dependency. A
+single-target project invocation has this shape:
 
 ```bash
 npx --yes --package=skillfish@latest skillfish add knoxgraeme/tieline \

--- a/scripts/test-skill-install.ts
+++ b/scripts/test-skill-install.ts
@@ -1,8 +1,17 @@
 import assert from "node:assert/strict";
 import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import {
   SUPPORTED_SKILL_AGENTS,
   SKILL_INSTALL_TIMEOUT_MS,
   buildSkillfishInvocation,
+  detectRepositoryAgents,
   installTielineAuthor,
   renderSkillInstallRetryCommand,
   runSkillfishProcess,
@@ -11,6 +20,9 @@ import {
 } from "../src/tieline/skill-install.js";
 
 const workspaceRoot = "/tmp/Example Repository";
+const installWorkspaceRoot = mkdtempSync(
+  resolve(tmpdir(), "tieline-skill-install-")
+);
 const sourceEnv: NodeJS.ProcessEnv = {
   PATH: "/usr/local/bin:/usr/bin",
   HOME: "/Users/example",
@@ -167,7 +179,7 @@ const successRunner: SkillfishProcessRunner = async (received) => {
 };
 const success = await installTielineAuthor(
   {
-    workspaceRoot,
+    workspaceRoot: installWorkspaceRoot,
     agentIds: ["codex", "claude-code"],
     scope: "project",
     env: sourceEnv,
@@ -175,7 +187,7 @@ const success = await installTielineAuthor(
   },
   successRunner
 );
-assert.equal(capturedInvocation.cwd, workspaceRoot);
+assert.equal(capturedInvocation.cwd, installWorkspaceRoot);
 assert.equal(success.status, "installed");
 assert.deepEqual(success.installedAgents, ["codex"]);
 assert.deepEqual(success.alreadyPresentAgents, ["claude-code"]);
@@ -214,6 +226,21 @@ const failureCases: Array<{
     reason: /exited with code 3/i,
   },
   {
+    name: "structured non-zero exit",
+    runner: async () => ({
+      code: 1,
+      stdout: JSON.stringify({
+        success: false,
+        errors: [
+          "No agents detected in this project. Create an agent directory or use --global.",
+        ],
+      }),
+      stderr: "private nested output",
+      timedOut: false,
+    }),
+    reason: /No agents detected in this project/,
+  },
+  {
     name: "empty output",
     runner: async () => ({
       code: 0,
@@ -247,7 +274,7 @@ const failureCases: Array<{
       stderr: "",
       timedOut: false,
     }),
-    reason: /reported an unsuccessful installation/i,
+    reason: /not found/i,
   },
   {
     name: "missing requested target",
@@ -288,6 +315,123 @@ for (const failureCase of failureCases) {
   );
 }
 
+const projectMarkers = [
+  ["claude-code", ".claude"],
+  ["codex", ".codex"],
+  ["cursor", ".cursor"],
+  ["gemini-cli", ".gemini"],
+  ["github-copilot", ".github/skills"],
+  ["opencode", ".opencode"],
+  ["windsurf", ".windsurf"],
+] as const;
+
+for (const [agentId, marker] of projectMarkers) {
+  const agentWorkspace = resolve(installWorkspaceRoot, agentId);
+  const selector = SUPPORTED_SKILL_AGENTS.find(
+    (agent) => agent.id === agentId
+  )?.selector;
+  assert.ok(selector);
+  const installed = await installTielineAuthor(
+    {
+      workspaceRoot: agentWorkspace,
+      agentIds: [agentId],
+      scope: "project",
+      env: sourceEnv,
+      platform: "darwin",
+    },
+    async () => {
+      assert.ok(
+        existsSync(resolve(agentWorkspace, marker)),
+        `${agentId} marker must exist before Skillfish runs`
+      );
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          success: true,
+          exit_code: 0,
+          errors: [],
+          installed: [
+            {
+              skill: "tieline-author",
+              agent: selector,
+              path: resolve(agentWorkspace, marker, "skills/tieline-author"),
+              location: "project",
+            },
+          ],
+          skipped: [],
+        }),
+        stderr: "",
+        timedOut: false,
+      };
+    }
+  );
+  assert.equal(installed.status, "installed", agentId);
+  assert.ok(
+    detectRepositoryAgents(agentWorkspace, {}).includes(agentId),
+    `${agentId} must be detected from its installed project marker`
+  );
+}
+
+const globalWorkspace = resolve(installWorkspaceRoot, "global");
+const globalInstall = await installTielineAuthor(
+  {
+    workspaceRoot: globalWorkspace,
+    agentIds: projectMarkers.map(([agentId]) => agentId),
+    scope: "global",
+    env: sourceEnv,
+    platform: "darwin",
+  },
+  async () => ({
+    code: 0,
+    stdout: JSON.stringify({
+      success: true,
+      exit_code: 0,
+      errors: [],
+      installed: projectMarkers.map(([agentId], index) => ({
+        skill: "tieline-author",
+        agent: SUPPORTED_SKILL_AGENTS[index].selector,
+        path: `/global/${agentId}/tieline-author`,
+        location: "global",
+      })),
+      skipped: [],
+    }),
+    stderr: "",
+    timedOut: false,
+  })
+);
+assert.equal(globalInstall.status, "installed");
+for (const [, marker] of projectMarkers) {
+  assert.equal(
+    existsSync(resolve(globalWorkspace, marker)),
+    false,
+    `global install must not create ${marker}`
+  );
+}
+
+const blockedMarkerWorkspace = resolve(installWorkspaceRoot, "blocked-marker");
+writeFileSync(blockedMarkerWorkspace, "occupied");
+let blockedMarkerRunnerCalled = false;
+const blockedMarker = await installTielineAuthor(
+  {
+    workspaceRoot: blockedMarkerWorkspace,
+    agentIds: ["codex"],
+    scope: "project",
+    env: sourceEnv,
+    platform: "darwin",
+  },
+  async () => {
+    blockedMarkerRunnerCalled = true;
+    throw new Error("runner must not start");
+  }
+);
+assert.equal(blockedMarker.status, "failed");
+assert.equal(blockedMarkerRunnerCalled, false);
+assert.match(
+  blockedMarker.reason ?? "",
+  /Could not prepare the Codex project marker '\.codex'/
+);
+assert.doesNotMatch(blockedMarker.reason ?? "", /Node\.js|npx/i);
+
 assert.deepEqual(skippedSkillInstall(), {
   status: "skipped",
   requestedAgents: [],
@@ -296,5 +440,7 @@ assert.deepEqual(skippedSkillInstall(), {
   reason: "Skill installation was not requested.",
   retryCommand: null,
 });
+
+rmSync(installWorkspaceRoot, { recursive: true, force: true });
 
 console.log("skill install adapter tests passed");

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -328,7 +328,7 @@ try {
   writeFileSync(resolve(interactiveTarget, "README.md"), "# Interactive\n");
   const interactive = interactiveIo({
     text: [],
-    confirm: [true],
+    confirm: [],
     select: [],
     multiselect: [["codex", "claude-code"]],
   });
@@ -357,6 +357,14 @@ try {
               TIELINE_CONFIG_HOME: interactiveConfigHome,
             }),
             "runtime profile must exist before Skillfish runs"
+          );
+          assert.ok(
+            existsSync(resolve(interactiveTarget, ".claude")),
+            "selected project agents must be detectable before Skillfish runs"
+          );
+          assert.ok(
+            existsSync(resolve(interactiveTarget, ".codex")),
+            "every selected project agent must be prepared before Skillfish runs"
           );
           return successfulSkillfish(invocation);
         },
@@ -393,6 +401,11 @@ try {
     "the agent selector must be the only interactive question"
   );
   assert.equal(
+    interactive.prompts.length,
+    1,
+    "selecting agents is consent; init must not repeat the setup as a confirmation"
+  );
+  assert.equal(
     interactive.prompts.some((prompt) =>
       [
         "Company/product name",
@@ -407,19 +420,14 @@ try {
     false,
     "identity and runtime must be detected, not asked"
   );
-  const interactiveReview =
-    interactive.prompts.find((prompt) => prompt.startsWith("Review:")) ?? "";
-  assert.match(
-    interactiveReview,
-    /Context: product description, README\.md, https:\/\/mcpmarket\.com\/hub.*Code scope: src/s
-  );
-  assert.match(
-    interactiveReview,
-    /create \.tieline for Interactive Checkout \(interactive-checkout\) \(auto-detected\)/
-  );
   assert.match(
     interactive.output.join(""),
-    /Skill: tieline-author installed for Codex and Claude Code \(project\)/
+    /Skill: tieline-author installed for Codex and Claude Code/
+  );
+  assert.doesNotMatch(
+    interactive.output.join(""),
+    /Context:|Runtime:|Code scope:|Skill source:|Skill targets:|Skill scope:/,
+    "init output must report outcomes rather than semantic defaults or integration internals"
   );
   // The onboarding prompt has to stand alone on its own line so it is
   // obviously the thing to copy; keep it out of the surrounding prose.
@@ -448,7 +456,7 @@ try {
   mkdirSync(resolve(noAgentTarget, "src"), { recursive: true });
   const noAgent = interactiveIo({
     text: [],
-    confirm: [true],
+    confirm: [],
     select: [],
     multiselect: [[]],
   });
@@ -502,7 +510,7 @@ try {
   assert.equal(automatedCalls, 1);
   assert.match(
     automated.output.join(""),
-    /Skill: tieline-author installed for Codex \(global\)/
+    /Skill: tieline-author installed for Codex/
   );
   const automatedWorkspace = findTielineWorkspace(automatedTarget);
   assert.ok(automatedWorkspace);
@@ -546,7 +554,7 @@ try {
   );
   assert.match(
     alreadyPresent.output.join(""),
-    /Skill: tieline-author already present for Codex \(global\)/
+    /Skill: tieline-author already present for Codex/
   );
   assert.equal(
     readFileSync(automatedWorkspace.configPath, "utf8"),
@@ -703,17 +711,10 @@ try {
   const mcpMergeOutput = mcpMerge.output.join("");
   assert.match(
     mcpMergeOutput,
-    /Skill: tieline-author installed for Cursor, Codex, and OpenCode \(project\)/,
+    /Skill: tieline-author installed for Cursor, Codex, and OpenCode/,
     "--agent without --skill-scope must default to the project scope"
   );
-  assert.match(
-    mcpMergeOutput,
-    /MCP server: \.mcp\.json updated; \.cursor\/mcp\.json written; opencode\.json written/
-  );
-  assert.match(
-    mcpMergeOutput,
-    /MCP server: Codex registered globally via 'codex mcp add'/
-  );
+  assert.match(mcpMergeOutput, /MCP: configured/);
   const mergedRootBody = readFileSync(
     resolve(mcpMergeTarget, ".mcp.json"),
     "utf8"
@@ -730,7 +731,7 @@ try {
     mergedRootBody,
     "re-running init must not rewrite an up-to-date MCP config"
   );
-  assert.match(mcpRepeat.output.join(""), /\.mcp\.json unchanged/);
+  assert.match(mcpRepeat.output.join(""), /MCP: configured/);
 
   const mcpInvalidTarget = resolve(root, "Mcp Invalid Checkout");
   mkdirSync(resolve(mcpInvalidTarget, "src"), { recursive: true });
@@ -845,19 +846,17 @@ try {
     "review.html\n"
   );
   const firstOutput = first.output.join("");
-  assert.match(firstOutput, /MCP server: \.mcp\.json written/);
+  assert.match(firstOutput, /MCP: configured/);
   assert.match(firstOutput, /Workspace: ready at \.tieline\//);
   assert.doesNotMatch(
     firstOutput,
     new RegExp(target.replaceAll("\\", "\\\\")),
     "the summary must not print absolute paths"
   );
-  assert.match(firstOutput, /Mode: offline.*local contract authoring ready/i);
-  assert.match(firstOutput, /code scope: src/i);
   assert.doesNotMatch(
     firstOutput,
-    /Optional capabilities|Review: open/,
-    "the summary leads to the paste prompt without optional-feature or review noise"
+    /Mode:|Runtime:|Context:|Code scope:|Optional capabilities|Review: open|Skill source:|Skill targets:|Skill scope:/,
+    "the summary leads to the paste prompt without setup internals"
   );
   assert.match(firstOutput, /skill: not installed/i);
   assert.match(
@@ -905,7 +904,7 @@ try {
 
   const existingInteractive = interactiveIo({
     text: [],
-    confirm: [true],
+    confirm: [],
     select: [],
     multiselect: [["codex"]],
   });
@@ -979,10 +978,7 @@ try {
     }),
     0
   );
-  assert.match(
-    resumed.output.join(""),
-    /Mode: offline.*local contract authoring ready/i
-  );
+  assert.doesNotMatch(resumed.output.join(""), /Mode:|Runtime:|Code scope:/);
   assert.ok(
     readWorkspaceProfile(workspace, {
       TIELINE_CONFIG_HOME: freshConfigHome,

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -11,6 +11,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
+import { stripVTControlCharacters } from "node:util";
 import {
   runCli,
   workspaceStartForCommand,
@@ -420,19 +421,22 @@ try {
     false,
     "identity and runtime must be detected, not asked"
   );
+  const interactiveOutput = stripVTControlCharacters(
+    interactive.output.join("")
+  );
   assert.match(
-    interactive.output.join(""),
+    interactiveOutput,
     /Skill: tieline-author installed for Codex and Claude Code/
   );
   assert.doesNotMatch(
-    interactive.output.join(""),
+    interactiveOutput,
     /Context:|Runtime:|Code scope:|Skill source:|Skill targets:|Skill scope:/,
     "init output must report outcomes rather than semantic defaults or integration internals"
   );
   // The onboarding prompt has to stand alone on its own line so it is
   // obviously the thing to copy; keep it out of the surrounding prose.
   assert.match(
-    interactive.output.join(""),
+    interactiveOutput,
     /Next steps\n {2}1\. Restart or reload your agent\.\n {2}2\. Copy the prompt below and paste it to your agent\.\n\n─+\nUse the tieline-author skill to onboard this repository to Tieline\.\n─+/
   );
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,14 +6,12 @@ import {
   type TielineCliIO,
 } from "../cli.js";
 import {
-  confirmChoice,
   intro,
   multiselectChoice,
   outro,
   paletteFor,
   renderBanner,
   renderCopyCallout,
-  showNote,
 } from "../cli-ui.js";
 import type { Palette } from "../cli-ui.js";
 import {
@@ -27,7 +25,6 @@ import {
 import {
   resolveEmbeddingProvider,
   runDatabasePreflight,
-  runInitPreflight,
   type PreflightCheck,
 } from "../tieline/preflight.js";
 import {
@@ -39,7 +36,6 @@ import {
   type DatabaseMode,
 } from "../tieline/setup.js";
 import {
-  plannedMcpTargets,
   registerCodexMcpServer,
   writeMcpClientConfigs,
   type CodexMcpOutcome,
@@ -93,12 +89,6 @@ interface SkillInstallSelection {
   scope: SkillInstallScope;
 }
 
-const EMBEDDING_PROVIDER_OPTIONS = [
-  { value: "local", label: "Local gte-small" },
-  { value: "openai", label: "OpenAI" },
-  { value: "supabase-edge", label: "Supabase Edge Function" },
-] as const;
-
 const SKILL_AGENT_OPTIONS = SUPPORTED_SKILL_AGENTS.map((agent) => ({
   value: agent.id,
   label: agent.selector,
@@ -127,26 +117,6 @@ function agentLabel(agentId: SkillAgentId): string {
   );
 }
 
-function databaseModeLabel(database: DatabaseMode): string {
-  if (database === "existing") return "hosted / remote PostgreSQL";
-  if (database === "local") return "local PostgreSQL";
-  return "offline";
-}
-
-function embeddingProviderLabel(provider: EmbeddingProvider): string {
-  if (provider === "local") return "local gte-small";
-  return (
-    EMBEDDING_PROVIDER_OPTIONS.find((option) => option.value === provider)
-      ?.label ?? "hash (development only)"
-  );
-}
-
-function codeScopeLabel(sourceRoots: readonly string[]): string {
-  return sourceRoots.length === 1 && sourceRoots[0] === "."
-    ? "entire repository"
-    : sourceRoots.join(", ");
-}
-
 function joinLabels(values: readonly string[]): string {
   if (values.length < 2) return values[0] ?? "";
   if (values.length === 2) return `${values[0]} and ${values[1]}`;
@@ -158,16 +128,11 @@ function renderMcpSummary(
   codex: CodexMcpOutcome | null,
   ui: Palette
 ): string[] {
-  const merged = mcp.writes.filter((write) => write.status !== "failed");
+  const configured = mcp.writes.some((write) => write.status !== "failed");
   const failed = mcp.writes.filter((write) => write.status === "failed");
   const lines: string[] = [];
-  if (merged.length > 0) {
-    lines.push(
-      `MCP server: ${merged
-        .map((write) => `${write.path} ${write.status}`)
-        .join("; ")}`,
-      "MCP tools load when your client starts its next session; the tieline CLI works immediately."
-    );
+  if (configured || codex?.status === "registered") {
+    lines.push("MCP: configured");
   }
   for (const write of failed) {
     lines.push(
@@ -176,11 +141,7 @@ function renderMcpSummary(
       )
     );
   }
-  if (codex?.status === "registered") {
-    lines.push(
-      "MCP server: Codex registered globally via 'codex mcp add'"
-    );
-  } else if (codex) {
+  if (codex && codex.status !== "registered") {
     lines.push(
       ui.yellow(
         `MCP server: Codex registration failed (${codex.reason}); run: ${codex.retryCommand}`
@@ -214,36 +175,17 @@ async function registerMcpClients(
 }
 
 function renderInitSummary(
-  workspace: TielineWorkspace,
   preflight: PreflightCheck[],
   skill: SkillInstallOutcome,
-  skillScope: SkillInstallScope | undefined,
   mcp: McpConfigOutcome,
   codex: CodexMcpOutcome | null,
-  io: TielineCliIO,
-  env: NodeJS.ProcessEnv
+  io: TielineCliIO
 ): void {
   const ui = paletteFor(io);
-  const status = getTielineStatus(workspace, env);
-  const modeDescription =
-    status.runtime.database_mode === "offline"
-      ? "offline — local contract authoring ready"
-      : `${databaseModeLabel(status.runtime.database_mode)} — ${status.runtime.setup_complete ? "setup complete" : "setup incomplete"}`;
-  const notes: string[] = [];
-  if (
-    preflight.some(
-      (check) => check.key === "repository" && check.status === "warning"
-    )
-  ) {
-    notes.push("Git metadata was not detected");
-  }
   const lines = [
     `${ui.green("Workspace:")} ready at ${TIELINE_DIRECTORY}/`,
-    `${ui.green("Mode:")} ${modeDescription}`,
-    `Code scope: ${codeScopeLabel(workspace.config.repository.source_roots)}`,
     ...renderMcpSummary(mcp, codex, ui),
   ];
-  if (notes.length > 0) lines.push(`Readiness notes: ${joinLabels(notes)}`);
   for (const check of preflight) {
     if (
       check.status === "warning" &&
@@ -265,7 +207,7 @@ function renderInitSummary(
         : []),
     ].join("; ");
     lines.push(
-      `Skill: tieline-author ${skillState} (${skillScope})`,
+      `Skill: tieline-author ${skillState}`,
       "",
       ui.bold("Next steps"),
       "  1. Restart or reload your agent.",
@@ -347,18 +289,6 @@ export async function runInit(
       parsed.databaseExplicit ||
       parsed.embeddingExplicit ||
       parsed.installLocalEmbedder;
-    if (io.interactive && !parsed.yes && (shouldConfigure || skillSelection)) {
-      const review = [
-        `Workspace: reuse ${existing.directory}`,
-        shouldConfigure
-          ? `Runtime: configure ${databaseModeLabel(databaseMode)} with ${embeddingProviderLabel(embeddingProvider)} embeddings`
-          : "Runtime: keep completed setup",
-        ...renderRuntimeRequirements(databaseMode, env),
-        ...renderSkillReview(skillSelection),
-        ...renderMcpReview(skillSelection),
-      ].join("\n");
-      await confirmInitReview(io, review);
-    }
     if (shouldConfigure) {
       env.EMBEDDING_PROVIDER = embeddingProvider;
       await configureWorkspaceRuntime({
@@ -410,17 +340,11 @@ export async function runInit(
     const preflightEnv =
       databaseMode === "offline" ? withoutDatabaseEnvironment(env) : env;
     renderInitSummary(
-      existing,
-      [
-        ...runInitPreflight(existing.root, embeddingProvider, preflightEnv),
-        ...(await runDatabasePreflight(preflightEnv)),
-      ],
+      await runDatabasePreflight(preflightEnv),
       skill,
-      skillSelection?.scope,
       mcp,
       codex,
-      io,
-      env
+      io
     );
     return skill.status === "failed" ? 1 : 0;
   }
@@ -449,24 +373,6 @@ export async function runInit(
     env
   );
 
-  if (richInteractive) {
-    const contextReview = [
-      ...(description?.trim() ? ["product description"] : []),
-      ...context,
-    ];
-    await confirmInitReview(
-      io,
-      [
-        `Workspace: create .tieline for ${product} (${repoName})${parsed.product ? "" : " (auto-detected)"}`,
-        `Context: ${contextReview.length > 0 ? contextReview.join(", ") : "discover during semantic onboarding"}`,
-        `Code scope: ${codeScopeLabel(sourceRoots)}${parsed.sourceRoots.length === 0 ? " (auto-detected)" : ""}`,
-        `Runtime: ${databaseModeLabel(database)} with ${embeddingProviderLabel(embedding)} embeddings`,
-        ...renderRuntimeRequirements(database, env),
-        ...renderSkillReview(skillSelection),
-        ...renderMcpReview(skillSelection),
-      ].join("\n")
-    );
-  }
   env.EMBEDDING_PROVIDER = embedding;
   const initEnv =
     database === "offline"
@@ -514,17 +420,11 @@ export async function runInit(
   // last thing on screen rather than trailing into the flow's end cap.
   if (richInteractive) await outro(io, "Tieline workspace ready");
   renderInitSummary(
-    result.workspace,
-    [
-      ...runInitPreflight(result.workspace.root, embedding, initEnv),
-      ...(await runDatabasePreflight(initEnv)),
-    ],
+    await runDatabasePreflight(initEnv),
     skill,
-    skillSelection?.scope,
     mcp,
     codex,
-    io,
-    env
+    io
   );
   return skill.status === "failed" ? 1 : 0;
 }
@@ -553,63 +453,6 @@ async function resolveSkillSelection(
     if (agents.length === 0) return null;
   }
   return { agents, scope: parsed.skillScope ?? "project" };
-}
-
-function renderSkillReview(
-  selection: SkillInstallSelection | null
-): string[] {
-  if (!selection) return ["Skill: do not install now"];
-  return [
-    "Skill: tieline-author (onboarding and authoring)",
-    "Skill source: github.com/knoxgraeme/tieline (default branch)",
-    `Skill targets: ${joinLabels(selection.agents.map(agentLabel))}`,
-    `Skill scope: ${selection.scope}`,
-  ];
-}
-
-function renderMcpReview(
-  selection: SkillInstallSelection | null
-): string[] {
-  const planned = plannedMcpTargets(selection?.agents ?? []);
-  const lines = [
-    `MCP: register the 'tieline' server (npx -y tieline serve) in ${planned.paths.join(", ")}`,
-  ];
-  if (planned.codex) {
-    lines.push(
-      "MCP: register with Codex globally via 'codex mcp add' (~/.codex/config.toml)"
-    );
-  }
-  if (planned.manualAgents.length > 0) {
-    lines.push(
-      `MCP: ${joinLabels(planned.manualAgents.map(agentLabel))} require${planned.manualAgents.length === 1 ? "s" : ""} manual MCP registration`
-    );
-  }
-  return lines;
-}
-
-function renderRuntimeRequirements(
-  database: DatabaseMode,
-  env: NodeJS.ProcessEnv
-): string[] {
-  if (database === "local") {
-    return ["Runtime requirement: Docker with PostgreSQL 16 and pgvector"];
-  }
-  if (database === "existing" && !env.DATABASE_URL_ADMIN?.trim()) {
-    return [
-      "Runtime requirement: configure DATABASE_URL_ADMIN for PostgreSQL 16 with pgvector",
-    ];
-  }
-  return [];
-}
-
-async function confirmInitReview(
-  io: TielineCliIO,
-  review: string
-): Promise<void> {
-  await showNote(io, "Review", review);
-  if (!(await confirmChoice(io, "Apply this setup?", true))) {
-    throw new Error("Cancelled.");
-  }
 }
 
 async function runSkillInstall(

--- a/src/tieline/skill-install.ts
+++ b/src/tieline/skill-install.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { z } from "zod";
 
@@ -23,14 +23,38 @@ export type SkillInstallScope = "project" | "global";
  * everything is indistinguishable from no detection at all. `.agents/` maps
  * to Codex because Codex resolves repository skills from `.agents/skills`.
  */
-const AGENT_REPO_MARKERS: Record<SkillAgentId, string[]> = {
-  "claude-code": [".claude"],
-  codex: [".codex", ".agents"],
-  cursor: [".cursor"],
-  "gemini-cli": [".gemini"],
-  "github-copilot": [".vscode"],
-  opencode: ["opencode.json"],
-  windsurf: [".windsurf"],
+const AGENT_REPOSITORY_CONFIG: Record<
+  SkillAgentId,
+  { detectionMarkers: string[]; skillfishProjectMarker: string }
+> = {
+  "claude-code": {
+    detectionMarkers: [".claude"],
+    skillfishProjectMarker: ".claude",
+  },
+  codex: {
+    detectionMarkers: [".codex", ".agents"],
+    skillfishProjectMarker: ".codex",
+  },
+  cursor: {
+    detectionMarkers: [".cursor"],
+    skillfishProjectMarker: ".cursor",
+  },
+  "gemini-cli": {
+    detectionMarkers: [".gemini"],
+    skillfishProjectMarker: ".gemini",
+  },
+  "github-copilot": {
+    detectionMarkers: [".vscode"],
+    skillfishProjectMarker: ".github/skills",
+  },
+  opencode: {
+    detectionMarkers: ["opencode.json"],
+    skillfishProjectMarker: ".opencode",
+  },
+  windsurf: {
+    detectionMarkers: [".windsurf"],
+    skillfishProjectMarker: ".windsurf",
+  },
 };
 
 /**
@@ -51,8 +75,9 @@ export function detectRepositoryAgents(
     ) {
       return true;
     }
-    return AGENT_REPO_MARKERS[agent.id].some((marker) =>
-      existsSync(resolve(root, marker))
+    const config = AGENT_REPOSITORY_CONFIG[agent.id];
+    return [...config.detectionMarkers, config.skillfishProjectMarker].some(
+      (marker) => existsSync(resolve(root, marker))
     );
   }).map((agent) => agent.id);
 }
@@ -179,6 +204,17 @@ const skillfishOutputSchema = z
   })
   .strict();
 
+const skillfishErrorOutputSchema = z
+  .object({
+    success: z.boolean(),
+    errors: z.array(z.string()),
+    exit_code: z.number().int().optional(),
+    installed: z.array(installedSkillSchema).optional(),
+    skipped: z.array(skippedSkillSchema).optional(),
+    skills_found: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
 function normalizedAgents(
   agentIds: readonly string[]
 ): NormalizedSkillAgent[] {
@@ -239,6 +275,22 @@ function skillfishInvocation(
     shell: platform === "win32",
     timeoutMs: SKILL_INSTALL_TIMEOUT_MS,
   };
+}
+
+function prepareSkillfishProjectMarkers(
+  workspaceRoot: string,
+  agents: readonly NormalizedSkillAgent[]
+): string | null {
+  for (const agent of agents) {
+    const marker = AGENT_REPOSITORY_CONFIG[agent.id].skillfishProjectMarker;
+    try {
+      mkdirSync(resolve(workspaceRoot, marker), { recursive: true });
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      return `Could not prepare the ${agent.selector} project marker '${marker}'${code ? ` (${code})` : ""}.`;
+    }
+  }
+  return null;
 }
 
 export function buildSkillfishInvocation(
@@ -347,6 +399,22 @@ function failedOutcome(
   };
 }
 
+function skillfishErrors(errors: readonly string[]): string | null {
+  const messages = errors.map((error) => error.trim()).filter(Boolean);
+  return messages.length > 0 ? messages.join(" ") : null;
+}
+
+function structuredSkillfishError(stdout: string): string | null {
+  if (!stdout.trim()) return null;
+  try {
+    const parsed = skillfishErrorOutputSchema.safeParse(JSON.parse(stdout));
+    if (!parsed.success) return null;
+    return skillfishErrors(parsed.data.errors);
+  } catch {
+    return null;
+  }
+}
+
 export async function installTielineAuthor(
   options: SkillInstallOptions,
   runner: SkillfishProcessRunner = runSkillfishProcess
@@ -355,6 +423,15 @@ export async function installTielineAuthor(
   const requestedAgents = agents.map((agent) => agent.id);
   const retryCommand = skillInstallRetryCommand(options, agents);
   const invocation = skillfishInvocation(options, agents);
+  if (options.scope === "project") {
+    const preparationError = prepareSkillfishProjectMarkers(
+      options.workspaceRoot,
+      agents
+    );
+    if (preparationError) {
+      return failedOutcome(requestedAgents, retryCommand, preparationError);
+    }
+  }
   let processResult: SkillfishProcessResult;
   try {
     processResult = await runner(invocation);
@@ -376,7 +453,8 @@ export async function installTielineAuthor(
     return failedOutcome(
       requestedAgents,
       retryCommand,
-      `Skillfish exited with code ${processResult.code}.`
+      structuredSkillfishError(processResult.stdout) ??
+        `Skillfish exited with code ${processResult.code}.`
     );
   }
   if (!processResult.stdout.trim()) {
@@ -409,7 +487,8 @@ export async function installTielineAuthor(
     return failedOutcome(
       requestedAgents,
       retryCommand,
-      "Skillfish reported an unsuccessful installation."
+      skillfishErrors(parsed.data.errors) ??
+        "Skillfish reported an unsuccessful installation."
     );
   }
 


### PR DESCRIPTION
## Summary

`tieline init` now treats agent selection as setup consent. Successful runs show only the concrete Workspace, MCP, and Skill outcomes, then hand the user a natural-language onboarding prompt. The redundant review screen and undeclared runtime, context, source, target, and scope details are gone.

Fresh repositories now prepare the selected project-agent marker before Skillfish runs, so users do not hit `No agents detected` just because `.claude/`, `.codex/`, or another agent directory does not exist yet. Installer failures keep their structured upstream explanation, while marker-path failures report the affected agent and marker instead of incorrectly blaming Node.js or npx.

## Validation

- `npm run test:tieline`
- `npm test`
- `node dist/cli.js contract compile .`
- Real fresh-repository smoke test with the published Skillfish CLI: exit 0, `.claude/skills/tieline-author/SKILL.md` installed, compact handoff rendered

## Post-Deploy Monitoring & Validation

- Validate the next npm release with `tieline init` in a fresh repository that has no agent directories.
- Healthy: exit 0, the selected agent skill exists, and output ends with the paste-ready onboarding prompt.
- Investigate any `Skill installation incomplete`, `No agents detected`, or missing `.claude/skills/tieline-author` result.
- If the release regresses, revert this PR's init/installer change and retain the existing `.tieline` workspace; owner: Tieline maintainer during the next-release smoke window.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
