### PR TITLE
fix(onboarding): make hosted setup deterministic

### DIFF
--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -690,7 +690,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
+                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -690,7 +690,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
+                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -58,7 +58,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
+                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -102,7 +102,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
+                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -156,7 +156,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
+                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -200,7 +200,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
+                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -244,7 +244,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "f4ca47675e8a8e7295a523720345a4a6d7bdae7ea4f07c166c551060c41f980f",
+                "reviewed_content_hash": "a01305e31c7c65db13a2bad0116e3492fdef8a34bb16508caf44b885906e5ea4",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/skill-install.ts",
@@ -254,7 +254,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c7977a150bea8b952dc80bffa83b408415be3a02436ea5456b101cf018e09a3b",
+                "reviewed_content_hash": "26f73c53807c1bd4561f18eacb41544c32d32a5a6f56fd79729d48c73c68529c",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -265,7 +265,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
+                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -299,7 +299,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "f4ca47675e8a8e7295a523720345a4a6d7bdae7ea4f07c166c551060c41f980f",
+                "reviewed_content_hash": "a01305e31c7c65db13a2bad0116e3492fdef8a34bb16508caf44b885906e5ea4",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/skill-install.ts",
@@ -309,7 +309,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
+                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -353,7 +353,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
+                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -387,7 +387,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "f4ca47675e8a8e7295a523720345a4a6d7bdae7ea4f07c166c551060c41f980f",
+                "reviewed_content_hash": "a01305e31c7c65db13a2bad0116e3492fdef8a34bb16508caf44b885906e5ea4",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/skill-install.ts",
@@ -397,7 +397,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c7977a150bea8b952dc80bffa83b408415be3a02436ea5456b101cf018e09a3b",
+                "reviewed_content_hash": "26f73c53807c1bd4561f18eacb41544c32d32a5a6f56fd79729d48c73c68529c",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -408,7 +408,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
+                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -452,7 +452,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
+                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -496,7 +496,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
+                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -800,7 +800,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
+                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -58,7 +58,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
+                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -102,7 +102,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
+                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -156,7 +156,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
+                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -200,7 +200,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
+                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -265,7 +265,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
+                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -309,7 +309,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
+                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -353,7 +353,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
+                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -408,7 +408,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
+                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -452,7 +452,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
+                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -496,7 +496,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
+                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -749,7 +749,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "c9738af42f127a53cf1c7a0fdb8163da42ffee6948a36b3e25adc2f48e784357",
+                "reviewed_content_hash": "c1ccedbeb69511ef0a36f71f7cf8034273a5c87dd5af9e6f947d416af5d61e1a",
                 "target": {
                   "kind": "code",
                   "path": "skills/tieline/references/onboarding.md",
@@ -759,7 +759,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "c6611486233d6f241d8379189be74d5890f63837e9de8a19e67ad391d9d51767",
+                "reviewed_content_hash": "48a19308506951ab749e415e4c6463acb85b2ba27893ef9a158ac5916bf35035",
                 "target": {
                   "kind": "code",
                   "path": "skills/tieline/SKILL.md",
@@ -800,7 +800,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "fa75d363003983e741902739890ef1769df0d8fb31ca48c4d4cb5f361b040c05",
+                "reviewed_content_hash": "b72cc36f2bfd3179f84ccd2a6f3e2a55d9ed55ec0d35b77b8655558b2e7580f2",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ From the repository you want to onboard (requires Node.js 20.12 or newer):
 
 ```bash
 cd /path/to/product-repository
-npx -y tieline init
+npx -y tieline@latest init
 ```
 
 Select the coding agents you use. Tieline creates or updates the `.tieline`
@@ -165,17 +165,16 @@ converges definitions without deleting history.
   Supabase Edge Function, or the optional local runtime adds vector similarity;
   full-text and identifier search remain available without one.
 
-No install is required: every command runs through `npx -y tieline <command>`,
-which is also how the registered MCP configuration launches the server. In a
-Node repository, pin the CLI as a dev dependency so the whole team resolves
-one version locally:
+No install is required. Bootstrap with the current published CLI explicitly:
 
 ```bash
-npm install --save-dev tieline
-npx tieline --help
+npx -y tieline@latest init
 ```
 
-A global install also works when a bare `tieline` command is preferred:
+This does not add Tieline to the application's dependencies or modify its
+lockfile. After setup, commands can run through `npx -y tieline <command>`,
+which is also how the registered MCP configuration launches the server. A
+global install also works when a bare `tieline` command is preferred:
 
 ```bash
 npm install --global tieline
@@ -214,7 +213,7 @@ verify instead of interrogate:
 
 ```bash
 cd /path/to/product-repository
-npx -y tieline init
+npx -y tieline@latest init
 ```
 
 Restart or reload the selected agent, then ask it to use the installed
@@ -225,7 +224,7 @@ request. That invocation is the semantic-onboarding handoff.
 The same setup remains prompt-free for automation:
 
 ```bash
-tieline init /path/to/product-repository \
+npx -y tieline@latest init /path/to/product-repository \
   --database offline \
   --embedding local \
   --description "A concise description of the product and business" \
@@ -238,7 +237,7 @@ tieline init /path/to/product-repository \
 `tieline` for multiple agents:
 
 ```bash
-tieline init /path/to/product-repository \
+npx -y tieline@latest init /path/to/product-repository \
   --database offline \
   --embedding local \
   --yes \
@@ -364,7 +363,7 @@ installer, exits non-zero, and prints a retry command using its stable agent
 IDs, for example:
 
 ```bash
-tieline init . --yes --agent codex --skill-scope project
+npx -y tieline@latest init . --yes --agent codex --skill-scope project
 ```
 
 The MCP server is registered as `npx -y tieline serve`, so hosts resolve the

--- a/scripts/test-skill-install.ts
+++ b/scripts/test-skill-install.ts
@@ -144,7 +144,16 @@ assert.equal(
     scope: "project",
     platform: "darwin",
   }),
-  "tieline init '/tmp/Example Repository' --yes --agent codex --agent claude-code --skill-scope project"
+  "npx -y tieline@latest init '/tmp/Example Repository' --yes --agent codex --agent claude-code --skill-scope project"
+);
+assert.equal(
+  renderSkillInstallRetryCommand({
+    workspaceRoot,
+    agentIds: ["codex"],
+    scope: "global",
+    platform: "win32",
+  }),
+  'npx -y tieline@latest init "/tmp/Example Repository" --yes --agent codex --skill-scope global'
 );
 
 let capturedInvocation = invocation;

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -1462,6 +1462,21 @@ capability:
     /Do not enumerate the authored\s+Stories or acceptance\s+criteria inline/,
     "onboarding must deliver the review page, not an inline listing"
   );
+  assert.doesNotMatch(
+    onboardingReference,
+    /pin the CLI|npm install --save-dev tieline/i,
+    "semantic onboarding must not ask to modify the repository's dependencies"
+  );
+  assert.match(
+    tielineSkill,
+    /npx -y tieline@latest init/,
+    "skill-driven bootstrap must explicitly resolve the latest Tieline release"
+  );
+  assert.match(
+    onboardingReference,
+    /npx -y tieline@latest init/,
+    "semantic setup commands must explicitly resolve the latest Tieline release"
+  );
   assert.match(
     tielineSkill,
     /pointing at `\.tieline\/review\.html`/,
@@ -1496,8 +1511,32 @@ capability:
     /provision option in the database question is the consent/,
     "picking the menu option is the consent; no double-ask"
   );
-  assert.match(provisioningReference, /neonctl projects create/);
-  assert.match(provisioningReference, /--provision-roles/);
+  assert.match(provisioningReference, /neonctl orgs list.*--output json/);
+  assert.match(
+    provisioningReference,
+    /exactly one.*--org-id/s,
+    "hosted provisioning must automatically select an unambiguous Neon organization"
+  );
+  assert.match(
+    provisioningReference,
+    /more than one.*ask\s+the user/s,
+    "hosted provisioning must preserve the ownership boundary when several organizations are available"
+  );
+  assert.match(
+    provisioningReference,
+    /no organization.*report that result.*continue in offline mode.*never create an\s+organization without explicit consent/s,
+    "hosted provisioning must fail safely when the Neon account has no organization"
+  );
+  assert.match(
+    provisioningReference,
+    /neonctl projects create.*--org-id/s,
+    "Neon project creation must pass the resolved organization explicitly"
+  );
+  assert.match(
+    provisioningReference,
+    /DATABASE_URL_ADMIN=<uri>[^\n]*npx -y tieline@latest init[^\n]*--database existing[^\n]*--provision-roles/,
+    "hosted provisioning must pass the captured URI through the explicit existing-database role-provisioning command"
+  );
   assert.match(
     provisioningReference,
     /never write it into any\s+repository file/,
@@ -1534,6 +1573,25 @@ capability:
   assert.ok(
     detailedSetupIndex > quickSetupIndex,
     "README Quick setup must precede detailed setup"
+  );
+  assert.ok(
+    (readme.match(/npx -y tieline@latest init/g) ?? []).length >= 2,
+    "README quick and detailed bootstrap commands must explicitly resolve the latest Tieline release"
+  );
+  assert.doesNotMatch(
+    readme,
+    /npx -y tieline init/,
+    "README must not leave a first-time init command on implicit package resolution"
+  );
+  assert.doesNotMatch(
+    readme,
+    /^tieline init /m,
+    "README automation and recovery examples must not require a global Tieline install"
+  );
+  assert.doesNotMatch(
+    readme,
+    /npm install --save-dev tieline|pin the CLI as a dev dependency/i,
+    "README setup must not make dependency pinning part of onboarding"
   );
   assert.match(
     readme,

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -616,7 +616,7 @@ try {
   );
   assert.match(
     failedOutput,
-    /Retry the install by running:\n\n─+\ntieline init .*Failed Install Checkout.*--yes --agent codex --skill-scope project\n─+/
+    /Retry the install by running:\n\n─+\nnpx -y tieline@latest init .*Failed Install Checkout.*--yes --agent codex --skill-scope project\n─+/
   );
   assert.doesNotMatch(failedOutput, /private nested output|Agent handoff prompt/);
 

--- a/skills/tieline/SKILL.md
+++ b/skills/tieline/SKILL.md
@@ -11,10 +11,10 @@ separate draft, proposal, or semantic-approval record.
 Read [contract.md](references/contract.md) before editing contract YAML.
 
 If `.tieline/config.json` does not exist, bootstrap deterministic setup first:
-run `npx -y tieline init . --yes --agent <this-agent-id>` and continue once it
-succeeds. Never wait for tieline MCP tools mid-session — registered servers
-load when the client starts its next session, and every workflow here also
-works through the CLI (`npx -y tieline <command>`).
+run `npx -y tieline@latest init . --yes --agent <this-agent-id>` and continue
+once it succeeds. Never wait for tieline MCP tools mid-session — registered
+servers load when the client starts its next session, and every workflow here
+also works through the CLI (`npx -y tieline <command>`).
 
 When invoked after `tieline init` as an installed skill or MCP prompt, inspect
 `.tieline/spec/`. If it has no YAML, read

--- a/skills/tieline/references/onboarding.md
+++ b/skills/tieline/references/onboarding.md
@@ -58,16 +58,15 @@ a human first sees them. Verify, do not re-ask.
 
    Present offline as "start here, connect later", never as the whole
    product. Map the answers to commands:
-   - Local: `npx -y tieline init . --yes --database local` (requires a
+   - Local: `npx -y tieline@latest init . --yes --database local` (requires a
      running Docker daemon).
    - Existing: with `DATABASE_URL_ADMIN` in the environment, run
-     `npx -y tieline init . --yes --database existing`.
+     `npx -y tieline@latest init . --yes --database existing`.
    - Provision: follow [provisioning.md](provisioning.md) to create a Neon
      Postgres in the user's own account and connect it.
-4. In a repository with a `package.json`, offer to pin the CLI with
-   `npm install --save-dev tieline` so the team shares one version and
-   `npx tieline` resolves locally. Skip this for non-Node repositories; `npx`
-   alone is sufficient.
+4. Do not ask whether to install or pin the Tieline CLI in the repository.
+   Setup runs through `npx` and does not modify the application's dependency
+   manifest or lockfile.
 5. Close the conversation with a handoff so the coming silence is expected:
    setup is complete, the rest runs without input, and the next thing the
    user sees is the completion report with the review page. Everything after

--- a/skills/tieline/references/provisioning.md
+++ b/skills/tieline/references/provisioning.md
@@ -16,18 +16,34 @@ Tieline's private profile outside the checkout.
    fails, stop and ask the user to either run `npx -y neonctl auth` (it
    finishes in their browser) or provide `NEON_API_KEY`. Never work around
    missing authentication.
-3. Create the project and capture the connection URI:
+3. Resolve the organization before creating anything:
 
    ```sh
-   npx -y neonctl projects create --name tieline-<repo_name> --output json
+   npx -y neonctl orgs list --output json
+   ```
+
+   Read each organization's `id` and `name` from the output. If there is
+   exactly one organization, select it automatically and pass its ID with
+   `--org-id`. If there is more than one, show only the names and IDs and ask
+   the user which organization should own the project. This is a required
+   ownership boundary, not a second provisioning confirmation. Do not treat
+   multiple organizations as a provider failure, choose one heuristically, or
+   change the user's global Neon context. If no organization is available,
+   report that result and continue in offline mode; never create an
+   organization without explicit consent.
+4. Create the project in the resolved organization and capture the connection
+   URI:
+
+   ```sh
+   npx -y neonctl projects create --name tieline-<repo_name> --org-id <org_id> --output json
    ```
 
    Read `connection_uris[0].connection_uri` from the output. Treat it as a
    secret: never print it back and never write it into any repository file.
-4. Run setup with the URI scoped to this single command:
+5. Run setup with the URI scoped to this single command:
 
    ```sh
-   DATABASE_URL_ADMIN=<uri> npx -y tieline init . --yes --database existing --provision-roles
+   DATABASE_URL_ADMIN=<uri> npx -y tieline@latest init . --yes --database existing --provision-roles
    ```
 
    `--provision-roles` assigns login credentials to the migration-created
@@ -36,11 +52,11 @@ Tieline's private profile outside the checkout.
    Run it at most once per database: re-running rotates the generated
    passwords and invalidates the credentials every other clone's profile
    already holds.
-5. Verify with `npx -y tieline status --json`: `runtime.setup_complete`
+6. Verify with `npx -y tieline status --json`: `runtime.setup_complete`
    must be true and the capability flags should report semantic matching
    and planning writes configured. On any provider failure, report the
    error and continue in offline mode — the workspace stays fully usable.
-6. If others work in this repository, they connect without admin access:
+7. If others work in this repository, they connect without admin access:
    share the reader and planning writer URLs from this machine's private
    Tieline profile through a secret manager, and each person sets
    `DATABASE_URL` and `DATABASE_URL_WRITE` in their environment. A solo

--- a/src/tieline/skill-install.ts
+++ b/src/tieline/skill-install.ts
@@ -314,14 +314,15 @@ function skillInstallRetryCommand(
 ): string {
   const platform = options.platform ?? process.platform;
   const args = [
-    "tieline",
-    "init",
     resolve(options.workspaceRoot),
     "--yes",
   ];
   for (const agent of agents) args.push("--agent", agent.id);
   args.push("--skill-scope", options.scope);
-  return args.map((value) => quoteShellArgument(value, platform)).join(" ");
+  return [
+    "npx -y tieline@latest init",
+    ...args.map((value) => quoteShellArgument(value, platform)),
+  ].join(" ");
 }
 
 export function renderSkillInstallRetryCommand(


### PR DESCRIPTION
## Summary

Hosted onboarding now resolves the user's Neon organization before creating a project. A single organization is selected automatically, multiple organizations trigger an ownership choice, and an account with no organization falls back safely without creating infrastructure.

Setup no longer asks to add Tieline to the application's dependencies. Every bootstrap, automation, and recovery example explicitly runs `tieline@latest`, while established post-setup commands retain normal local package resolution.

## Validation

- `npm run test:tieline`
- `npm test`
- `npx -y neonctl orgs list --help`
- `npx -y neonctl projects create --help`

## Post-Deploy Monitoring & Validation

- Validation window: the first hosted onboarding runs after release; owner: Tieline maintainer.
- Healthy signals: onboarding lists Neon organizations, passes the selected `--org-id`, reaches `runtime.setup_complete`, and leaves the application's dependency manifest and lockfile unchanged.
- Failure signals: Neon requests an interactive organization after selection, provisioning falls offline despite an available organization, or setup changes application dependencies.
- Mitigation: use the existing-Postgres path for the affected repository and revert this onboarding instruction change if the CLI contract has drifted.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
