### PR TITLE
fix(skill): consolidate onboarding under tieline

### DIFF
--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -680,7 +680,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -212,7 +212,7 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "f02efe5490a38c050fae1167614c9c049e63603931cba14c1c12828edec40eda",
+            "contract_hash": "3096d59a6b06c1f3f7b794adf8c1c5d0bb3c8a3a456c750bc8593dc3c131cb72",
             "criterion": "Tieline must render accepted Stories and Acceptance Criteria as a self-contained human-readable review page.",
             "links": [
               {
@@ -228,10 +228,20 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "3403080c9008609604303fe44bbe514ed7329ce81b19df401da957e999920765",
+                "reviewed_content_hash": "0dc50bb336e32cf0006d46d19216505c0026e9b6c98776debd77dbddbc025c03",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/review-page.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "979b1406178f9de8df83c6d142521dad4d85eee0d6437e4dc9abaae11170292a",
+                "target": {
+                  "kind": "code",
+                  "path": "src/tieline/review.ts",
                   "repository": "tieline"
                 }
               },
@@ -342,7 +352,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2201b51cbbcee1cda5778c7890c42f1327f63c9357bb9ede1639e52bf19caccb",
+                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -556,7 +566,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2201b51cbbcee1cda5778c7890c42f1327f63c9357bb9ede1639e52bf19caccb",
+                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -616,7 +626,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2a17c0f6cac7280a4b210d8edcf5a332dc92b2c841a4c3f71ae6c92651f9213d",
+                "reviewed_content_hash": "c633617320c31d2a9f5a22d852ae4dae57240cfcf88cbf6c912804a5517ff6b4",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -680,7 +690,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
+                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -745,7 +755,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2201b51cbbcee1cda5778c7890c42f1327f63c9357bb9ede1639e52bf19caccb",
+                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -841,7 +851,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "aedae71097a5d7e46e775aaaba1798b55b2b20cdd436f91e2ad71e3386417442",
+                "reviewed_content_hash": "bcbe5086a8d618fe356b3843b9ae7baef9b361458ff2b82ba591914b85153fcc",
                 "target": {
                   "kind": "code",
                   "path": "src/server.ts",
@@ -914,6 +924,6 @@
   },
   "input": {
     "path": ".tieline/spec/contract.yaml",
-    "sha256": "a05bda29b720f44c5b577c1de546dbfaf3f74e8cc58fb08fb2792ab0bdd89f7b"
+    "sha256": "440c2e2a57483a9c2629266af45ba876892f94d0b87fe1d04158c43d93113f5d"
   }
 }

--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -690,7 +690,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
+                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -228,7 +228,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "0dc50bb336e32cf0006d46d19216505c0026e9b6c98776debd77dbddbc025c03",
+                "reviewed_content_hash": "5803d683b0eec4c1d8a59b903b75b55e7ed19759e93c2fce230403d301042afc",
                 "target": {
                   "kind": "code",
                   "path": "src/contract/review-page.ts",
@@ -626,7 +626,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "c633617320c31d2a9f5a22d852ae4dae57240cfcf88cbf6c912804a5517ff6b4",
+                "reviewed_content_hash": "d170a3e87d436f60292dd7081ae161f11dd03eff7b4f0ab4943973a932af1a12",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -690,7 +690,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
+                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -680,7 +680,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/GRADING.json
+++ b/.tieline/manifest/GRADING.json
@@ -150,7 +150,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2201b51cbbcee1cda5778c7890c42f1327f63c9357bb9ede1639e52bf19caccb",
+                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -372,16 +372,16 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "ee66a0baf65dd19f779dfe877884eb841c3bf0a52bff49b64993b2da0be3cad1",
-            "criterion": "The grading skill must direct the host agent to read and judge every scoped artifact, print every judgment before verification, cite only exact emitted symbols, treat unsupported as useful evidence, and leave contract YAML unchanged.",
+            "contract_hash": "fe9f7833ed697cf9602f23b5988e13b4c2a272576fbdec2f909305ac0fb7b49a",
+            "criterion": "The Tieline skill's grading reference must direct the host agent to read and judge every scoped artifact, print every judgment before verification, cite only exact emitted symbols, treat unsupported as useful evidence, and leave contract YAML unchanged.",
             "links": [
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "aacb93b354891c278694a985e4a30cf48e4aa8b86faf59afdacc36df6f95d109",
+                "reviewed_content_hash": "cceebba845c2557452d8633cd9d84178e3bf6238534aa6c0b053ebe733ccf65f",
                 "target": {
                   "kind": "code",
-                  "path": "skills/tieline-grade/SKILL.md",
+                  "path": "skills/tieline/references/grading.md",
                   "repository": "tieline"
                 }
               }
@@ -412,6 +412,6 @@
   },
   "input": {
     "path": ".tieline/spec/grading.yaml",
-    "sha256": "4c9e239faadad8b5e3392ee441aa4fc9445a64b7a049cf20931340f0e4f8897a"
+    "sha256": "daf706c72a18ea3604b1b1a4d2a7787711dee59e52c983a87dcab42be208628f"
   }
 }

--- a/.tieline/manifest/MATCHING.json
+++ b/.tieline/manifest/MATCHING.json
@@ -175,7 +175,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7d61deff98acd160ad205b123af34ac1a0e06d57dde0e030acc50bba70d941a7",
+                "reviewed_content_hash": "94e5df3a038386349c2028af1524a81c9ff164e3784a6b34ae3adde6dccc2e0f",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/RETRIEVAL.json
+++ b/.tieline/manifest/RETRIEVAL.json
@@ -129,7 +129,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "8be8afd609bcfcd465906e6898f0af7608162c234ca135d36968e229ad28fb19",
+                "reviewed_content_hash": "55108945acfa1475ad1aab0fc39f8f1c1a22196a68ec1a2ca17e0da18e82c787",
                 "target": {
                   "kind": "code",
                   "path": "src/resources.ts",
@@ -150,7 +150,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7d61deff98acd160ad205b123af34ac1a0e06d57dde0e030acc50bba70d941a7",
+                "reviewed_content_hash": "94e5df3a038386349c2028af1524a81c9ff164e3784a6b34ae3adde6dccc2e0f",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -18,7 +18,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2201b51cbbcee1cda5778c7890c42f1327f63c9357bb9ede1639e52bf19caccb",
+                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -38,7 +38,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2a17c0f6cac7280a4b210d8edcf5a332dc92b2c841a4c3f71ae6c92651f9213d",
+                "reviewed_content_hash": "c633617320c31d2a9f5a22d852ae4dae57240cfcf88cbf6c912804a5517ff6b4",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -58,7 +58,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
+                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -102,7 +102,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
+                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -146,7 +146,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2a17c0f6cac7280a4b210d8edcf5a332dc92b2c841a4c3f71ae6c92651f9213d",
+                "reviewed_content_hash": "c633617320c31d2a9f5a22d852ae4dae57240cfcf88cbf6c912804a5517ff6b4",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -156,7 +156,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
+                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -180,7 +180,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2201b51cbbcee1cda5778c7890c42f1327f63c9357bb9ede1639e52bf19caccb",
+                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -200,7 +200,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
+                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -218,13 +218,13 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "16bebe62c37b7376e6120433c66dd0b6ea40cf5f9fad9266fad7eb2ad375d8cc",
-            "criterion": "Tieline initialization must prepare explicitly selected project-agent targets and install the tieline-author skill through Skillfish only for those supported agents and scope.",
+            "contract_hash": "5311ce256ae958045b538b683052044f2f6752d6e1b58dc0b1311a0eb8b32fbf",
+            "criterion": "Tieline initialization must prepare explicitly selected project-agent targets and install the tieline skill through Skillfish only for those supported agents and scope.",
             "links": [
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2201b51cbbcee1cda5778c7890c42f1327f63c9357bb9ede1639e52bf19caccb",
+                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -234,7 +234,17 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "c57f7df103b479e9f7070b670e5e0ae2edc841bba78e7b95523249e9316ace28",
+                "reviewed_content_hash": "5cb95e8e0bcf74ad3d20ad8ed73abca8d90606ae012a13ebeb63659f810f227b",
+                "target": {
+                  "kind": "code",
+                  "path": "src/commands/init.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "f4ca47675e8a8e7295a523720345a4a6d7bdae7ea4f07c166c551060c41f980f",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/skill-install.ts",
@@ -244,7 +254,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "66fecf45d896687bc08b6593ff432ba33e7547f0fd1fb8e44419bbe78869a2bf",
+                "reviewed_content_hash": "c7977a150bea8b952dc80bffa83b408415be3a02436ea5456b101cf018e09a3b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -255,7 +265,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
+                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -279,7 +289,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2201b51cbbcee1cda5778c7890c42f1327f63c9357bb9ede1639e52bf19caccb",
+                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -289,7 +299,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "c57f7df103b479e9f7070b670e5e0ae2edc841bba78e7b95523249e9316ace28",
+                "reviewed_content_hash": "f4ca47675e8a8e7295a523720345a4a6d7bdae7ea4f07c166c551060c41f980f",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/skill-install.ts",
@@ -299,7 +309,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
+                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -323,7 +333,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2201b51cbbcee1cda5778c7890c42f1327f63c9357bb9ede1639e52bf19caccb",
+                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -333,7 +343,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2a17c0f6cac7280a4b210d8edcf5a332dc92b2c841a4c3f71ae6c92651f9213d",
+                "reviewed_content_hash": "c633617320c31d2a9f5a22d852ae4dae57240cfcf88cbf6c912804a5517ff6b4",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -343,7 +353,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
+                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -367,7 +377,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2201b51cbbcee1cda5778c7890c42f1327f63c9357bb9ede1639e52bf19caccb",
+                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -377,7 +387,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "c57f7df103b479e9f7070b670e5e0ae2edc841bba78e7b95523249e9316ace28",
+                "reviewed_content_hash": "f4ca47675e8a8e7295a523720345a4a6d7bdae7ea4f07c166c551060c41f980f",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/skill-install.ts",
@@ -387,7 +397,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "66fecf45d896687bc08b6593ff432ba33e7547f0fd1fb8e44419bbe78869a2bf",
+                "reviewed_content_hash": "c7977a150bea8b952dc80bffa83b408415be3a02436ea5456b101cf018e09a3b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -398,7 +408,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
+                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -422,7 +432,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2201b51cbbcee1cda5778c7890c42f1327f63c9357bb9ede1639e52bf19caccb",
+                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -442,7 +452,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
+                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -466,7 +476,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "2201b51cbbcee1cda5778c7890c42f1327f63c9357bb9ede1639e52bf19caccb",
+                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -486,7 +496,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
+                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -567,7 +577,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "aedae71097a5d7e46e775aaaba1798b55b2b20cdd436f91e2ad71e3386417442",
+                "reviewed_content_hash": "bcbe5086a8d618fe356b3843b9ae7baef9b361458ff2b82ba591914b85153fcc",
                 "target": {
                   "kind": "code",
                   "path": "src/server.ts",
@@ -587,7 +597,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7d61deff98acd160ad205b123af34ac1a0e06d57dde0e030acc50bba70d941a7",
+                "reviewed_content_hash": "94e5df3a038386349c2028af1524a81c9ff164e3784a6b34ae3adde6dccc2e0f",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -723,33 +733,43 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "8ac0facb4ba10825b7a8211ee55f2b0d150cd5d5d15c20cbbda07c7699efd80a",
-            "criterion": "Tieline must expose a semantic-authoring prompt that uses configured repository context and falls back to disclosed local duplicate checks when database-backed matching is unavailable.",
+            "contract_hash": "0d9f6ad2b181c72a1345d0c33d9ed96b4616ef2e6df5ac96cb0b57cd00fec42e",
+            "criterion": "Tieline must expose one semantic workflow prompt bundle that onboards, authors, grades, and reconciles using configured repository context and disclosed local duplicate checks when database-backed matching is unavailable, with a compatibility alias for its former prompt name.",
             "links": [
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "84431e12ecacfa410792a7527d1e1beaa05ba626016d0eed4e1f23fde53b59c4",
+                "reviewed_content_hash": "cceebba845c2557452d8633cd9d84178e3bf6238534aa6c0b053ebe733ccf65f",
                 "target": {
                   "kind": "code",
-                  "path": "skills/tieline-author/references/onboarding.md",
+                  "path": "skills/tieline/references/grading.md",
                   "repository": "tieline"
                 }
               },
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "d39ddc0d72068e3e525eb7576f91a01b579a2c59279128c1dc20ed00d841862b",
+                "reviewed_content_hash": "c9738af42f127a53cf1c7a0fdb8163da42ffee6948a36b3e25adc2f48e784357",
                 "target": {
                   "kind": "code",
-                  "path": "skills/tieline-author/SKILL.md",
+                  "path": "skills/tieline/references/onboarding.md",
                   "repository": "tieline"
                 }
               },
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "a5417d6f082a102a9b9f88d114fb1c35cee18506024cc31920fa5f096e524d1b",
+                "reviewed_content_hash": "c6611486233d6f241d8379189be74d5890f63837e9de8a19e67ad391d9d51767",
+                "target": {
+                  "kind": "code",
+                  "path": "skills/tieline/SKILL.md",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "d5ffff1580e8f76d657f72e75699ca93729908ec82915017567cc34bbe546d48",
                 "target": {
                   "kind": "code",
                   "path": "src/prompts.ts",
@@ -759,7 +779,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "aedae71097a5d7e46e775aaaba1798b55b2b20cdd436f91e2ad71e3386417442",
+                "reviewed_content_hash": "bcbe5086a8d618fe356b3843b9ae7baef9b361458ff2b82ba591914b85153fcc",
                 "target": {
                   "kind": "code",
                   "path": "src/server.ts",
@@ -769,7 +789,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7d61deff98acd160ad205b123af34ac1a0e06d57dde0e030acc50bba70d941a7",
+                "reviewed_content_hash": "94e5df3a038386349c2028af1524a81c9ff164e3784a6b34ae3adde6dccc2e0f",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -780,7 +800,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
+                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -867,6 +887,6 @@
   },
   "input": {
     "path": ".tieline/spec/runtime.yaml",
-    "sha256": "3c89abec67a3177db70b4a95c910156fe36cb4f7601ac674d04028f7895bd326"
+    "sha256": "ce404e9d1f7f25fa4efd2ed7f719c844005d5120eeb648aefffda9d15be0ca2e"
   }
 }

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -58,7 +58,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -102,7 +102,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -156,7 +156,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -200,7 +200,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -255,7 +255,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -299,7 +299,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -343,7 +343,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -398,7 +398,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -442,7 +442,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -486,7 +486,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -780,7 +780,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
+                "reviewed_content_hash": "7db198fb96418c685fdd45c7eec990ce8d684fad6141e7c92373b72e58a94395",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -58,7 +58,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -102,7 +102,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -156,7 +156,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -174,8 +174,8 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "6241bd3c8f2f191b1a3e5325432769d651013bc161c17d7ee306d492c6a18084",
-            "criterion": "Tieline initialization must persist user-confirmed deterministic repository and runtime inputs without generating semantic contract content.",
+            "contract_hash": "1f1ac7fd498b9a12342148ff6b33e7293d84135c135e6443b1a90fe811f638a3",
+            "criterion": "Tieline initialization must persist deterministic repository and runtime inputs from explicit flags and auto-detection without generating semantic contract content.",
             "links": [
               {
                 "provenance": "authored",
@@ -200,7 +200,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -218,8 +218,8 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "685fb657cc388ca2fea42b4c549125cb388b36ac4615f92d210d4a75e1b2d638",
-            "criterion": "Tieline initialization must install the tieline-author skill through Skillfish only for explicitly selected supported agents and scope.",
+            "contract_hash": "16bebe62c37b7376e6120433c66dd0b6ea40cf5f9fad9266fad7eb2ad375d8cc",
+            "criterion": "Tieline initialization must prepare explicitly selected project-agent targets and install the tieline-author skill through Skillfish only for those supported agents and scope.",
             "links": [
               {
                 "provenance": "authored",
@@ -234,7 +234,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "526c9b8879cd1a0d3a180de09619833041226e94855b3b3fad9008f35b17ae0c",
+                "reviewed_content_hash": "c57f7df103b479e9f7070b670e5e0ae2edc841bba78e7b95523249e9316ace28",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/skill-install.ts",
@@ -244,7 +244,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "94d56128fec8a8d33b83d3ff5d2918319d8c0ae88efaf26a0cfcce17af670e18",
+                "reviewed_content_hash": "66fecf45d896687bc08b6593ff432ba33e7547f0fd1fb8e44419bbe78869a2bf",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -255,7 +255,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -273,8 +273,8 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "96fb2484f79a468ff4b54b695bc9f4303f78884915e4b4546e5e724a431e32d6",
-            "criterion": "Tieline must preserve a ready workspace when requested skill installation fails.",
+            "contract_hash": "62557624443b4845f5c36a00a08cdb8e19c45de6d54f4167e03c5f6d83416413",
+            "criterion": "Tieline must preserve a ready workspace and report a structured installer error when requested skill installation fails.",
             "links": [
               {
                 "provenance": "authored",
@@ -289,7 +289,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "526c9b8879cd1a0d3a180de09619833041226e94855b3b3fad9008f35b17ae0c",
+                "reviewed_content_hash": "c57f7df103b479e9f7070b670e5e0ae2edc841bba78e7b95523249e9316ace28",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/skill-install.ts",
@@ -299,7 +299,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -343,7 +343,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -377,7 +377,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "526c9b8879cd1a0d3a180de09619833041226e94855b3b3fad9008f35b17ae0c",
+                "reviewed_content_hash": "c57f7df103b479e9f7070b670e5e0ae2edc841bba78e7b95523249e9316ace28",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/skill-install.ts",
@@ -387,7 +387,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "94d56128fec8a8d33b83d3ff5d2918319d8c0ae88efaf26a0cfcce17af670e18",
+                "reviewed_content_hash": "66fecf45d896687bc08b6593ff432ba33e7547f0fd1fb8e44419bbe78869a2bf",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -398,7 +398,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -442,7 +442,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -460,8 +460,8 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "3bd91d37fd117d257524572bcf9c70daf84f4bc60384fd6ad6d098d6a4df9dd7",
-            "criterion": "Tieline interactive initialization must auto-detect code scope and defer product description and context discovery to semantic onboarding while retaining explicit CLI overrides.",
+            "contract_hash": "28707c526d98ff9f720db80e12e67e0652885420ef315e8cfac2ad61d9433187",
+            "criterion": "Tieline interactive initialization must use agent selection as setup consent, auto-detect code scope, and defer product description and context discovery to semantic onboarding while retaining explicit CLI overrides.",
             "links": [
               {
                 "provenance": "authored",
@@ -486,7 +486,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -780,7 +780,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "7c49ac1b3da97790ca22578b107f2b9509df8aa213073cefd7b27431a0d580a7",
+                "reviewed_content_hash": "9023d93f173c0261edbfe1c0324e76f296cec0e6edd324a4a540e5d6e6197602",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -867,6 +867,6 @@
   },
   "input": {
     "path": ".tieline/spec/runtime.yaml",
-    "sha256": "8076dd685a32622eb15a21b2ca8d9e0f2d91e7de6012d728455a15702989cf03"
+    "sha256": "3c89abec67a3177db70b4a95c910156fe36cb4f7601ac674d04028f7895bd326"
   }
 }

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -38,7 +38,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "c633617320c31d2a9f5a22d852ae4dae57240cfcf88cbf6c912804a5517ff6b4",
+                "reviewed_content_hash": "d170a3e87d436f60292dd7081ae161f11dd03eff7b4f0ab4943973a932af1a12",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -58,7 +58,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
+                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -102,7 +102,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
+                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -146,7 +146,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "c633617320c31d2a9f5a22d852ae4dae57240cfcf88cbf6c912804a5517ff6b4",
+                "reviewed_content_hash": "d170a3e87d436f60292dd7081ae161f11dd03eff7b4f0ab4943973a932af1a12",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -156,7 +156,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
+                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -200,7 +200,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
+                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -265,7 +265,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
+                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -309,7 +309,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
+                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -343,7 +343,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "c633617320c31d2a9f5a22d852ae4dae57240cfcf88cbf6c912804a5517ff6b4",
+                "reviewed_content_hash": "d170a3e87d436f60292dd7081ae161f11dd03eff7b4f0ab4943973a932af1a12",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -353,7 +353,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
+                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -408,7 +408,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
+                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -452,7 +452,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
+                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -496,7 +496,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
+                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -800,7 +800,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "403daf93fecfd779ef2cae33a66c1f1065bd452b70ad0b53c86eddcf45a0976b",
+                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -58,7 +58,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
+                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -102,7 +102,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
+                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -156,7 +156,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
+                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -200,7 +200,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
+                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -265,7 +265,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
+                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -309,7 +309,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
+                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -353,7 +353,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
+                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -408,7 +408,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
+                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -452,7 +452,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
+                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -496,7 +496,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
+                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -800,7 +800,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "6adec98eed0c0d084fe0280d2028565a441b95fb46dbffd29dcb0cb9ac8bcc69",
+                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/spec/contract.yaml
+++ b/.tieline/spec/contract.yaml
@@ -137,6 +137,12 @@ capability:
                 kind: code
                 repository: tieline
                 path: src/commands/contract.ts
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/tieline/review.ts
             - relation: tests
               provenance: authored
               target:

--- a/.tieline/spec/grading.yaml
+++ b/.tieline/spec/grading.yaml
@@ -199,7 +199,7 @@ capability:
                 path: scripts/test-grade.ts
                 framework_hint: custom-script
         - key: GRADING-002-AC4
-          criterion: The grading skill must direct the host agent to read and judge every scoped artifact, print every judgment before verification, cite only exact emitted symbols, treat unsupported as useful evidence, and leave contract YAML unchanged.
+          criterion: The Tieline skill's grading reference must direct the host agent to read and judge every scoped artifact, print every judgment before verification, cite only exact emitted symbols, treat unsupported as useful evidence, and leave contract YAML unchanged.
           rationale: The host judgment is the only non-deterministic phase, so its refusal and audit rules are part of the shipped workflow.
           links:
             - relation: implements
@@ -207,4 +207,4 @@ capability:
               target:
                 kind: code
                 repository: tieline
-                path: skills/tieline-grade/SKILL.md
+                path: skills/tieline/references/grading.md

--- a/.tieline/spec/runtime.yaml
+++ b/.tieline/spec/runtime.yaml
@@ -75,7 +75,7 @@ capability:
                 path: scripts/test-tieline.ts
                 framework_hint: custom-script
         - key: RUNTIME-001-AC3
-          criterion: Tieline initialization must persist user-confirmed deterministic repository and runtime inputs without generating semantic contract content.
+          criterion: Tieline initialization must persist deterministic repository and runtime inputs from explicit flags and auto-detection without generating semantic contract content.
           rationale: Deterministic setup belongs in the CLI, while interpreting repository context and proposing semantic boundaries belongs with an agent and normal pull-request review.
           links:
             - relation: implements
@@ -98,7 +98,7 @@ capability:
                 path: scripts/test-tieline.ts
                 framework_hint: custom-script
         - key: RUNTIME-001-AC4
-          criterion: Tieline initialization must install the tieline-author skill through Skillfish only for explicitly selected supported agents and scope.
+          criterion: Tieline initialization must prepare explicitly selected project-agent targets and install the tieline-author skill through Skillfish only for those supported agents and scope.
           links:
             - relation: implements
               provenance: authored
@@ -127,7 +127,7 @@ capability:
                 path: scripts/test-tieline.ts
                 framework_hint: custom-script
         - key: RUNTIME-001-AC5
-          criterion: Tieline must preserve a ready workspace when requested skill installation fails.
+          criterion: Tieline must preserve a ready workspace and report a structured installer error when requested skill installation fails.
           links:
             - relation: implements
               provenance: authored
@@ -222,7 +222,7 @@ capability:
                 path: scripts/test-tieline.ts
                 framework_hint: custom-script
         - key: RUNTIME-001-AC9
-          criterion: Tieline interactive initialization must auto-detect code scope and defer product description and context discovery to semantic onboarding while retaining explicit CLI overrides.
+          criterion: Tieline interactive initialization must use agent selection as setup consent, auto-detect code scope, and defer product description and context discovery to semantic onboarding while retaining explicit CLI overrides.
           links:
             - relation: implements
               provenance: authored

--- a/.tieline/spec/runtime.yaml
+++ b/.tieline/spec/runtime.yaml
@@ -98,7 +98,7 @@ capability:
                 path: scripts/test-tieline.ts
                 framework_hint: custom-script
         - key: RUNTIME-001-AC4
-          criterion: Tieline initialization must prepare explicitly selected project-agent targets and install the tieline-author skill through Skillfish only for those supported agents and scope.
+          criterion: Tieline initialization must prepare explicitly selected project-agent targets and install the tieline skill through Skillfish only for those supported agents and scope.
           links:
             - relation: implements
               provenance: authored
@@ -112,6 +112,12 @@ capability:
                 kind: code
                 repository: tieline
                 path: src/tieline/skill-install.ts
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/commands/init.ts
             - relation: tests
               provenance: authored
               target:
@@ -381,7 +387,7 @@ capability:
                 path: scripts/test-contract-read.ts
                 framework_hint: custom-script
         - key: RUNTIME-002-AC4
-          criterion: Tieline must expose a semantic-authoring prompt that uses configured repository context and falls back to disclosed local duplicate checks when database-backed matching is unavailable.
+          criterion: Tieline must expose one semantic workflow prompt bundle that onboards, authors, grades, and reconciles using configured repository context and disclosed local duplicate checks when database-backed matching is unavailable, with a compatibility alias for its former prompt name.
           links:
             - relation: implements
               provenance: authored
@@ -400,13 +406,19 @@ capability:
               target:
                 kind: code
                 repository: tieline
-                path: skills/tieline-author/SKILL.md
+                path: skills/tieline/SKILL.md
             - relation: implements
               provenance: authored
               target:
                 kind: code
                 repository: tieline
-                path: skills/tieline-author/references/onboarding.md
+                path: skills/tieline/references/onboarding.md
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: skills/tieline/references/grading.md
             - relation: tests
               provenance: authored
               target:

--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ name, and code scope, defaults the runtime to offline, and asks one question:
 which coding agents should receive the onboarding skill. Agents the
 repository already shows evidence of (`.claude/`, `.agents/`, `.cursor/`, and
 similar), or the agent whose session is running init, arrive preselected;
-nothing else does. Everything else — product description,
+nothing else does. Selecting the agents is the confirmation: init applies the
+setup immediately without repeating detected defaults in a second review
+screen. Everything else — product description,
 context sources, database upgrades — is gathered conversationally by the
 agent during semantic onboarding, where it can read the repository first and
 verify instead of interrogate:
@@ -225,7 +227,7 @@ terms, invariants, and glossary entries. It should describe the business, not
 ideas, feature requests, or a second backlog.
 
 Tieline also auto-detects the code directories used for mapping coverage and
-shows them as the **Code scope**—for example, `apps` and `packages`. Most users
+records them as the **Code scope**—for example, `apps` and `packages`. Most users
 do not need to configure this. Use a repeatable `--source-root` only when the
 repository uses code directories Tieline did not detect. The stored
 configuration name for this code scope is `repository.source_roots`.
@@ -308,10 +310,11 @@ installation.
 | `opencode` | OpenCode |
 | `windsurf` | Windsurf |
 
-Tieline delegates native agent-directory handling to Skillfish. It invokes the
-latest installer through `npx`, against Tieline's public default branch and
-without adding Skillfish as a package dependency. A single-target project
-invocation has this shape:
+For a project-scoped install, Tieline creates the selected agent's project
+marker when the repository is fresh, then delegates skill installation to
+Skillfish. It invokes the latest installer through `npx`, against Tieline's
+public default branch and without adding Skillfish as a package dependency. A
+single-target project invocation has this shape:
 
 ```bash
 npx --yes --package=skillfish@latest skillfish add knoxgraeme/tieline \

--- a/README.md
+++ b/README.md
@@ -189,9 +189,10 @@ cd /path/to/product-repository
 npx -y tieline init
 ```
 
-Restart or reload the selected agent, then invoke the installed `tieline`
-skill (`/tieline` in Claude Code; `$tieline` in Codex). That invocation is the
-semantic-onboarding handoff; no prose prompt needs to be copied.
+Restart or reload the selected agent, then ask it to use the installed
+`tieline` skill. In Claude Code, run `/tieline`; in Codex, run `$tieline`.
+Other supported agents can activate the skill from the same natural-language
+request. That invocation is the semantic-onboarding handoff.
 
 The same setup remains prompt-free for automation:
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,36 @@
 
 # Tieline
 
-Tieline is a living semantic contract for how a product and business work. It
-connects user intent to code, tests, help content, requests, bugs, questions,
-and planned work, while keeping the accepted definition reviewable beside the
-implementation.
+Tieline keeps product intent from getting lost between docs, tickets, code, and
+AI agents. It turns how a product and business work into a living, versioned
+semantic contract, so people and agents share the same reviewed definition of
+what the product should do and where that behavior lives.
+
+## Quick setup
+
+From the repository you want to onboard (requires Node.js 20.12 or newer):
+
+```bash
+cd /path/to/product-repository
+npx -y tieline init
+```
+
+Select the coding agents you use. Tieline creates or updates the `.tieline`
+workspace and installs the project-scoped `tieline` skill for those agents. It
+configures MCP automatically where the selected agent supports repository or
+CLI registration; otherwise, follow init's printed manual MCP instruction.
+Restart or reload the selected agent, then start semantic onboarding:
+
+- Claude Code: run `/tieline`
+- Codex: run `$tieline`
+- Other supported agents: ask the agent to use the installed `tieline` skill
+
+The agent then discovers product context from the repository, proposes the
+initial semantic contract for review, and guides the remaining setup. See
+[Detailed setup and configuration](#detailed-setup-and-configuration) for
+database modes, automation, agent-specific behavior, and advanced options.
+
+## How Tieline works
 
 The core hierarchy is:
 
@@ -127,7 +153,9 @@ Stable IDs are identity, not embedding prose. Aliases support alternate language
 applicability distinguishes legitimately different behavior, and `supersedes`
 converges definitions without deleting history.
 
-## Requirements and installation
+## Detailed setup and configuration
+
+### Requirements and installation
 
 - Node.js 20.12 or newer.
 - Docker with a running daemon when using `--database local`.
@@ -170,7 +198,7 @@ tieline --help
 current machine. Without it, replace `tieline` in the examples below with
 `node dist/cli.js` from the checkout.
 
-## Initialize and onboard a repository
+### Initialize and onboard a repository
 
 Run init from the repository. It auto-detects the product name, repository
 name, and code scope, defaults the runtime to offline, and asks one question:

--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ cd /path/to/product-repository
 npx -y tieline init
 ```
 
+Restart or reload the selected agent, then invoke the installed `tieline`
+skill (`/tieline` in Claude Code; `$tieline` in Codex). That invocation is the
+semantic-onboarding handoff; no prose prompt needs to be copied.
+
 The same setup remains prompt-free for automation:
 
 ```bash
@@ -202,7 +206,7 @@ tieline init /path/to/product-repository \
 
 `--yes` installs an agent skill only when `--agent` is explicit;
 `--skill-scope` defaults to `project`. To initialize and install
-`tieline-author` for multiple agents:
+`tieline` for multiple agents:
 
 ```bash
 tieline init /path/to/product-repository \
@@ -215,7 +219,7 @@ tieline init /path/to/product-repository \
 ```
 
 Interactive init does not ask for a product description or context inventory;
-the installed `tieline-author` skill discovers README, product documentation,
+the installed `tieline` skill discovers README, product documentation,
 public code entry points, and tests during semantic onboarding. Automation can
 still provide known product framing with `--description`. Additional context
 sources are optional and explicit: provide each one with a repeatable
@@ -287,7 +291,7 @@ clone completes its own runtime setup instead of inheriting another machine's
 
 On a new repository, the only Tieline command a user needs to begin onboarding
 is `tieline init`. It captures deterministic setup, then asks which coding
-agents should receive the packaged `tieline-author` skill. That one skill owns
+agents should receive the packaged `tieline` skill. That one skill owns
 both first-time semantic onboarding and ongoing authoring/reconciliation; a
 separate onboarding skill is not required. Tieline
 does not auto-detect or launch an agent, persist agent choices in shared
@@ -318,7 +322,7 @@ single-target project invocation has this shape:
 
 ```bash
 npx --yes --package=skillfish@latest skillfish add knoxgraeme/tieline \
-  --path skills/tieline-author \
+  --path skills/tieline \
   --agent "Codex" \
   --project \
   --yes \
@@ -354,9 +358,13 @@ path:
 }
 ```
 
-The installed `$tieline-author` skill and the equivalent
-`tieline_author` MCP prompt are two delivery surfaces for the same maintained
-semantic workflow. That workflow can:
+The installed `tieline` skill (`/tieline` in slash-command agents and
+`$tieline` in Codex) and the equivalent `tieline` MCP prompt are two delivery
+surfaces for the same maintained semantic workflow. The MCP prompt is a
+reusable instruction template exposed by the Tieline server; retrieving it
+loads the workflow into the conversation, while MCP tools remain the operations
+the agent calls. Existing MCP clients can continue to request the deprecated
+`tieline_author` prompt name; it returns the same content. That workflow can:
 
 - shape a planning Story/AC or Backlog Item in Postgres;
 - semantically onboard an empty spec from configured descriptions, local
@@ -370,9 +378,8 @@ semantic workflow. That workflow can:
 An empty `.tieline/spec/` immediately after init is intentional: init does not
 invent generic capabilities. The authoring skill validates the detected code
 scope against the repository before claiming coverage. While the spec has no Stories,
-`tieline status --json` exposes `onboarding.required`, the `tieline-author`
-skill name, a paste-ready agent prompt (`Use the tieline-author skill to
-onboard this repository to Tieline.`), and `tieline init .` as the install
+`tieline status --json` exposes `onboarding.required`, the `tieline` skill
+name, its direct invocation instruction, and `tieline init .` as the install
 command. `onboarding` becomes
 `null` after the first Story exists. Status also reports whether the local
 profile is ready and whether database-backed semantic matching and planning
@@ -485,8 +492,9 @@ the second command verifies that every verdict belongs to the scope and that
 every claimed citation came from its allow-list. Tieline does
 not call a model, database, or network for this workflow. Verification is
 advisory by default, including negative results; add `--strict` to the verify
-command only when unsupported evidence should fail the gate. The packaged
-`tieline-grade` skill leads an agent through the full workflow.
+command only when unsupported evidence should fail the gate. The installed
+`tieline` skill carries this grading workflow as an internal reference and
+dispatches fresh grading contexts so authors do not judge their own rationale.
 
 Generate a human-readable browser review of the accepted YAML:
 
@@ -833,8 +841,7 @@ earlier model must be recreated rather than upgraded in place.
 | `src/tieline/` | Repository initialization, profiles, status, and setup |
 | `migrations/` | PostgreSQL/pgvector schema and role baseline |
 | `scripts/` | Contract, retrieval, transport, and integration verification |
-| `skills/tieline-author/` | Packaged semantic authoring workflow |
-| `skills/tieline-grade/` | Packaged agent workflow for grading changed contract evidence |
+| `skills/tieline/` | Packaged onboarding, authoring, grading, and reconciliation workflow |
 | `.tieline/` | This repository's own accepted contract and compiled manifest |
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tieline",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tieline",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tieline",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tieline",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tieline",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Living Story/AC contract and semantic graph grounded in code, tests, help content, and organizational evidence.",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tieline",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Living Story/AC contract and semantic graph grounded in code, tests, help content, and organizational evidence.",
   "license": "MIT",
   "repository": {

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -3,6 +3,8 @@ delete process.env.DATABASE_URL;
 delete process.env.DATABASE_URL_WRITE;
 
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { FakeKnowledgeStore } from "../src/domain/testing/fake-knowledge-store.js";
@@ -92,14 +94,38 @@ try {
   const prompts = await client.listPrompts();
   assert.deepEqual(
     prompts.prompts.map((prompt) => prompt.name),
-    ["tieline_author"]
+    ["tieline", "tieline_author"]
   );
-  const authorPrompt = await client.getPrompt({ name: "tieline_author" });
-  assert.match(
-    String(authorPrompt.messages[0]?.content.type === "text"
-      ? authorPrompt.messages[0].content.text
-      : ""),
-    /\.tieline\/config\.json[\s\S]*Search before creating[\s\S]*Semantic onboarding/
+  const tielinePrompt = await client.getPrompt({ name: "tieline" });
+  const promptText = String(
+    tielinePrompt.messages[0]?.content.type === "text"
+      ? tielinePrompt.messages[0].content.text
+      : ""
+  );
+  const expectedPromptText = [
+    "SKILL.md",
+    "references/contract.md",
+    "references/onboarding.md",
+    "references/provisioning.md",
+    "references/grading.md",
+    "references/report.md",
+  ]
+    .map((path) =>
+      readFileSync(resolve(process.cwd(), "skills/tieline", path), "utf8")
+    )
+    .join("\n\n");
+  assert.equal(
+    promptText,
+    expectedPromptText,
+    "the MCP prompt must expose the complete installed Tieline workflow"
+  );
+  const legacyPrompt = await client.getPrompt({ name: "tieline_author" });
+  assert.equal(
+    legacyPrompt.messages[0]?.content.type === "text"
+      ? legacyPrompt.messages[0].content.text
+      : "",
+    promptText,
+    "the legacy MCP prompt name must remain a content-identical alias"
   );
 
   const omittedProfile = (await client.callTool({

--- a/scripts/test-skill-install.ts
+++ b/scripts/test-skill-install.ts
@@ -12,7 +12,7 @@ import {
   SKILL_INSTALL_TIMEOUT_MS,
   buildSkillfishInvocation,
   detectRepositoryAgents,
-  installTielineAuthor,
+  installTielineSkill,
   renderSkillInstallRetryCommand,
   runSkillfishProcess,
   skippedSkillInstall,
@@ -72,7 +72,7 @@ assert.deepEqual(invocation.args, [
   "add",
   "knoxgraeme/tieline",
   "--path",
-  "skills/tieline-author",
+  "skills/tieline",
   "--agent",
   "Codex",
   "--agent",
@@ -158,26 +158,26 @@ const successRunner: SkillfishProcessRunner = async (received) => {
       errors: [],
       installed: [
         {
-          skill: "tieline-author",
+          skill: "tieline",
           agent: "Codex",
-          path: "/tmp/Example Repository/.codex/skills/tieline-author",
+          path: "/tmp/Example Repository/.codex/skills/tieline",
           location: "project",
         },
       ],
       skipped: [
         {
-          skill: "tieline-author",
+          skill: "tieline",
           agent: "Claude Code",
           reason: "Already installed",
         },
       ],
-      skills_found: ["tieline-author"],
+      skills_found: ["tieline"],
     }),
     stderr: "",
     timedOut: false,
   };
 };
-const success = await installTielineAuthor(
+const success = await installTielineSkill(
   {
     workspaceRoot: installWorkspaceRoot,
     agentIds: ["codex", "claude-code"],
@@ -295,7 +295,7 @@ const failureCases: Array<{
 ];
 
 for (const failureCase of failureCases) {
-  const failed = await installTielineAuthor(
+  const failed = await installTielineSkill(
     {
       workspaceRoot,
       agentIds: ["codex"],
@@ -331,7 +331,7 @@ for (const [agentId, marker] of projectMarkers) {
     (agent) => agent.id === agentId
   )?.selector;
   assert.ok(selector);
-  const installed = await installTielineAuthor(
+  const installed = await installTielineSkill(
     {
       workspaceRoot: agentWorkspace,
       agentIds: [agentId],
@@ -352,9 +352,9 @@ for (const [agentId, marker] of projectMarkers) {
           errors: [],
           installed: [
             {
-              skill: "tieline-author",
+              skill: "tieline",
               agent: selector,
-              path: resolve(agentWorkspace, marker, "skills/tieline-author"),
+              path: resolve(agentWorkspace, marker, "skills/tieline"),
               location: "project",
             },
           ],
@@ -373,7 +373,7 @@ for (const [agentId, marker] of projectMarkers) {
 }
 
 const globalWorkspace = resolve(installWorkspaceRoot, "global");
-const globalInstall = await installTielineAuthor(
+const globalInstall = await installTielineSkill(
   {
     workspaceRoot: globalWorkspace,
     agentIds: projectMarkers.map(([agentId]) => agentId),
@@ -388,9 +388,9 @@ const globalInstall = await installTielineAuthor(
       exit_code: 0,
       errors: [],
       installed: projectMarkers.map(([agentId], index) => ({
-        skill: "tieline-author",
+        skill: "tieline",
         agent: SUPPORTED_SKILL_AGENTS[index].selector,
-        path: `/global/${agentId}/tieline-author`,
+        path: `/global/${agentId}/tieline`,
         location: "global",
       })),
       skipped: [],
@@ -411,7 +411,7 @@ for (const [, marker] of projectMarkers) {
 const blockedMarkerWorkspace = resolve(installWorkspaceRoot, "blocked-marker");
 writeFileSync(blockedMarkerWorkspace, "occupied");
 let blockedMarkerRunnerCalled = false;
-const blockedMarker = await installTielineAuthor(
+const blockedMarker = await installTielineSkill(
   {
     workspaceRoot: blockedMarkerWorkspace,
     agentIds: ["codex"],

--- a/scripts/test-skill-install.ts
+++ b/scripts/test-skill-install.ts
@@ -1,8 +1,17 @@
 import assert from "node:assert/strict";
 import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import {
   SUPPORTED_SKILL_AGENTS,
   SKILL_INSTALL_TIMEOUT_MS,
   buildSkillfishInvocation,
+  detectRepositoryAgents,
   installTielineAuthor,
   renderSkillInstallRetryCommand,
   runSkillfishProcess,
@@ -11,6 +20,9 @@ import {
 } from "../src/tieline/skill-install.js";
 
 const workspaceRoot = "/tmp/Example Repository";
+const installWorkspaceRoot = mkdtempSync(
+  resolve(tmpdir(), "tieline-skill-install-")
+);
 const sourceEnv: NodeJS.ProcessEnv = {
   PATH: "/usr/local/bin:/usr/bin",
   HOME: "/Users/example",
@@ -167,7 +179,7 @@ const successRunner: SkillfishProcessRunner = async (received) => {
 };
 const success = await installTielineAuthor(
   {
-    workspaceRoot,
+    workspaceRoot: installWorkspaceRoot,
     agentIds: ["codex", "claude-code"],
     scope: "project",
     env: sourceEnv,
@@ -175,7 +187,7 @@ const success = await installTielineAuthor(
   },
   successRunner
 );
-assert.equal(capturedInvocation.cwd, workspaceRoot);
+assert.equal(capturedInvocation.cwd, installWorkspaceRoot);
 assert.equal(success.status, "installed");
 assert.deepEqual(success.installedAgents, ["codex"]);
 assert.deepEqual(success.alreadyPresentAgents, ["claude-code"]);
@@ -214,6 +226,21 @@ const failureCases: Array<{
     reason: /exited with code 3/i,
   },
   {
+    name: "structured non-zero exit",
+    runner: async () => ({
+      code: 1,
+      stdout: JSON.stringify({
+        success: false,
+        errors: [
+          "No agents detected in this project. Create an agent directory or use --global.",
+        ],
+      }),
+      stderr: "private nested output",
+      timedOut: false,
+    }),
+    reason: /No agents detected in this project/,
+  },
+  {
     name: "empty output",
     runner: async () => ({
       code: 0,
@@ -247,7 +274,7 @@ const failureCases: Array<{
       stderr: "",
       timedOut: false,
     }),
-    reason: /reported an unsuccessful installation/i,
+    reason: /not found/i,
   },
   {
     name: "missing requested target",
@@ -288,6 +315,123 @@ for (const failureCase of failureCases) {
   );
 }
 
+const projectMarkers = [
+  ["claude-code", ".claude"],
+  ["codex", ".codex"],
+  ["cursor", ".cursor"],
+  ["gemini-cli", ".gemini"],
+  ["github-copilot", ".github/skills"],
+  ["opencode", ".opencode"],
+  ["windsurf", ".windsurf"],
+] as const;
+
+for (const [agentId, marker] of projectMarkers) {
+  const agentWorkspace = resolve(installWorkspaceRoot, agentId);
+  const selector = SUPPORTED_SKILL_AGENTS.find(
+    (agent) => agent.id === agentId
+  )?.selector;
+  assert.ok(selector);
+  const installed = await installTielineAuthor(
+    {
+      workspaceRoot: agentWorkspace,
+      agentIds: [agentId],
+      scope: "project",
+      env: sourceEnv,
+      platform: "darwin",
+    },
+    async () => {
+      assert.ok(
+        existsSync(resolve(agentWorkspace, marker)),
+        `${agentId} marker must exist before Skillfish runs`
+      );
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          success: true,
+          exit_code: 0,
+          errors: [],
+          installed: [
+            {
+              skill: "tieline-author",
+              agent: selector,
+              path: resolve(agentWorkspace, marker, "skills/tieline-author"),
+              location: "project",
+            },
+          ],
+          skipped: [],
+        }),
+        stderr: "",
+        timedOut: false,
+      };
+    }
+  );
+  assert.equal(installed.status, "installed", agentId);
+  assert.ok(
+    detectRepositoryAgents(agentWorkspace, {}).includes(agentId),
+    `${agentId} must be detected from its installed project marker`
+  );
+}
+
+const globalWorkspace = resolve(installWorkspaceRoot, "global");
+const globalInstall = await installTielineAuthor(
+  {
+    workspaceRoot: globalWorkspace,
+    agentIds: projectMarkers.map(([agentId]) => agentId),
+    scope: "global",
+    env: sourceEnv,
+    platform: "darwin",
+  },
+  async () => ({
+    code: 0,
+    stdout: JSON.stringify({
+      success: true,
+      exit_code: 0,
+      errors: [],
+      installed: projectMarkers.map(([agentId], index) => ({
+        skill: "tieline-author",
+        agent: SUPPORTED_SKILL_AGENTS[index].selector,
+        path: `/global/${agentId}/tieline-author`,
+        location: "global",
+      })),
+      skipped: [],
+    }),
+    stderr: "",
+    timedOut: false,
+  })
+);
+assert.equal(globalInstall.status, "installed");
+for (const [, marker] of projectMarkers) {
+  assert.equal(
+    existsSync(resolve(globalWorkspace, marker)),
+    false,
+    `global install must not create ${marker}`
+  );
+}
+
+const blockedMarkerWorkspace = resolve(installWorkspaceRoot, "blocked-marker");
+writeFileSync(blockedMarkerWorkspace, "occupied");
+let blockedMarkerRunnerCalled = false;
+const blockedMarker = await installTielineAuthor(
+  {
+    workspaceRoot: blockedMarkerWorkspace,
+    agentIds: ["codex"],
+    scope: "project",
+    env: sourceEnv,
+    platform: "darwin",
+  },
+  async () => {
+    blockedMarkerRunnerCalled = true;
+    throw new Error("runner must not start");
+  }
+);
+assert.equal(blockedMarker.status, "failed");
+assert.equal(blockedMarkerRunnerCalled, false);
+assert.match(
+  blockedMarker.reason ?? "",
+  /Could not prepare the Codex project marker '\.codex'/
+);
+assert.doesNotMatch(blockedMarker.reason ?? "", /Node\.js|npx/i);
+
 assert.deepEqual(skippedSkillInstall(), {
   status: "skipped",
   requestedAgents: [],
@@ -296,5 +440,7 @@ assert.deepEqual(skippedSkillInstall(), {
   reason: "Skill installation was not requested.",
   retryCommand: null,
 });
+
+rmSync(installWorkspaceRoot, { recursive: true, force: true });
 
 console.log("skill install adapter tests passed");

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -1522,6 +1522,19 @@ capability:
 
   // README wording is under test: editing the install instructions there breaks test:tieline unless these assertions move with it.
   const readme = readFileSync(resolve(process.cwd(), "README.md"), "utf8");
+  const quickSetupIndex = readme.indexOf("## Quick setup");
+  const detailedSetupIndex = readme.indexOf("## Detailed setup and configuration");
+  const firstSectionIndex = readme.search(/^## /m);
+  assert.ok(quickSetupIndex > 0, "README must include Quick setup near the top");
+  assert.equal(
+    quickSetupIndex,
+    firstSectionIndex,
+    "README Quick setup must be the first section after the value proposition"
+  );
+  assert.ok(
+    detailedSetupIndex > quickSetupIndex,
+    "README Quick setup must precede detailed setup"
+  );
   assert.match(
     readme,
     /npx --yes --package=skillfish@latest skillfish add knoxgraeme\/tieline/

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -131,7 +131,7 @@ function successfulSkillfish(
       exit_code: 0,
       errors: [],
       installed: selectors.map((agent) => ({
-        skill: "tieline-author",
+        skill: "tieline",
         agent,
         path: `/test/${agent}`,
       })),
@@ -426,18 +426,16 @@ try {
   );
   assert.match(
     interactiveOutput,
-    /Skill: tieline-author installed for Codex and Claude Code/
+    /Skill: tieline installed for Codex and Claude Code/
   );
   assert.doesNotMatch(
     interactiveOutput,
     /Context:|Runtime:|Code scope:|Skill source:|Skill targets:|Skill scope:/,
     "init output must report outcomes rather than semantic defaults or integration internals"
   );
-  // The onboarding prompt has to stand alone on its own line so it is
-  // obviously the thing to copy; keep it out of the surrounding prose.
   assert.match(
     interactiveOutput,
-    /Next steps\n {2}1\. Restart or reload your agent\.\n {2}2\. Copy the prompt below and paste it to your agent\.\n\n─+\nUse the tieline-author skill to onboard this repository to Tieline\.\n─+/
+    /Next steps\n {2}1\. Restart or reload your agent\.\n {2}2\. Invoke the installed tieline skill to onboard this repository \(\/tieline in Claude Code; \$tieline in Codex\)\./
   );
 
   const cancelledTarget = resolve(root, "Cancelled Checkout");
@@ -514,7 +512,7 @@ try {
   assert.equal(automatedCalls, 1);
   assert.match(
     automated.output.join(""),
-    /Skill: tieline-author installed for Codex/
+    /Skill: tieline installed for Codex/
   );
   const automatedWorkspace = findTielineWorkspace(automatedTarget);
   assert.ok(automatedWorkspace);
@@ -543,7 +541,7 @@ try {
             installed: [],
             skipped: [
               {
-                skill: "tieline-author",
+                skill: "tieline",
                 agent: "Codex",
                 reason: "Already exists",
               },
@@ -558,7 +556,7 @@ try {
   );
   assert.match(
     alreadyPresent.output.join(""),
-    /Skill: tieline-author already present for Codex/
+    /Skill: tieline already present for Codex/
   );
   assert.equal(
     readFileSync(automatedWorkspace.configPath, "utf8"),
@@ -715,7 +713,7 @@ try {
   const mcpMergeOutput = mcpMerge.output.join("");
   assert.match(
     mcpMergeOutput,
-    /Skill: tieline-author installed for Cursor, Codex, and OpenCode/,
+    /Skill: tieline installed for Cursor, Codex, and OpenCode/,
     "--agent without --skill-scope must default to the project scope"
   );
   assert.match(mcpMergeOutput, /MCP: configured/);
@@ -843,7 +841,7 @@ try {
   assert.match(reviewPage, /No capabilities yet/);
   assert.match(
     reviewPage,
-    /Use the tieline-author skill to onboard this repository to Tieline\./
+    /Invoke the installed tieline skill to onboard this repository \(\/tieline in Claude Code; \$tieline in Codex\)\./
   );
   assert.equal(
     readFileSync(resolve(target, ".tieline/.gitignore"), "utf8"),
@@ -860,12 +858,12 @@ try {
   assert.doesNotMatch(
     firstOutput,
     /Mode:|Runtime:|Context:|Code scope:|Optional capabilities|Review: open|Skill source:|Skill targets:|Skill scope:/,
-    "the summary leads to the paste prompt without setup internals"
+    "the summary leads to the skill invocation without setup internals"
   );
   assert.match(firstOutput, /skill: not installed/i);
   assert.match(
     firstOutput,
-    /Install the tieline-author skill by running:\n\n─+\ntieline init \.\n─+/
+    /Install the tieline skill by running:\n\n─+\ntieline init \.\n─+/
   );
   assert.doesNotMatch(firstOutput, /Warning \[/);
   assert.doesNotMatch(firstOutput, /Agent handoff prompt:/);
@@ -1010,13 +1008,13 @@ try {
   assert.equal(parsedStatus.contract.acceptance_criteria, 0);
   assert.equal(
     parsedStatus.next_action,
-    'Paste this prompt to your agent to finish onboarding: "Use the tieline-author skill to onboard this repository to Tieline."'
+    "Invoke the installed tieline skill to onboard this repository (/tieline in Claude Code; $tieline in Codex)."
   );
   assert.deepEqual(parsedStatus.onboarding, {
     required: true,
-    skill: "tieline-author",
+    skill: "tieline",
     instruction:
-      "Use the tieline-author skill to onboard this repository to Tieline.",
+      "Invoke the installed tieline skill to onboard this repository (/tieline in Claude Code; $tieline in Codex).",
     install_command: "tieline init .",
   });
   assert.equal("agent_onboarding_prompt" in parsedStatus, false);
@@ -1030,12 +1028,9 @@ try {
   );
   assert.match(
     humanStatus.output.join(""),
-    /Next: Copy the prompt below and paste it to your agent to finish onboarding\./
+    /Next: Invoke the installed tieline skill to onboard this repository \(\/tieline in Claude Code; \$tieline in Codex\)\./
   );
-  assert.match(
-    humanStatus.output.join(""),
-    /─+\nUse the tieline-author skill to onboard this repository to Tieline\.\n─+/
-  );
+  assert.doesNotMatch(humanStatus.output.join(""), /Copy the prompt/);
   assert.match(humanStatus.output.join(""), /Install skill: tieline init \./);
   assert.doesNotMatch(humanStatus.output.join(""), /Agent handoff prompt:/);
 
@@ -1365,25 +1360,25 @@ capability:
   assert.ok(!serveProfile.loaded.includes("DATABASE_URL_SYNC"));
   assert.ok(!serveProfile.loaded.includes("DATABASE_URL_ADMIN"));
 
-  const authorSkill = readFileSync(
-    resolve(process.cwd(), "skills/tieline-author/SKILL.md"),
+  const tielineSkill = readFileSync(
+    resolve(process.cwd(), "skills/tieline/SKILL.md"),
     "utf8"
   );
   const onboardingReference = readFileSync(
     resolve(
       process.cwd(),
-      "skills/tieline-author/references/onboarding.md"
+      "skills/tieline/references/onboarding.md"
     ),
     "utf8"
   );
-  assert.match(authorSkill, /\.tieline\/config\.json/);
-  assert.match(authorSkill, /allow_external_fetch/);
-  assert.match(authorSkill, /local YAML.*manifest/i);
-  assert.match(authorSkill, /semantic matching.*unavailable/i);
-  assert.match(authorSkill, /after `tieline init`/i);
-  assert.match(authorSkill, /installed skill or MCP prompt/i);
-  assert.match(authorSkill, /semantic onboarding/i);
-  assert.match(authorSkill, /references\/onboarding\.md/);
+  assert.match(tielineSkill, /\.tieline\/config\.json/);
+  assert.match(tielineSkill, /allow_external_fetch/);
+  assert.match(tielineSkill, /local YAML.*manifest/i);
+  assert.match(tielineSkill, /semantic matching.*unavailable/i);
+  assert.match(tielineSkill, /after `tieline init`/i);
+  assert.match(tielineSkill, /installed skill or MCP prompt/i);
+  assert.match(tielineSkill, /semantic onboarding/i);
+  assert.match(tielineSkill, /references\/onboarding\.md/);
   assert.match(
     onboardingReference,
     /Discover these repository sources directly/
@@ -1405,7 +1400,7 @@ capability:
     "setup must end with a handoff into the autonomous phase"
   );
   assert.match(
-    authorSkill,
+    tielineSkill,
     /starts with a\s+conversation, not with repository reading/,
     "the skill dispatch must order conversation before orientation steps"
   );
@@ -1468,14 +1463,14 @@ capability:
     "onboarding must deliver the review page, not an inline listing"
   );
   assert.match(
-    authorSkill,
+    tielineSkill,
     /pointing at `\.tieline\/review\.html`/,
     "the skill must present contract content through the review page"
   );
   const reportReference = readFileSync(
     resolve(
       process.cwd(),
-      "skills/tieline-author/references/report.md"
+      "skills/tieline/references/report.md"
     ),
     "utf8"
   );
@@ -1487,12 +1482,12 @@ capability:
     "compile keeps the page current; the report must not claim otherwise"
   );
   assert.match(reportReference, /pull-request body/);
-  assert.match(authorSkill, /references\/report\.md/);
+  assert.match(tielineSkill, /references\/report\.md/);
   assert.match(onboardingReference, /references\/report\.md/);
   const provisioningReference = readFileSync(
     resolve(
       process.cwd(),
-      "skills/tieline-author/references/provisioning.md"
+      "skills/tieline/references/provisioning.md"
     ),
     "utf8"
   );
@@ -1514,7 +1509,16 @@ capability:
     "provisioning must warn about credential rotation on re-run"
   );
   assert.match(onboardingReference, /provisioning\.md/);
-  assert.doesNotMatch(authorSkill, /agent handoff printed/i);
+  const gradingReference = readFileSync(
+    resolve(process.cwd(), "skills/tieline/references/grading.md"),
+    "utf8"
+  );
+  assert.match(tielineSkill, /references\/grading\.md/);
+  assert.match(tielineSkill, /For grading an existing contract change/);
+  assert.match(tielineSkill, /grading-only flow returns after its report/);
+  assert.match(gradingReference, /Dispatch fresh subagents/);
+  assert.match(gradingReference, /tieline contract grade/);
+  assert.doesNotMatch(tielineSkill, /agent handoff printed/i);
 
   // README wording is under test: editing the install instructions there breaks test:tieline unless these assertions move with it.
   const readme = readFileSync(resolve(process.cwd(), "README.md"), "utf8");

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -328,7 +328,7 @@ try {
   writeFileSync(resolve(interactiveTarget, "README.md"), "# Interactive\n");
   const interactive = interactiveIo({
     text: [],
-    confirm: [true],
+    confirm: [],
     select: [],
     multiselect: [["codex", "claude-code"]],
   });
@@ -357,6 +357,14 @@ try {
               TIELINE_CONFIG_HOME: interactiveConfigHome,
             }),
             "runtime profile must exist before Skillfish runs"
+          );
+          assert.ok(
+            existsSync(resolve(interactiveTarget, ".claude")),
+            "selected project agents must be detectable before Skillfish runs"
+          );
+          assert.ok(
+            existsSync(resolve(interactiveTarget, ".codex")),
+            "every selected project agent must be prepared before Skillfish runs"
           );
           return successfulSkillfish(invocation);
         },
@@ -393,6 +401,11 @@ try {
     "the agent selector must be the only interactive question"
   );
   assert.equal(
+    interactive.prompts.length,
+    1,
+    "selecting agents is consent; init must not repeat the setup as a confirmation"
+  );
+  assert.equal(
     interactive.prompts.some((prompt) =>
       [
         "Company/product name",
@@ -407,19 +420,14 @@ try {
     false,
     "identity and runtime must be detected, not asked"
   );
-  const interactiveReview =
-    interactive.prompts.find((prompt) => prompt.startsWith("Review:")) ?? "";
-  assert.match(
-    interactiveReview,
-    /Context: product description, README\.md, https:\/\/mcpmarket\.com\/hub.*Code scope: src/s
-  );
-  assert.match(
-    interactiveReview,
-    /create \.tieline for Interactive Checkout \(interactive-checkout\) \(auto-detected\)/
-  );
   assert.match(
     interactive.output.join(""),
-    /Skill: tieline-author installed for Codex and Claude Code \(project\)/
+    /Skill: tieline-author installed for Codex and Claude Code/
+  );
+  assert.doesNotMatch(
+    interactive.output.join(""),
+    /Context:|Runtime:|Code scope:|Skill source:|Skill targets:|Skill scope:/,
+    "init output must report outcomes rather than semantic defaults or integration internals"
   );
   // The onboarding prompt has to stand alone on its own line so it is
   // obviously the thing to copy; keep it out of the surrounding prose.
@@ -448,7 +456,7 @@ try {
   mkdirSync(resolve(noAgentTarget, "src"), { recursive: true });
   const noAgent = interactiveIo({
     text: [],
-    confirm: [true],
+    confirm: [],
     select: [],
     multiselect: [[]],
   });
@@ -502,7 +510,7 @@ try {
   assert.equal(automatedCalls, 1);
   assert.match(
     automated.output.join(""),
-    /Skill: tieline-author installed for Codex \(global\)/
+    /Skill: tieline-author installed for Codex/
   );
   const automatedWorkspace = findTielineWorkspace(automatedTarget);
   assert.ok(automatedWorkspace);
@@ -546,7 +554,7 @@ try {
   );
   assert.match(
     alreadyPresent.output.join(""),
-    /Skill: tieline-author already present for Codex \(global\)/
+    /Skill: tieline-author already present for Codex/
   );
   assert.equal(
     readFileSync(automatedWorkspace.configPath, "utf8"),
@@ -703,17 +711,10 @@ try {
   const mcpMergeOutput = mcpMerge.output.join("");
   assert.match(
     mcpMergeOutput,
-    /Skill: tieline-author installed for Cursor, Codex, and OpenCode \(project\)/,
+    /Skill: tieline-author installed for Cursor, Codex, and OpenCode/,
     "--agent without --skill-scope must default to the project scope"
   );
-  assert.match(
-    mcpMergeOutput,
-    /MCP server: \.mcp\.json updated; \.cursor\/mcp\.json written; opencode\.json written/
-  );
-  assert.match(
-    mcpMergeOutput,
-    /MCP server: Codex registered globally via 'codex mcp add'/
-  );
+  assert.match(mcpMergeOutput, /MCP: configured/);
   const mergedRootBody = readFileSync(
     resolve(mcpMergeTarget, ".mcp.json"),
     "utf8"
@@ -730,7 +731,7 @@ try {
     mergedRootBody,
     "re-running init must not rewrite an up-to-date MCP config"
   );
-  assert.match(mcpRepeat.output.join(""), /\.mcp\.json unchanged/);
+  assert.match(mcpRepeat.output.join(""), /MCP: configured/);
 
   const mcpInvalidTarget = resolve(root, "Mcp Invalid Checkout");
   mkdirSync(resolve(mcpInvalidTarget, "src"), { recursive: true });
@@ -845,19 +846,17 @@ try {
     "review.html\n"
   );
   const firstOutput = first.output.join("");
-  assert.match(firstOutput, /MCP server: \.mcp\.json written/);
+  assert.match(firstOutput, /MCP: configured/);
   assert.match(firstOutput, /Workspace: ready at \.tieline\//);
   assert.doesNotMatch(
     firstOutput,
     new RegExp(target.replaceAll("\\", "\\\\")),
     "the summary must not print absolute paths"
   );
-  assert.match(firstOutput, /Mode: offline.*local contract authoring ready/i);
-  assert.match(firstOutput, /code scope: src/i);
   assert.doesNotMatch(
     firstOutput,
-    /Optional capabilities|Review: open/,
-    "the summary leads to the paste prompt without optional-feature or review noise"
+    /Mode:|Runtime:|Context:|Code scope:|Optional capabilities|Review: open|Skill source:|Skill targets:|Skill scope:/,
+    "the summary leads to the paste prompt without setup internals"
   );
   assert.match(firstOutput, /skill: not installed/i);
   assert.match(
@@ -905,7 +904,7 @@ try {
 
   const existingInteractive = interactiveIo({
     text: [],
-    confirm: [true],
+    confirm: [],
     select: [],
     multiselect: [["codex"]],
   });
@@ -979,10 +978,7 @@ try {
     }),
     0
   );
-  assert.match(
-    resumed.output.join(""),
-    /Mode: offline.*local contract authoring ready/i
-  );
+  assert.doesNotMatch(resumed.output.join(""), /Mode:|Runtime:|Code scope:/);
   assert.ok(
     readWorkspaceProfile(workspace, {
       TIELINE_CONFIG_HOME: freshConfigHome,

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -11,6 +11,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
+import { stripVTControlCharacters } from "node:util";
 import {
   runCli,
   workspaceStartForCommand,
@@ -420,19 +421,22 @@ try {
     false,
     "identity and runtime must be detected, not asked"
   );
+  const interactiveOutput = stripVTControlCharacters(
+    interactive.output.join("")
+  );
   assert.match(
-    interactive.output.join(""),
+    interactiveOutput,
     /Skill: tieline-author installed for Codex and Claude Code/
   );
   assert.doesNotMatch(
-    interactive.output.join(""),
+    interactiveOutput,
     /Context:|Runtime:|Code scope:|Skill source:|Skill targets:|Skill scope:/,
     "init output must report outcomes rather than semantic defaults or integration internals"
   );
   // The onboarding prompt has to stand alone on its own line so it is
   // obviously the thing to copy; keep it out of the surrounding prose.
   assert.match(
-    interactive.output.join(""),
+    interactiveOutput,
     /Next steps\n {2}1\. Restart or reload your agent\.\n {2}2\. Copy the prompt below and paste it to your agent\.\n\n─+\nUse the tieline-author skill to onboard this repository to Tieline\.\n─+/
   );
 

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -435,7 +435,7 @@ try {
   );
   assert.match(
     interactiveOutput,
-    /Next steps\n {2}1\. Restart or reload your agent\.\n {2}2\. Invoke the installed tieline skill to onboard this repository \(\/tieline in Claude Code; \$tieline in Codex\)\./
+    /Next steps\n {2}1\. Restart or reload your agent\.\n {2}2\. Ask your agent to use the installed tieline skill to onboard this repository\. In Claude Code, run \/tieline; in Codex, run \$tieline\./
   );
 
   const cancelledTarget = resolve(root, "Cancelled Checkout");
@@ -841,7 +841,7 @@ try {
   assert.match(reviewPage, /No capabilities yet/);
   assert.match(
     reviewPage,
-    /Invoke the installed tieline skill to onboard this repository \(\/tieline in Claude Code; \$tieline in Codex\)\./
+    /Ask your agent to use the installed tieline skill to onboard this repository\. In Claude Code, run \/tieline; in Codex, run \$tieline\./
   );
   assert.equal(
     readFileSync(resolve(target, ".tieline/.gitignore"), "utf8"),
@@ -1008,13 +1008,13 @@ try {
   assert.equal(parsedStatus.contract.acceptance_criteria, 0);
   assert.equal(
     parsedStatus.next_action,
-    "Invoke the installed tieline skill to onboard this repository (/tieline in Claude Code; $tieline in Codex)."
+    "Ask your agent to use the installed tieline skill to onboard this repository. In Claude Code, run /tieline; in Codex, run $tieline."
   );
   assert.deepEqual(parsedStatus.onboarding, {
     required: true,
     skill: "tieline",
     instruction:
-      "Invoke the installed tieline skill to onboard this repository (/tieline in Claude Code; $tieline in Codex).",
+      "Ask your agent to use the installed tieline skill to onboard this repository. In Claude Code, run /tieline; in Codex, run $tieline.",
     install_command: "tieline init .",
   });
   assert.equal("agent_onboarding_prompt" in parsedStatus, false);
@@ -1028,7 +1028,7 @@ try {
   );
   assert.match(
     humanStatus.output.join(""),
-    /Next: Invoke the installed tieline skill to onboard this repository \(\/tieline in Claude Code; \$tieline in Codex\)\./
+    /Next: Ask your agent to use the installed tieline skill to onboard this repository\. In Claude Code, run \/tieline; in Codex, run \$tieline\./
   );
   assert.doesNotMatch(humanStatus.output.join(""), /Copy the prompt/);
   assert.match(humanStatus.output.join(""), /Install skill: tieline init \./);

--- a/skills/tieline-author/agents/openai.yaml
+++ b/skills/tieline-author/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Tieline Author"
-  short_description: "Onboard, author, and reconcile Tieline contracts"
-  default_prompt: "Use $tieline-author to semantically onboard this repository from its configured context, or reconcile existing contract behavior."

--- a/skills/tieline-grade/agents/openai.yaml
+++ b/skills/tieline-grade/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Tieline Grade"
-  short_description: "Grade changed Tieline contract evidence"
-  default_prompt: "Use $tieline-grade to judge the contract evidence touched by this branch."

--- a/skills/tieline/SKILL.md
+++ b/skills/tieline/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: tieline-author
-description: Semantically onboard an initialized Tieline repository, or author, plan, implement, and reconcile Tieline User Stories and Acceptance Criteria. Use after `tieline init` to inspect configured context and create the first repository-specific capabilities, Stories, and ACs; also use to refine planning Stories/ACs or Backlog Items in Postgres, materialize planning records into repository YAML, connect branch work to product behavior, resolve likely duplicate definitions, or prepare a semantic contract change for pull-request review.
+name: tieline
+description: Semantically onboard an initialized Tieline repository, or author, plan, implement, grade, and reconcile Tieline User Stories and Acceptance Criteria. Use after `tieline init` to inspect configured context and create the first repository-specific capabilities, Stories, and ACs; also use to refine planning Stories/ACs or Backlog Items in Postgres, materialize planning records into repository YAML, connect branch work to product behavior, grade changed contract evidence, resolve likely duplicate definitions, or prepare a semantic contract change for pull-request review.
 ---
 
-# Tieline author
+# Tieline
 
 Treat the pull request as the proposal and merge as approval. Never create a
 separate draft, proposal, or semantic-approval record.
@@ -54,11 +54,17 @@ anything the repository can answer.
   and `list_handoff_conflicts`; then update YAML and its manifest. Present both
   the merged repository definition and later planning snapshot before choosing
   what to preserve.
+- For grading an existing contract change, read
+  [grading.md](references/grading.md), run that workflow without editing
+  contract YAML, report its results, and stop. Do not enter the authoring,
+  materialization, or reconciliation steps below.
 - For work coordination without a defined behavior, create or update a Backlog
   Item. It remains a DB record and never moves into YAML.
 
 An Observation is evidence, not a required starting point. A flow may begin
 from an Observation, Backlog Item, planning Story, existing AC, or branch diff.
+The remaining sections apply only to onboarding, planning, implementation, and
+reconciliation; the grading-only flow returns after its report.
 
 ## Search before creating
 
@@ -121,11 +127,12 @@ from an Observation, Backlog Item, planning Story, existing AC, or branch diff.
    tieline check --base <base-ref>
    ```
 
-9. Grade the contract change with the tieline-grade skill. The grading scope
-   covers both sides of every link — artifacts the branch moved, and links or
-   criteria the branch added or re-worded against unchanged code. You authored
-   these links, so dispatch fresh subagents batched by artifact path and give
-   them only the emitted scope entries, never your authoring rationale.
+9. Read [grading.md](references/grading.md) and grade the contract change. The
+   grading scope covers both sides of every link — artifacts the branch moved,
+   and links or criteria the branch added or re-worded against unchanged code.
+   You authored these links, so dispatch fresh subagents batched by artifact
+   path and give them only the emitted scope entries, never your authoring
+   rationale.
 10. Summarize the semantic diff, impacted ACs, grade findings, freshness
     warnings, coverage delta, likely duplicates, unresolved conflicts, and
     unmapped source files.

--- a/skills/tieline/agents/openai.yaml
+++ b/skills/tieline/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Tieline"
+  short_description: "Onboard, author, grade, and reconcile Tieline contracts"
+  default_prompt: "Use $tieline to semantically onboard this repository from its configured context, or reconcile existing contract behavior."

--- a/skills/tieline/references/contract.md
+++ b/skills/tieline/references/contract.md
@@ -1,4 +1,4 @@
-# Tieline authoring contract
+# Authoring contract
 
 ## Authority
 

--- a/skills/tieline/references/grading.md
+++ b/skills/tieline/references/grading.md
@@ -1,9 +1,4 @@
----
-name: tieline-grade
-description: Judge whether the Tieline acceptance-criterion links touched by a branch — artifacts that moved, links that were added, criteria that were re-worded, or an entire initial contract — are supported by their artifacts, then verify every judgment against a deterministic citation fence. Use when asked to grade, judge, audit, or check the evidence quality of changed Tieline contract links, to grade a freshly onboarded contract, or to confirm that linked code and tests still support their criteria before a pull request merges.
----
-
-# Tieline grade
+# Grade changed evidence
 
 Tieline supplies a complete diff-scoped work list and a closed set of legal
 citations. Supply the semantic judgment the deterministic tooling cannot make.

--- a/skills/tieline/references/onboarding.md
+++ b/skills/tieline/references/onboarding.md
@@ -95,7 +95,7 @@ a human first sees them. Verify, do not re-ask.
 6. Author the initial capabilities, Stories, and ACs under `.tieline/spec/`.
    Never create generic starter content merely to make the directory non-empty.
 7. Validate and compile the contract.
-8. Grade the initial contract with the tieline-grade skill. With no manifest
+8. Read [grading.md](grading.md) and grade the initial contract. With no manifest
    at the comparison base, every authored link enters the grading scope as
    `link_added`. You authored every one of them, so dispatch fresh subagents
    batched by artifact path, passing only the emitted scope entries and never

--- a/skills/tieline/references/provisioning.md
+++ b/skills/tieline/references/provisioning.md
@@ -1,4 +1,4 @@
-# Provision a hosted database
+# Provision hosted database
 
 The Tieline database is organization infrastructure shared across
 repositories, not part of any one application. Keep every provider artifact

--- a/skills/tieline/references/report.md
+++ b/skills/tieline/references/report.md
@@ -1,4 +1,4 @@
-# Completion report
+# Report completion
 
 Every flow closes with a short report in chat. The report is a pointer to
 artifacts, not a transcript of the work: the review page carries the

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -91,10 +91,8 @@ export function renderStatus(status: TielineStatus, ui: Palette): string {
   ];
   if (status.onboarding) {
     lines.push(
-      `${ui.cyan("Next:")} Copy the prompt below and paste it to your agent to finish onboarding.`,
-      `${ui.cyan("Install skill:")} ${status.onboarding.install_command}`,
-      "",
-      ...renderCopyCallout(ui, status.onboarding.instruction)
+      `${ui.cyan("Next:")} ${status.onboarding.instruction}`,
+      `${ui.cyan("Install skill:")} ${status.onboarding.install_command}`
     );
   } else {
     lines.push(`${ui.cyan("Next:")} ${status.next_action}`);
@@ -221,7 +219,7 @@ function buildProgram(
     .addHelpText("before", () => `${renderBanner(paletteFor(io))}\n\n`)
     .addHelpText(
       "after",
-      "\nRun `tieline init` for deterministic setup and agent-skill installation. Use $tieline-author for onboarding, planning Story/AC writes, implementation, and branch reconciliation."
+      "\nRun `tieline init` for deterministic setup and agent-skill installation. Use $tieline for onboarding, planning Story/AC writes, implementation, and branch reconciliation."
     );
 
   program
@@ -261,7 +259,7 @@ function buildProgram(
     )
     .option(
       "--agent <id>",
-      `install tieline-author for a supported agent (repeatable: ${SUPPORTED_SKILL_AGENTS.map((agent) => agent.id).join(", ")})`,
+      `install tieline for a supported agent (repeatable: ${SUPPORTED_SKILL_AGENTS.map((agent) => agent.id).join(", ")})`,
       collect,
       []
     )
@@ -273,7 +271,7 @@ function buildProgram(
     )
     .option(
       "--skip-skill-install",
-      "initialize without installing tieline-author"
+      "initialize without installing tieline"
     )
     .option("--yes", "accept detected defaults without prompting")
     .option("--skip-migrate", "skip applying database migrations")

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,14 +6,12 @@ import {
   type TielineCliIO,
 } from "../cli.js";
 import {
-  confirmChoice,
   intro,
   multiselectChoice,
   outro,
   paletteFor,
   renderBanner,
   renderCopyCallout,
-  showNote,
 } from "../cli-ui.js";
 import type { Palette } from "../cli-ui.js";
 import {
@@ -27,7 +25,6 @@ import {
 import {
   resolveEmbeddingProvider,
   runDatabasePreflight,
-  runInitPreflight,
   type PreflightCheck,
 } from "../tieline/preflight.js";
 import {
@@ -39,7 +36,6 @@ import {
   type DatabaseMode,
 } from "../tieline/setup.js";
 import {
-  plannedMcpTargets,
   registerCodexMcpServer,
   writeMcpClientConfigs,
   type CodexMcpOutcome,
@@ -93,12 +89,6 @@ interface SkillInstallSelection {
   scope: SkillInstallScope;
 }
 
-const EMBEDDING_PROVIDER_OPTIONS = [
-  { value: "local", label: "Local gte-small" },
-  { value: "openai", label: "OpenAI" },
-  { value: "supabase-edge", label: "Supabase Edge Function" },
-] as const;
-
 const SKILL_AGENT_OPTIONS = SUPPORTED_SKILL_AGENTS.map((agent) => ({
   value: agent.id,
   label: agent.selector,
@@ -127,26 +117,6 @@ function agentLabel(agentId: SkillAgentId): string {
   );
 }
 
-function databaseModeLabel(database: DatabaseMode): string {
-  if (database === "existing") return "hosted / remote PostgreSQL";
-  if (database === "local") return "local PostgreSQL";
-  return "offline";
-}
-
-function embeddingProviderLabel(provider: EmbeddingProvider): string {
-  if (provider === "local") return "local gte-small";
-  return (
-    EMBEDDING_PROVIDER_OPTIONS.find((option) => option.value === provider)
-      ?.label ?? "hash (development only)"
-  );
-}
-
-function codeScopeLabel(sourceRoots: readonly string[]): string {
-  return sourceRoots.length === 1 && sourceRoots[0] === "."
-    ? "entire repository"
-    : sourceRoots.join(", ");
-}
-
 function joinLabels(values: readonly string[]): string {
   if (values.length < 2) return values[0] ?? "";
   if (values.length === 2) return `${values[0]} and ${values[1]}`;
@@ -158,16 +128,11 @@ function renderMcpSummary(
   codex: CodexMcpOutcome | null,
   ui: Palette
 ): string[] {
-  const merged = mcp.writes.filter((write) => write.status !== "failed");
+  const configured = mcp.writes.some((write) => write.status !== "failed");
   const failed = mcp.writes.filter((write) => write.status === "failed");
   const lines: string[] = [];
-  if (merged.length > 0) {
-    lines.push(
-      `MCP server: ${merged
-        .map((write) => `${write.path} ${write.status}`)
-        .join("; ")}`,
-      "MCP tools load when your client starts its next session; the tieline CLI works immediately."
-    );
+  if (configured || codex?.status === "registered") {
+    lines.push("MCP: configured");
   }
   for (const write of failed) {
     lines.push(
@@ -176,11 +141,7 @@ function renderMcpSummary(
       )
     );
   }
-  if (codex?.status === "registered") {
-    lines.push(
-      "MCP server: Codex registered globally via 'codex mcp add'"
-    );
-  } else if (codex) {
+  if (codex && codex.status !== "registered") {
     lines.push(
       ui.yellow(
         `MCP server: Codex registration failed (${codex.reason}); run: ${codex.retryCommand}`
@@ -214,36 +175,17 @@ async function registerMcpClients(
 }
 
 function renderInitSummary(
-  workspace: TielineWorkspace,
   preflight: PreflightCheck[],
   skill: SkillInstallOutcome,
-  skillScope: SkillInstallScope | undefined,
   mcp: McpConfigOutcome,
   codex: CodexMcpOutcome | null,
-  io: TielineCliIO,
-  env: NodeJS.ProcessEnv
+  io: TielineCliIO
 ): void {
   const ui = paletteFor(io);
-  const status = getTielineStatus(workspace, env);
-  const modeDescription =
-    status.runtime.database_mode === "offline"
-      ? "offline — local contract authoring ready"
-      : `${databaseModeLabel(status.runtime.database_mode)} — ${status.runtime.setup_complete ? "setup complete" : "setup incomplete"}`;
-  const notes: string[] = [];
-  if (
-    preflight.some(
-      (check) => check.key === "repository" && check.status === "warning"
-    )
-  ) {
-    notes.push("Git metadata was not detected");
-  }
   const lines = [
     `${ui.green("Workspace:")} ready at ${TIELINE_DIRECTORY}/`,
-    `${ui.green("Mode:")} ${modeDescription}`,
-    `Code scope: ${codeScopeLabel(workspace.config.repository.source_roots)}`,
     ...renderMcpSummary(mcp, codex, ui),
   ];
-  if (notes.length > 0) lines.push(`Readiness notes: ${joinLabels(notes)}`);
   for (const check of preflight) {
     if (
       check.status === "warning" &&
@@ -265,7 +207,7 @@ function renderInitSummary(
         : []),
     ].join("; ");
     lines.push(
-      `Skill: tieline-author ${skillState} (${skillScope})`,
+      `Skill: tieline-author ${skillState}`,
       "",
       ui.bold("Next steps"),
       "  1. Restart or reload your agent.",
@@ -347,18 +289,6 @@ export async function runInit(
       parsed.databaseExplicit ||
       parsed.embeddingExplicit ||
       parsed.installLocalEmbedder;
-    if (io.interactive && !parsed.yes && (shouldConfigure || skillSelection)) {
-      const review = [
-        `Workspace: reuse ${existing.directory}`,
-        shouldConfigure
-          ? `Runtime: configure ${databaseModeLabel(databaseMode)} with ${embeddingProviderLabel(embeddingProvider)} embeddings`
-          : "Runtime: keep completed setup",
-        ...renderRuntimeRequirements(databaseMode, env),
-        ...renderSkillReview(skillSelection),
-        ...renderMcpReview(skillSelection),
-      ].join("\n");
-      await confirmInitReview(io, review);
-    }
     if (shouldConfigure) {
       env.EMBEDDING_PROVIDER = embeddingProvider;
       await configureWorkspaceRuntime({
@@ -410,17 +340,11 @@ export async function runInit(
     const preflightEnv =
       databaseMode === "offline" ? withoutDatabaseEnvironment(env) : env;
     renderInitSummary(
-      existing,
-      [
-        ...runInitPreflight(existing.root, embeddingProvider, preflightEnv),
-        ...(await runDatabasePreflight(preflightEnv)),
-      ],
+      await runDatabasePreflight(preflightEnv),
       skill,
-      skillSelection?.scope,
       mcp,
       codex,
-      io,
-      env
+      io
     );
     return skill.status === "failed" ? 1 : 0;
   }
@@ -449,24 +373,6 @@ export async function runInit(
     env
   );
 
-  if (richInteractive) {
-    const contextReview = [
-      ...(description?.trim() ? ["product description"] : []),
-      ...context,
-    ];
-    await confirmInitReview(
-      io,
-      [
-        `Workspace: create .tieline for ${product} (${repoName})${parsed.product ? "" : " (auto-detected)"}`,
-        `Context: ${contextReview.length > 0 ? contextReview.join(", ") : "discover during semantic onboarding"}`,
-        `Code scope: ${codeScopeLabel(sourceRoots)}${parsed.sourceRoots.length === 0 ? " (auto-detected)" : ""}`,
-        `Runtime: ${databaseModeLabel(database)} with ${embeddingProviderLabel(embedding)} embeddings`,
-        ...renderRuntimeRequirements(database, env),
-        ...renderSkillReview(skillSelection),
-        ...renderMcpReview(skillSelection),
-      ].join("\n")
-    );
-  }
   env.EMBEDDING_PROVIDER = embedding;
   const initEnv =
     database === "offline"
@@ -514,17 +420,11 @@ export async function runInit(
   // last thing on screen rather than trailing into the flow's end cap.
   if (richInteractive) await outro(io, "Tieline workspace ready");
   renderInitSummary(
-    result.workspace,
-    [
-      ...runInitPreflight(result.workspace.root, embedding, initEnv),
-      ...(await runDatabasePreflight(initEnv)),
-    ],
+    await runDatabasePreflight(initEnv),
     skill,
-    skillSelection?.scope,
     mcp,
     codex,
-    io,
-    env
+    io
   );
   return skill.status === "failed" ? 1 : 0;
 }
@@ -553,63 +453,6 @@ async function resolveSkillSelection(
     if (agents.length === 0) return null;
   }
   return { agents, scope: parsed.skillScope ?? "project" };
-}
-
-function renderSkillReview(
-  selection: SkillInstallSelection | null
-): string[] {
-  if (!selection) return ["Skill: do not install now"];
-  return [
-    "Skill: tieline-author (onboarding and authoring)",
-    "Skill source: github.com/knoxgraeme/tieline (default branch)",
-    `Skill targets: ${joinLabels(selection.agents.map(agentLabel))}`,
-    `Skill scope: ${selection.scope}`,
-  ];
-}
-
-function renderMcpReview(
-  selection: SkillInstallSelection | null
-): string[] {
-  const planned = plannedMcpTargets(selection?.agents ?? []);
-  const lines = [
-    `MCP: register the 'tieline' server (npx -y tieline serve) in ${planned.paths.join(", ")}`,
-  ];
-  if (planned.codex) {
-    lines.push(
-      "MCP: register with Codex globally via 'codex mcp add' (~/.codex/config.toml)"
-    );
-  }
-  if (planned.manualAgents.length > 0) {
-    lines.push(
-      `MCP: ${joinLabels(planned.manualAgents.map(agentLabel))} require${planned.manualAgents.length === 1 ? "s" : ""} manual MCP registration`
-    );
-  }
-  return lines;
-}
-
-function renderRuntimeRequirements(
-  database: DatabaseMode,
-  env: NodeJS.ProcessEnv
-): string[] {
-  if (database === "local") {
-    return ["Runtime requirement: Docker with PostgreSQL 16 and pgvector"];
-  }
-  if (database === "existing" && !env.DATABASE_URL_ADMIN?.trim()) {
-    return [
-      "Runtime requirement: configure DATABASE_URL_ADMIN for PostgreSQL 16 with pgvector",
-    ];
-  }
-  return [];
-}
-
-async function confirmInitReview(
-  io: TielineCliIO,
-  review: string
-): Promise<void> {
-  await showNote(io, "Review", review);
-  if (!(await confirmChoice(io, "Apply this setup?", true))) {
-    throw new Error("Cancelled.");
-  }
 }
 
 async function runSkillInstall(

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -44,7 +44,7 @@ import {
 import { writeWorkspaceReviewPage } from "../tieline/review.js";
 import {
   detectRepositoryAgents,
-  installTielineAuthor,
+  installTielineSkill,
   normalizeSkillAgentIds,
   runSkillfishProcess,
   skippedSkillInstall,
@@ -55,7 +55,7 @@ import {
 } from "../tieline/skill-install.js";
 import {
   getTielineStatus,
-  ONBOARDING_AGENT_PROMPT,
+  ONBOARDING_AGENT_INSTRUCTION,
 } from "../tieline/status.js";
 import {
   findTielineWorkspace,
@@ -207,17 +207,15 @@ function renderInitSummary(
         : []),
     ].join("; ");
     lines.push(
-      `Skill: tieline-author ${skillState}`,
+      `Skill: tieline ${skillState}`,
       "",
       ui.bold("Next steps"),
       "  1. Restart or reload your agent.",
-      "  2. Copy the prompt below and paste it to your agent.",
-      "",
-      ...renderCopyCallout(ui, ONBOARDING_AGENT_PROMPT)
+      `  2. ${ONBOARDING_AGENT_INSTRUCTION}`
     );
   } else if (skill.status === "failed") {
     lines.push(
-      ui.yellow("Skill: tieline-author installation incomplete"),
+      ui.yellow("Skill: tieline installation incomplete"),
       `Reason: ${skill.reason}`,
       "",
       ui.bold("Next step"),
@@ -230,7 +228,7 @@ function renderInitSummary(
       "Skill: not installed",
       "",
       ui.bold("Next step"),
-      "  Install the tieline-author skill by running:",
+      "  Install the tieline skill by running:",
       "",
       ...renderCopyCallout(ui, "tieline init .")
     );
@@ -416,8 +414,8 @@ export async function runInit(
     result.workspace.root,
     result.workspace.config.product.repo_name
   );
-  // Close the Clack flow before the summary so the paste-ready prompt is the
-  // last thing on screen rather than trailing into the flow's end cap.
+  // Close the Clack flow before the summary so the direct skill invocation is
+  // the last thing on screen rather than trailing into the flow's end cap.
   if (richInteractive) await outro(io, "Tieline workspace ready");
   renderInitSummary(
     await runDatabasePreflight(initEnv),
@@ -462,7 +460,7 @@ async function runSkillInstall(
   dependencies: TielineCliDependencies
 ): Promise<SkillInstallOutcome> {
   if (!selection) return skippedSkillInstall();
-  return installTielineAuthor(
+  return installTielineSkill(
     {
       workspaceRoot: workspace.root,
       agentIds: selection.agents,

--- a/src/contract/review-page.ts
+++ b/src/contract/review-page.ts
@@ -288,7 +288,7 @@ export function renderContractReviewPage(
         <code>.tieline/spec/</code>.</p>
         ${
           options.onboardingInstruction
-            ? `<p>Run this command in your coding agent to begin:</p>
+            ? `<p>Invoke the installed skill in your coding agent to begin:</p>
               <pre class="prompt">${escapeHtml(options.onboardingInstruction)}</pre>`
             : ""
         }

--- a/src/contract/review-page.ts
+++ b/src/contract/review-page.ts
@@ -21,7 +21,7 @@ export interface ContractReviewPageOptions {
    * Rendered in the empty state so a page generated before onboarding tells
    * the reader how to author the first capabilities.
    */
-  onboardingPrompt?: string;
+  onboardingInstruction?: string;
 }
 
 function escapeHtml(value: string): string {
@@ -287,9 +287,9 @@ export function renderContractReviewPage(
         acceptance criteria once semantic onboarding authors them under
         <code>.tieline/spec/</code>.</p>
         ${
-          options.onboardingPrompt
-            ? `<p>Paste this prompt to your coding agent to begin:</p>
-              <pre class="prompt">${escapeHtml(options.onboardingPrompt)}</pre>`
+          options.onboardingInstruction
+            ? `<p>Run this command in your coding agent to begin:</p>
+              <pre class="prompt">${escapeHtml(options.onboardingInstruction)}</pre>`
             : ""
         }
         <p><code>tieline contract compile .</code> refreshes this page

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,43 +1,62 @@
-import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
-function authoringInstructions(): string {
-  const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-  const skill = readFileSync(
-    resolve(packageRoot, "skills/tieline-author/SKILL.md"),
-    "utf8"
-  );
-  const contract = readFileSync(
-    resolve(packageRoot, "skills/tieline-author/references/contract.md"),
-    "utf8"
-  );
-  const onboarding = readFileSync(
-    resolve(packageRoot, "skills/tieline-author/references/onboarding.md"),
-    "utf8"
-  );
-  return `${skill}\n\n${contract}\n\n${onboarding}`;
+const TIELINE_SKILL_FILES = [
+  "SKILL.md",
+  "references/contract.md",
+  "references/onboarding.md",
+  "references/provisioning.md",
+  "references/grading.md",
+  "references/report.md",
+] as const;
+const TIELINE_SKILL_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../skills/tieline"
+);
+let tielineInstructionsPromise: Promise<string> | undefined;
+
+function tielineInstructions(): Promise<string> {
+  tielineInstructionsPromise ??= Promise.all(
+    TIELINE_SKILL_FILES.map((path) =>
+      readFile(resolve(TIELINE_SKILL_ROOT, path), "utf8")
+    )
+  ).then((files) => files.join("\n\n"));
+  return tielineInstructionsPromise;
+}
+
+async function tielinePrompt() {
+  return {
+    messages: [
+      {
+        role: "user" as const,
+        content: {
+          type: "text" as const,
+          text: await tielineInstructions(),
+        },
+      },
+    ],
+  };
 }
 
 export function registerPrompts(server: McpServer): void {
   server.registerPrompt(
+    "tieline",
+    {
+      title: "Onboard, author, grade, or reconcile with Tieline",
+      description:
+        "Onboard repository behavior, shape planning Stories/ACs, grade evidence, or reconcile a branch while preserving Tieline authority boundaries.",
+    },
+    tielinePrompt
+  );
+  server.registerPrompt(
     "tieline_author",
     {
-      title: "Author or reconcile the Tieline contract",
+      title: "Tieline (legacy prompt name)",
       description:
-        "Onboard repository behavior, shape planning Stories/ACs, or reconcile a branch while preserving Tieline authority boundaries.",
+        "Deprecated compatibility alias for the tieline semantic workflow prompt.",
     },
-    async () => ({
-      messages: [
-        {
-          role: "user",
-          content: {
-            type: "text",
-            text: authoringInstructions(),
-          },
-        },
-      ],
-    })
+    tielinePrompt
   );
 }

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -60,8 +60,8 @@ were applied, their ranking features, and concise match reasons.
 6. Create or update planning Stories/ACs through the planning tools. The tools
    search before creation and require an explicit reuse-or-continue decision.
 
-Invoke the MCP \`tieline_author\` prompt (or use the bundled
-\`$tieline-author\` skill) to onboard repository behavior, materialize planning
+Invoke the MCP \`tieline\` prompt (or use the bundled
+\`$tieline\` skill) to onboard repository behavior, materialize planning
 definitions, reconcile branch changes, validate/compile YAML, and review the
 semantic diff. Normal pull-request merge is the semantic approval event.
 During deterministic setup, interactive \`tieline init\` asks which coding

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,7 +42,7 @@ export function createServer(): McpServer {
         "Tieline is a lifecycle-aware semantic contract grounded in repository YAML. " +
         "Use search_knowledge with an explicit profile for cross-type search, find_related for engineering-oriented discovery, and query_stories for exact Story/AC reads. " +
         "Use get_path_criteria before editing a repository path to learn which acceptance criteria the accepted contract records for it; the tool reads the compiled manifest and needs no database. " +
-        "Use the tieline_author prompt to onboard or reconcile repository behavior. " +
+        "Use the tieline prompt to onboard, author, grade, or reconcile repository behavior. " +
         "Planning writes can shape backlog Stories/ACs, append Observations, and manage " +
         "Backlog Items. Repository-owned behavior changes only through YAML and normal PR review.",
     }

--- a/src/tieline/review.ts
+++ b/src/tieline/review.ts
@@ -9,7 +9,7 @@ import {
   type ContractReviewDocument,
 } from "../contract/review-page.js";
 import { ContractValidationError } from "../contract/validate.js";
-import { ONBOARDING_AGENT_PROMPT } from "./status.js";
+import { ONBOARDING_AGENT_INSTRUCTION } from "./status.js";
 
 export const TIELINE_REVIEW_PAGE = ".tieline/review.html";
 
@@ -59,7 +59,7 @@ export function writeWorkspaceReviewPage(
     repositoryKey,
     documents,
     warnings,
-    onboardingPrompt: ONBOARDING_AGENT_PROMPT,
+    onboardingInstruction: ONBOARDING_AGENT_INSTRUCTION,
   });
   writeFileSync(path, serialized);
   if (path === defaultPath) ensureReviewPageIgnored(root);

--- a/src/tieline/skill-install.ts
+++ b/src/tieline/skill-install.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { z } from "zod";
 
@@ -23,14 +23,38 @@ export type SkillInstallScope = "project" | "global";
  * everything is indistinguishable from no detection at all. `.agents/` maps
  * to Codex because Codex resolves repository skills from `.agents/skills`.
  */
-const AGENT_REPO_MARKERS: Record<SkillAgentId, string[]> = {
-  "claude-code": [".claude"],
-  codex: [".codex", ".agents"],
-  cursor: [".cursor"],
-  "gemini-cli": [".gemini"],
-  "github-copilot": [".vscode"],
-  opencode: ["opencode.json"],
-  windsurf: [".windsurf"],
+const AGENT_REPOSITORY_CONFIG: Record<
+  SkillAgentId,
+  { detectionMarkers: string[]; skillfishProjectMarker: string }
+> = {
+  "claude-code": {
+    detectionMarkers: [".claude"],
+    skillfishProjectMarker: ".claude",
+  },
+  codex: {
+    detectionMarkers: [".codex", ".agents"],
+    skillfishProjectMarker: ".codex",
+  },
+  cursor: {
+    detectionMarkers: [".cursor"],
+    skillfishProjectMarker: ".cursor",
+  },
+  "gemini-cli": {
+    detectionMarkers: [".gemini"],
+    skillfishProjectMarker: ".gemini",
+  },
+  "github-copilot": {
+    detectionMarkers: [".vscode"],
+    skillfishProjectMarker: ".github/skills",
+  },
+  opencode: {
+    detectionMarkers: ["opencode.json"],
+    skillfishProjectMarker: ".opencode",
+  },
+  windsurf: {
+    detectionMarkers: [".windsurf"],
+    skillfishProjectMarker: ".windsurf",
+  },
 };
 
 /**
@@ -51,8 +75,9 @@ export function detectRepositoryAgents(
     ) {
       return true;
     }
-    return AGENT_REPO_MARKERS[agent.id].some((marker) =>
-      existsSync(resolve(root, marker))
+    const config = AGENT_REPOSITORY_CONFIG[agent.id];
+    return [...config.detectionMarkers, config.skillfishProjectMarker].some(
+      (marker) => existsSync(resolve(root, marker))
     );
   }).map((agent) => agent.id);
 }
@@ -179,6 +204,17 @@ const skillfishOutputSchema = z
   })
   .strict();
 
+const skillfishErrorOutputSchema = z
+  .object({
+    success: z.boolean(),
+    errors: z.array(z.string()),
+    exit_code: z.number().int().optional(),
+    installed: z.array(installedSkillSchema).optional(),
+    skipped: z.array(skippedSkillSchema).optional(),
+    skills_found: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
 function normalizedAgents(
   agentIds: readonly string[]
 ): NormalizedSkillAgent[] {
@@ -239,6 +275,22 @@ function skillfishInvocation(
     shell: platform === "win32",
     timeoutMs: SKILL_INSTALL_TIMEOUT_MS,
   };
+}
+
+function prepareSkillfishProjectMarkers(
+  workspaceRoot: string,
+  agents: readonly NormalizedSkillAgent[]
+): string | null {
+  for (const agent of agents) {
+    const marker = AGENT_REPOSITORY_CONFIG[agent.id].skillfishProjectMarker;
+    try {
+      mkdirSync(resolve(workspaceRoot, marker), { recursive: true });
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      return `Could not prepare the ${agent.selector} project marker '${marker}'${code ? ` (${code})` : ""}.`;
+    }
+  }
+  return null;
 }
 
 export function buildSkillfishInvocation(
@@ -347,6 +399,22 @@ function failedOutcome(
   };
 }
 
+function skillfishErrors(errors: readonly string[]): string | null {
+  const messages = errors.map((error) => error.trim()).filter(Boolean);
+  return messages.length > 0 ? messages.join(" ") : null;
+}
+
+function structuredSkillfishError(stdout: string): string | null {
+  if (!stdout.trim()) return null;
+  try {
+    const parsed = skillfishErrorOutputSchema.safeParse(JSON.parse(stdout));
+    if (!parsed.success) return null;
+    return skillfishErrors(parsed.data.errors);
+  } catch {
+    return null;
+  }
+}
+
 export async function installTielineAuthor(
   options: SkillInstallOptions,
   runner: SkillfishProcessRunner = runSkillfishProcess
@@ -355,6 +423,15 @@ export async function installTielineAuthor(
   const requestedAgents = agents.map((agent) => agent.id);
   const retryCommand = skillInstallRetryCommand(options, agents);
   const invocation = skillfishInvocation(options, agents);
+  if (options.scope === "project") {
+    const preparationError = prepareSkillfishProjectMarkers(
+      options.workspaceRoot,
+      agents
+    );
+    if (preparationError) {
+      return failedOutcome(requestedAgents, retryCommand, preparationError);
+    }
+  }
   let processResult: SkillfishProcessResult;
   try {
     processResult = await runner(invocation);
@@ -376,7 +453,8 @@ export async function installTielineAuthor(
     return failedOutcome(
       requestedAgents,
       retryCommand,
-      `Skillfish exited with code ${processResult.code}.`
+      structuredSkillfishError(processResult.stdout) ??
+        `Skillfish exited with code ${processResult.code}.`
     );
   }
   if (!processResult.stdout.trim()) {
@@ -409,7 +487,8 @@ export async function installTielineAuthor(
     return failedOutcome(
       requestedAgents,
       retryCommand,
-      "Skillfish reported an unsuccessful installation."
+      skillfishErrors(parsed.data.errors) ??
+        "Skillfish reported an unsuccessful installation."
     );
   }
 

--- a/src/tieline/skill-install.ts
+++ b/src/tieline/skill-install.ts
@@ -262,7 +262,7 @@ function skillfishInvocation(
     "add",
     "knoxgraeme/tieline",
     "--path",
-    "skills/tieline-author",
+    "skills/tieline",
   ];
   for (const agent of agents) args.push("--agent", agent.selector);
   args.push(options.scope === "project" ? "--project" : "--global");
@@ -415,7 +415,7 @@ function structuredSkillfishError(stdout: string): string | null {
   }
 }
 
-export async function installTielineAuthor(
+export async function installTielineSkill(
   options: SkillInstallOptions,
   runner: SkillfishProcessRunner = runSkillfishProcess
 ): Promise<SkillInstallOutcome> {
@@ -493,13 +493,13 @@ export async function installTielineAuthor(
   }
 
   const installedAgents = parsed.data.installed
-    .filter((item) => item.skill === "tieline-author")
+    .filter((item) => item.skill === "tieline")
     .map((item) => agentIdBySelector.get(item.agent))
     .filter((id): id is SkillAgentId => id !== undefined);
   const alreadyPresentAgents = parsed.data.skipped
     .filter(
       (item) =>
-        item.skill === "tieline-author" && /already|exist/i.test(item.reason)
+        item.skill === "tieline" && /already|exist/i.test(item.reason)
     )
     .map((item) => agentIdBySelector.get(item.agent))
     .filter((id): id is SkillAgentId => id !== undefined);

--- a/src/tieline/status.ts
+++ b/src/tieline/status.ts
@@ -38,18 +38,14 @@ export interface TielineStatus {
   next_action: string;
   onboarding: {
     required: true;
-    skill: "tieline-author";
-    instruction: typeof ONBOARDING_AGENT_PROMPT;
+    skill: "tieline";
+    instruction: typeof ONBOARDING_AGENT_INSTRUCTION;
     install_command: "tieline init .";
   } | null;
 }
 
-export const ONBOARDING_AGENT_PROMPT =
-  "Use the tieline-author skill to onboard this repository to Tieline.";
-
-function onboardingPasteInstruction(): string {
-  return `Paste this prompt to your agent to finish onboarding: "${ONBOARDING_AGENT_PROMPT}"`;
-}
+export const ONBOARDING_AGENT_INSTRUCTION =
+  "Invoke the installed tieline skill to onboard this repository (/tieline in Claude Code; $tieline in Codex).";
 
 function configured(value: string | undefined): boolean {
   return Boolean(value?.trim());
@@ -105,17 +101,17 @@ export function getTielineStatus(
     stories.length === 0
       ? ({
           required: true,
-          skill: "tieline-author",
-          instruction: ONBOARDING_AGENT_PROMPT,
+          skill: "tieline",
+          instruction: ONBOARDING_AGENT_INSTRUCTION,
           install_command: "tieline init .",
         } as const)
       : null;
   const nextAction =
     onboarding
-      ? onboardingPasteInstruction()
+      ? onboarding.instruction
       : !manifestExists
         ? "Run `tieline contract compile .` and review the semantic diff."
-        : "Use $tieline-author to reconcile branch work; the pull request is the approval boundary.";
+        : "Use $tieline to reconcile branch work; the pull request is the approval boundary.";
   return {
     initialized: true,
     root: workspace.root,

--- a/src/tieline/status.ts
+++ b/src/tieline/status.ts
@@ -45,7 +45,7 @@ export interface TielineStatus {
 }
 
 export const ONBOARDING_AGENT_INSTRUCTION =
-  "Invoke the installed tieline skill to onboard this repository (/tieline in Claude Code; $tieline in Codex).";
+  "Ask your agent to use the installed tieline skill to onboard this repository. In Claude Code, run /tieline; in Codex, run $tieline.";
 
 function configured(value: string | undefined): boolean {
   return Boolean(value?.trim());


### PR DESCRIPTION
## Summary

Tieline setup now leaves users with one installed `tieline` skill and a direct host-specific invocation instead of a prose prompt to copy. The README opens with the product value, a short Quick setup, and then the deeper contract and configuration reference.

The same skill owns semantic onboarding, authoring, reconciliation, and grading; grading remains an explicit internal workflow rather than a second installed skill. The canonical MCP `tieline` prompt loads that complete workflow, while existing clients can continue to request `tieline_author` through a content-identical compatibility alias.

The branch also brings the package metadata on `main` through the published `0.1.14` release.

## Migration note

Fresh initialization installs only `tieline`. Repositories that previously installed `tieline-author` or `tieline-grade` can retain those old local skill directories until the user removes them.

## Validation

- `npm test`
- `npm run test:tieline`
- `tieline contract validate .`
- `tieline contract compile .`
- `tieline check --base origin/main --json` reports a current manifest, no broken links, and no unclaimed changes

## Post-Deploy Monitoring & Validation

- Validation window and owner: maintainer, during the first 24 hours after the next npm publication.
- Healthy signal: `npx -y tieline@<version> init` completes in a disposable repository, installs one `tieline` skill, configures or explains MCP registration, and prints the correct agent-specific invocation.
- Failure signal: skill installation exits non-zero, the selected agent lacks its skill or MCP configuration, or the handoff names an unavailable command.
- Mitigation: reproduce against the published version, fix forward when isolated, or direct users to the previous package version until a patch is published.
