### PR TITLE
fix(init): require explicit skill selection

### DIFF
--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -352,7 +352,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
+                "reviewed_content_hash": "6a6b37b0d55118d934324936fb02128f77e545750be228594b7cd3c39ebe2b87",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -566,7 +566,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
+                "reviewed_content_hash": "6a6b37b0d55118d934324936fb02128f77e545750be228594b7cd3c39ebe2b87",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -626,7 +626,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "d170a3e87d436f60292dd7081ae161f11dd03eff7b4f0ab4943973a932af1a12",
+                "reviewed_content_hash": "0c1b2ea813965fee82fdcb40782e8117552a6277341f8241a973de6ce59e9341",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -690,7 +690,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
+                "reviewed_content_hash": "c7c56acf79a6c1216b8414fb4d8b82235f865c2ea2cd758a1671f1771c1b4567",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -755,7 +755,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
+                "reviewed_content_hash": "6a6b37b0d55118d934324936fb02128f77e545750be228594b7cd3c39ebe2b87",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",

--- a/.tieline/manifest/GRADING.json
+++ b/.tieline/manifest/GRADING.json
@@ -150,7 +150,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
+                "reviewed_content_hash": "6a6b37b0d55118d934324936fb02128f77e545750be228594b7cd3c39ebe2b87",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",

--- a/.tieline/manifest/RETRIEVAL.json
+++ b/.tieline/manifest/RETRIEVAL.json
@@ -129,7 +129,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "55108945acfa1475ad1aab0fc39f8f1c1a22196a68ec1a2ca17e0da18e82c787",
+                "reviewed_content_hash": "7a197ddb3e88080a4757c39af4a42cda73d12f274b93a73b7ec67a616116eb51",
                 "target": {
                   "kind": "code",
                   "path": "src/resources.ts",

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -18,7 +18,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
+                "reviewed_content_hash": "6a6b37b0d55118d934324936fb02128f77e545750be228594b7cd3c39ebe2b87",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -38,7 +38,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "d170a3e87d436f60292dd7081ae161f11dd03eff7b4f0ab4943973a932af1a12",
+                "reviewed_content_hash": "0c1b2ea813965fee82fdcb40782e8117552a6277341f8241a973de6ce59e9341",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -58,7 +58,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
+                "reviewed_content_hash": "c7c56acf79a6c1216b8414fb4d8b82235f865c2ea2cd758a1671f1771c1b4567",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -102,7 +102,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
+                "reviewed_content_hash": "c7c56acf79a6c1216b8414fb4d8b82235f865c2ea2cd758a1671f1771c1b4567",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -146,7 +146,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "d170a3e87d436f60292dd7081ae161f11dd03eff7b4f0ab4943973a932af1a12",
+                "reviewed_content_hash": "0c1b2ea813965fee82fdcb40782e8117552a6277341f8241a973de6ce59e9341",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -156,7 +156,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
+                "reviewed_content_hash": "c7c56acf79a6c1216b8414fb4d8b82235f865c2ea2cd758a1671f1771c1b4567",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -180,7 +180,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
+                "reviewed_content_hash": "6a6b37b0d55118d934324936fb02128f77e545750be228594b7cd3c39ebe2b87",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -200,7 +200,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
+                "reviewed_content_hash": "c7c56acf79a6c1216b8414fb4d8b82235f865c2ea2cd758a1671f1771c1b4567",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -224,7 +224,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
+                "reviewed_content_hash": "6a6b37b0d55118d934324936fb02128f77e545750be228594b7cd3c39ebe2b87",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -234,7 +234,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "5cb95e8e0bcf74ad3d20ad8ed73abca8d90606ae012a13ebeb63659f810f227b",
+                "reviewed_content_hash": "c677acdaa23ed221c1f23c63c054e41c5e27010ad94a7651d7784fc44d6f7c64",
                 "target": {
                   "kind": "code",
                   "path": "src/commands/init.ts",
@@ -265,7 +265,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
+                "reviewed_content_hash": "c7c56acf79a6c1216b8414fb4d8b82235f865c2ea2cd758a1671f1771c1b4567",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -289,7 +289,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
+                "reviewed_content_hash": "6a6b37b0d55118d934324936fb02128f77e545750be228594b7cd3c39ebe2b87",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -309,7 +309,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
+                "reviewed_content_hash": "c7c56acf79a6c1216b8414fb4d8b82235f865c2ea2cd758a1671f1771c1b4567",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -333,7 +333,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
+                "reviewed_content_hash": "6a6b37b0d55118d934324936fb02128f77e545750be228594b7cd3c39ebe2b87",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -343,7 +343,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "d170a3e87d436f60292dd7081ae161f11dd03eff7b4f0ab4943973a932af1a12",
+                "reviewed_content_hash": "0c1b2ea813965fee82fdcb40782e8117552a6277341f8241a973de6ce59e9341",
                 "target": {
                   "kind": "code",
                   "path": "src/tieline/status.ts",
@@ -353,7 +353,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
+                "reviewed_content_hash": "c7c56acf79a6c1216b8414fb4d8b82235f865c2ea2cd758a1671f1771c1b4567",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -377,7 +377,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
+                "reviewed_content_hash": "6a6b37b0d55118d934324936fb02128f77e545750be228594b7cd3c39ebe2b87",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -408,7 +408,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
+                "reviewed_content_hash": "c7c56acf79a6c1216b8414fb4d8b82235f865c2ea2cd758a1671f1771c1b4567",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -432,7 +432,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
+                "reviewed_content_hash": "6a6b37b0d55118d934324936fb02128f77e545750be228594b7cd3c39ebe2b87",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
@@ -452,7 +452,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
+                "reviewed_content_hash": "c7c56acf79a6c1216b8414fb4d8b82235f865c2ea2cd758a1671f1771c1b4567",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -470,16 +470,36 @@
           {
             "aliases": [],
             "applies_to": null,
-            "contract_hash": "28707c526d98ff9f720db80e12e67e0652885420ef315e8cfac2ad61d9433187",
-            "criterion": "Tieline interactive initialization must use agent selection as setup consent, auto-detect code scope, and defer product description and context discovery to semantic onboarding while retaining explicit CLI overrides.",
+            "contract_hash": "a9d10846045b99aeb18f09ce5b114491307d7497faa0970a124397baa08ff0d6",
+            "criterion": "Tieline initialization must use a non-empty interactive agent selection as setup consent, require non-interactive callers to pass an explicit agent or explicitly skip skill installation, auto-detect code scope, and defer product description and context discovery to semantic onboarding while retaining explicit CLI overrides.",
             "links": [
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "91aeb349ed4a7f0e2f1e977bf089bb9106f69be71ccea547fa84f9d04f6508c4",
+                "reviewed_content_hash": "4365ab40d548290718baa2eb1d529b5f8e4c838ebdba063fab9c475e0a285057",
+                "target": {
+                  "kind": "code",
+                  "path": "src/cli-ui.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "6a6b37b0d55118d934324936fb02128f77e545750be228594b7cd3c39ebe2b87",
                 "target": {
                   "kind": "code",
                   "path": "src/cli.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "c677acdaa23ed221c1f23c63c054e41c5e27010ad94a7651d7784fc44d6f7c64",
+                "target": {
+                  "kind": "code",
+                  "path": "src/commands/init.ts",
                   "repository": "tieline"
                 }
               },
@@ -496,7 +516,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
+                "reviewed_content_hash": "c7c56acf79a6c1216b8414fb4d8b82235f865c2ea2cd758a1671f1771c1b4567",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -749,7 +769,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "c1ccedbeb69511ef0a36f71f7cf8034273a5c87dd5af9e6f947d416af5d61e1a",
+                "reviewed_content_hash": "7b89e8547fcf8eed63948567cbd098e3b8822d60d33e963babcb9ce2b26f61a5",
                 "target": {
                   "kind": "code",
                   "path": "skills/tieline/references/onboarding.md",
@@ -800,7 +820,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "54a7523e0767378cf94172fdbee77cbf3e4bb2ae63ff138874619d5fe25dc2e7",
+                "reviewed_content_hash": "c7c56acf79a6c1216b8414fb4d8b82235f865c2ea2cd758a1671f1771c1b4567",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -887,6 +907,6 @@
   },
   "input": {
     "path": ".tieline/spec/runtime.yaml",
-    "sha256": "ce404e9d1f7f25fa4efd2ed7f719c844005d5120eeb648aefffda9d15be0ca2e"
+    "sha256": "7b444fd069d9a66b42582f48a276ae80b4be14cd5798220bb407c6b958025993"
   }
 }

--- a/.tieline/spec/runtime.yaml
+++ b/.tieline/spec/runtime.yaml
@@ -228,8 +228,20 @@ capability:
                 path: scripts/test-tieline.ts
                 framework_hint: custom-script
         - key: RUNTIME-001-AC9
-          criterion: Tieline interactive initialization must use agent selection as setup consent, auto-detect code scope, and defer product description and context discovery to semantic onboarding while retaining explicit CLI overrides.
+          criterion: Tieline initialization must use a non-empty interactive agent selection as setup consent, require non-interactive callers to pass an explicit agent or explicitly skip skill installation, auto-detect code scope, and defer product description and context discovery to semantic onboarding while retaining explicit CLI overrides.
           links:
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/commands/init.ts
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/cli-ui.ts
             - relation: implements
               provenance: authored
               target:

--- a/README.md
+++ b/README.md
@@ -229,10 +229,12 @@ npx -y tieline@latest init /path/to/product-repository \
   --embedding local \
   --description "A concise description of the product and business" \
   --context docs/product-context.md \
+  --skip-skill-install \
   --yes
 ```
 
-`--yes` installs an agent skill only when `--agent` is explicit;
+Prompt-free setup requires at least one explicit `--agent`, or
+`--skip-skill-install` when no agent should receive the skill.
 `--skill-scope` defaults to `project`. To initialize and install
 `tieline` for multiple agents:
 
@@ -405,10 +407,10 @@ the agent calls. Existing MCP clients can continue to request the deprecated
 
 An empty `.tieline/spec/` immediately after init is intentional: init does not
 invent generic capabilities. The authoring skill validates the detected code
-scope against the repository before claiming coverage. While the spec has no Stories,
-`tieline status --json` exposes `onboarding.required`, the `tieline` skill
-name, its direct invocation instruction, and `tieline init .` as the install
-command. `onboarding` becomes
+scope against the repository before claiming coverage. While the spec has no
+Stories, `tieline status --json` exposes `onboarding.required`, the `tieline`
+skill name, its direct invocation instruction, and
+`npx -y tieline@latest init .` as the install command. `onboarding` becomes
 `null` after the first Story exists. Status also reports whether the local
 profile is ready and whether database-backed semantic matching and planning
 writes are configured. Tool calls remain the operational check.

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -13,10 +13,12 @@ import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { stripVTControlCharacters } from "node:util";
 import {
+  renderStatus,
   runCli,
   workspaceStartForCommand,
   type TielineCliIO,
 } from "../src/cli.js";
+import { createPalette } from "../src/cli-ui.js";
 import {
   detectRepositoryName,
   normalizeContextLocations,
@@ -304,7 +306,14 @@ try {
   mkdirSync(resolve(repositoryContextTarget, "src"), { recursive: true });
   assert.equal(
     await runCli(
-      ["init", repositoryContextTarget, "--yes", "--context", "."],
+      [
+        "init",
+        repositoryContextTarget,
+        "--yes",
+        "--context",
+        ".",
+        "--skip-skill-install",
+      ],
       io().adapter,
       { TIELINE_CONFIG_HOME: resolve(root, "repository-context-config") }
     ),
@@ -462,15 +471,17 @@ try {
     select: [],
     multiselect: [[]],
   });
-  assert.equal(
-    await runCli(["init", noAgentTarget], noAgent.adapter, {
+  await assert.rejects(
+    runCli(["init", noAgentTarget], noAgent.adapter, {
       TIELINE_CONFIG_HOME: resolve(root, "no-agent-config"),
     }),
-    0,
-    "deselecting every agent must skip the skill install, not fail"
+    /select at least one agent/i
   );
-  assert.match(noAgent.output.join(""), /Skill: not installed/);
-  assert.ok(existsSync(resolve(noAgentTarget, ".mcp.json")));
+  assert.equal(
+    existsSync(resolve(noAgentTarget, ".tieline")),
+    false,
+    "an empty agent choice must stop before workspace mutation"
+  );
 
   const automatedTarget = resolve(root, "Automated Checkout");
   const automatedConfigHome = resolve(root, "automated-config");
@@ -723,9 +734,13 @@ try {
   );
   const mcpRepeat = io();
   assert.equal(
-    await runCli(["init", mcpMergeTarget, "--yes"], mcpRepeat.adapter, {
-      TIELINE_CONFIG_HOME: mcpMergeConfigHome,
-    }),
+    await runCli(
+      ["init", mcpMergeTarget, "--yes", "--skip-skill-install"],
+      mcpRepeat.adapter,
+      {
+        TIELINE_CONFIG_HOME: mcpMergeConfigHome,
+      }
+    ),
     0
   );
   assert.equal(
@@ -741,7 +756,14 @@ try {
   const mcpInvalid = io();
   assert.equal(
     await runCli(
-      ["init", mcpInvalidTarget, "--yes", "--embedding", "hash"],
+      [
+        "init",
+        mcpInvalidTarget,
+        "--yes",
+        "--embedding",
+        "hash",
+        "--skip-skill-install",
+      ],
       mcpInvalid.adapter,
       { TIELINE_CONFIG_HOME: resolve(root, "mcp-invalid-config") },
       {
@@ -784,6 +806,7 @@ try {
         "A product with a living semantic contract.",
         "--embedding",
         "hash",
+        "--skip-skill-install",
       ],
       first.adapter,
       {
@@ -863,7 +886,7 @@ try {
   assert.match(firstOutput, /skill: not installed/i);
   assert.match(
     firstOutput,
-    /Install the tieline skill by running:\n\n─+\ntieline init \.\n─+/
+    /Install the tieline skill by running:\n\n─+\nnpx -y tieline@latest init \.\n─+/
   );
   assert.doesNotMatch(firstOutput, /Warning \[/);
   assert.doesNotMatch(firstOutput, /Agent handoff prompt:/);
@@ -896,7 +919,7 @@ try {
   const second = io();
   assert.equal(
     await runCli(
-      ["init", target, "--yes"],
+      ["init", target, "--yes", "--skip-skill-install"],
       second.adapter,
       { TIELINE_CONFIG_HOME: configHome }
     ),
@@ -973,11 +996,30 @@ try {
     false
   );
 
-  const resumed = io();
-  assert.equal(
-    await runCli(["init", target, "--yes"], resumed.adapter, {
+  const pendingOnboardingInit = io();
+  await assert.rejects(
+    runCli(["init", target, "--yes"], pendingOnboardingInit.adapter, {
       TIELINE_CONFIG_HOME: freshConfigHome,
     }),
+    /non-interactive init requires.*--agent.*--skip-skill-install/i
+  );
+  assert.equal(
+    readWorkspaceProfile(workspace, {
+      TIELINE_CONFIG_HOME: freshConfigHome,
+    }),
+    null,
+    "an existing onboarding workspace must reject before writing a local profile"
+  );
+
+  const resumed = io();
+  assert.equal(
+    await runCli(
+      ["init", target, "--yes", "--skip-skill-install"],
+      resumed.adapter,
+      {
+        TIELINE_CONFIG_HOME: freshConfigHome,
+      }
+    ),
     0
   );
   assert.doesNotMatch(resumed.output.join(""), /Mode:|Runtime:|Code scope:/);
@@ -1015,7 +1057,7 @@ try {
     skill: "tieline",
     instruction:
       "Ask your agent to use the installed tieline skill to onboard this repository. In Claude Code, run /tieline; in Codex, run $tieline.",
-    install_command: "tieline init .",
+    install_command: "npx -y tieline@latest init .",
   });
   assert.equal("agent_onboarding_prompt" in parsedStatus, false);
 
@@ -1031,8 +1073,24 @@ try {
     /Next: Ask your agent to use the installed tieline skill to onboard this repository\. In Claude Code, run \/tieline; in Codex, run \$tieline\./
   );
   assert.doesNotMatch(humanStatus.output.join(""), /Copy the prompt/);
-  assert.match(humanStatus.output.join(""), /Install skill: tieline init \./);
+  assert.match(
+    humanStatus.output.join(""),
+    /Install skill: npx -y tieline@latest init \./
+  );
   assert.doesNotMatch(humanStatus.output.join(""), /Agent handoff prompt:/);
+
+  const missingMcpStatus = renderStatus(
+    {
+      ...parsedStatus,
+      integration: { mcp_clients: [] },
+    },
+    createPalette(false)
+  );
+  assert.match(
+    missingMcpStatus,
+    /not registered \(rerun `npx -y tieline@latest init \.`\)/
+  );
+  assert.doesNotMatch(missingMcpStatus, /rerun `tieline init \.`/);
 
   writeFileSync(
     resolve(workspace.specDirectoryPath, "status.yaml"),
@@ -1052,6 +1110,32 @@ capability:
         - key: STATUS-001-AC1
           criterion: Tieline must direct maintainers to compile an unreadable manifest.
 `
+  );
+
+  const onboardedCloneConfigHome = resolve(
+    root,
+    "onboarded-clone-config-home"
+  );
+  await assert.rejects(
+    runCli(["init", target, "--yes"], io().adapter, {
+      TIELINE_CONFIG_HOME: onboardedCloneConfigHome,
+    }),
+    /non-interactive init requires.*--agent.*--skip-skill-install/i
+  );
+  assert.equal(
+    readWorkspaceProfile(workspace, {
+      TIELINE_CONFIG_HOME: onboardedCloneConfigHome,
+    }),
+    null,
+    "a configured repository clone must require an agent or explicit skip before local setup"
+  );
+  assert.equal(
+    await runCli(
+      ["init", target, "--yes", "--skip-skill-install"],
+      io().adapter,
+      { TIELINE_CONFIG_HOME: onboardedCloneConfigHome }
+    ),
+    0
   );
   mkdirSync(workspace.manifestPath, { recursive: true });
   const legacyIndex = `${JSON.stringify(
@@ -1095,6 +1179,25 @@ capability:
   assert.doesNotMatch(
     onboardedHumanStatus.output.join(""),
     /Agent handoff prompt:/
+  );
+
+  const onboardedInit = interactiveIo({
+    text: [],
+    confirm: [],
+    select: [],
+    multiselect: [],
+  });
+  assert.equal(
+    await runCli(["init", target], onboardedInit.adapter, {
+      TIELINE_CONFIG_HOME: configHome,
+    }),
+    0
+  );
+  assert.match(onboardedInit.output.join(""), /already initialized/i);
+  assert.deepEqual(
+    onboardedInit.prompts,
+    [],
+    "a configured, onboarded workspace must report status without prompting"
   );
 
   const environmentStatus = io();
@@ -1396,6 +1499,16 @@ capability:
   );
   assert.match(
     onboardingReference,
+    /init \. --yes --skip-skill-install --database local/,
+    "agent-led runtime configuration must explicitly preserve the installed skill"
+  );
+  assert.match(
+    onboardingReference,
+    /init \. --yes --skip-skill-install --database existing/,
+    "agent-led existing-database setup must not trigger skill selection"
+  );
+  assert.match(
+    onboardingReference,
     /handoff so the coming silence is expected/,
     "setup must end with a handoff into the autonomous phase"
   );
@@ -1534,7 +1647,7 @@ capability:
   );
   assert.match(
     provisioningReference,
-    /DATABASE_URL_ADMIN=<uri>[^\n]*npx -y tieline@latest init[^\n]*--database existing[^\n]*--provision-roles/,
+    /DATABASE_URL_ADMIN=<uri>[^\n]*npx -y tieline@latest init[^\n]*--skip-skill-install[^\n]*--database existing[^\n]*--provision-roles/,
     "hosted provisioning must pass the captured URI through the explicit existing-database role-provisioning command"
   );
   assert.match(
@@ -1629,7 +1742,34 @@ capability:
       env: { ...process.env, TIELINE_CONFIG_HOME: configHome },
     }
   );
-  assert.equal(piped.status, 0, piped.stderr);
+  assert.notEqual(piped.status, 0, piped.stdout);
+  assert.match(
+    piped.stderr,
+    /non-interactive init requires.*--agent.*--skip-skill-install/i
+  );
+  assert.equal(
+    existsSync(resolve(pipedTarget, ".tieline")),
+    false,
+    "headless init without an explicit agent or skip must not leave a partial workspace"
+  );
+
+  const explicitlySkipped = spawnSync(
+    "node",
+    [
+      cliBin,
+      "init",
+      pipedTarget,
+      "--embedding",
+      "hash",
+      "--skip-skill-install",
+    ],
+    {
+      input: "",
+      encoding: "utf8",
+      env: { ...process.env, TIELINE_CONFIG_HOME: configHome },
+    }
+  );
+  assert.equal(explicitlySkipped.status, 0, explicitlySkipped.stderr);
   const pipedWorkspace = findTielineWorkspace(pipedTarget);
   assert.ok(pipedWorkspace);
   assert.equal(

--- a/skills/tieline/references/onboarding.md
+++ b/skills/tieline/references/onboarding.md
@@ -58,10 +58,11 @@ a human first sees them. Verify, do not re-ask.
 
    Present offline as "start here, connect later", never as the whole
    product. Map the answers to commands:
-   - Local: `npx -y tieline@latest init . --yes --database local` (requires a
-     running Docker daemon).
+   - Local:
+     `npx -y tieline@latest init . --yes --skip-skill-install --database local`
+     (requires a running Docker daemon).
    - Existing: with `DATABASE_URL_ADMIN` in the environment, run
-     `npx -y tieline@latest init . --yes --database existing`.
+     `npx -y tieline@latest init . --yes --skip-skill-install --database existing`.
    - Provision: follow [provisioning.md](provisioning.md) to create a Neon
      Postgres in the user's own account and connect it.
 4. Do not ask whether to install or pin the Tieline CLI in the repository.

--- a/skills/tieline/references/provisioning.md
+++ b/skills/tieline/references/provisioning.md
@@ -43,7 +43,7 @@ Tieline's private profile outside the checkout.
 5. Run setup with the URI scoped to this single command:
 
    ```sh
-   DATABASE_URL_ADMIN=<uri> npx -y tieline@latest init . --yes --database existing --provision-roles
+   DATABASE_URL_ADMIN=<uri> npx -y tieline@latest init . --yes --skip-skill-install --database existing --provision-roles
    ```
 
    `--provision-roles` assigns login credentials to the migration-created

--- a/src/cli-ui.ts
+++ b/src/cli-ui.ts
@@ -98,7 +98,7 @@ export async function multiselectChoice<T extends string>(
     message,
     options: [...options],
     initialValues: [...initialValues],
-    required: false,
+    required: true,
   });
   if (clack.isCancel(value)) {
     clack.cancel("Cancelled.");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,11 @@ import {
   type SkillfishProcessRunner,
   type SkillInstallScope,
 } from "./tieline/skill-install.js";
-import { statusFromPath, type TielineStatus } from "./tieline/status.js";
+import {
+  ONBOARDING_SKILL_INSTALL_COMMAND,
+  statusFromPath,
+  type TielineStatus,
+} from "./tieline/status.js";
 
 export interface TielineCliIO {
   write(message: string): void;
@@ -86,7 +90,7 @@ export function renderStatus(status: TielineStatus, ui: Palette): string {
     `  root: ${status.root}`,
     `  runtime: profile=${state(status.runtime.profile_present, "present", "missing")}, database=${status.runtime.database_mode}, embedding=${status.runtime.embedding_provider}, setup=${state(status.runtime.setup_complete, "complete", "incomplete")}`,
     `  optional capabilities: organization_matching=${state(status.capabilities.semantic_matching_configured, "configured", "not configured")}, planning_writes=${state(status.capabilities.planning_writes_configured, "configured", "not configured")}`,
-    `  integration: mcp=${state(status.integration.mcp_clients.length > 0, status.integration.mcp_clients.join(", "), "not registered (rerun `tieline init .`)")}`,
+    `  integration: mcp=${state(status.integration.mcp_clients.length > 0, status.integration.mcp_clients.join(", "), `not registered (rerun \`${ONBOARDING_SKILL_INSTALL_COMMAND}\`)`)}`,
     `  contract: ${status.contract.stories} Stories, ${status.contract.acceptance_criteria} ACs, manifest=${state(status.contract.manifest_exists, "present", "missing")}`,
   ];
   if (status.onboarding) {
@@ -273,7 +277,10 @@ function buildProgram(
       "--skip-skill-install",
       "initialize without installing tieline"
     )
-    .option("--yes", "accept detected defaults without prompting")
+    .option(
+      "--yes",
+      "accept detected defaults without prompting (pair with --agent or --skip-skill-install when setup needs a skill)"
+    )
     .option("--skip-migrate", "skip applying database migrations")
     .option(
       "--install-local-embedder",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -56,6 +56,7 @@ import {
 import {
   getTielineStatus,
   ONBOARDING_AGENT_INSTRUCTION,
+  ONBOARDING_SKILL_INSTALL_COMMAND,
 } from "../tieline/status.js";
 import {
   findTielineWorkspace,
@@ -221,7 +222,10 @@ function renderInitSummary(
       ui.bold("Next step"),
       "  Retry the install by running:",
       "",
-      ...renderCopyCallout(ui, skill.retryCommand ?? "tieline init .")
+      ...renderCopyCallout(
+        ui,
+        skill.retryCommand ?? ONBOARDING_SKILL_INSTALL_COMMAND
+      )
     );
   } else {
     lines.push(
@@ -230,7 +234,7 @@ function renderInitSummary(
       ui.bold("Next step"),
       "  Install the tieline skill by running:",
       "",
-      ...renderCopyCallout(ui, "tieline init .")
+      ...renderCopyCallout(ui, ONBOARDING_SKILL_INSTALL_COMMAND)
     );
   }
   io.write(`${lines.join("\n")}\n`);
@@ -267,12 +271,6 @@ export async function runInit(
 
   if (existing) {
     const existingStatus = getTielineStatus(existing, env);
-    skillSelection = await resolveSkillSelection(
-      parsed,
-      io,
-      Boolean(io.interactive && !parsed.yes && existingStatus.onboarding),
-      env
-    );
     const stored = readWorkspaceProfile(existing, env);
     const databaseMode = parsed.databaseExplicit
       ? parsed.database
@@ -287,6 +285,12 @@ export async function runInit(
       parsed.databaseExplicit ||
       parsed.embeddingExplicit ||
       parsed.installLocalEmbedder;
+    skillSelection = await resolveSkillSelection(
+      parsed,
+      io,
+      Boolean(existingStatus.onboarding || shouldConfigure),
+      env
+    );
     if (shouldConfigure) {
       env.EMBEDDING_PROVIDER = embeddingProvider;
       await configureWorkspaceRuntime({
@@ -367,7 +371,7 @@ export async function runInit(
   skillSelection = await resolveSkillSelection(
     parsed,
     io,
-    richInteractive,
+    true,
     env
   );
 
@@ -430,7 +434,7 @@ export async function runInit(
 async function resolveSkillSelection(
   parsed: InitOptions,
   io: TielineCliIO,
-  offerInteractive: boolean,
+  requireSelection: boolean,
   env: NodeJS.ProcessEnv
 ): Promise<SkillInstallSelection | null> {
   if (parsed.skipSkillInstall) return null;
@@ -439,16 +443,23 @@ async function resolveSkillSelection(
       ? normalizeSkillAgentIds(parsed.agents)
       : [];
   if (agents.length === 0) {
-    if (!offerInteractive) return null;
+    if (!requireSelection) return null;
+    if (!io.interactive || parsed.yes) {
+      throw new Error(
+        "Non-interactive init requires at least one --agent <id>, or --skip-skill-install."
+      );
+    }
     agents = await multiselectChoice<SkillAgentId>(
       io,
       "Where should Tieline install its onboarding and authoring skill?",
       SKILL_AGENT_OPTIONS,
       detectRepositoryAgents(parsed.target, env)
     );
-    // Deselecting everything is a choice, not an error: initialize the
-    // workspace without pushing the skill into any agent.
-    if (agents.length === 0) return null;
+    if (agents.length === 0) {
+      throw new Error(
+        "Select at least one agent, or rerun with --skip-skill-install."
+      );
+    }
   }
   return { agents, scope: parsed.skillScope ?? "project" };
 }

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -1,4 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { SUPPORTED_SKILL_AGENTS } from "./tieline/skill-install.js";
+import { ONBOARDING_SKILL_INSTALL_COMMAND } from "./tieline/status.js";
 
 const HOW_TO_QUERY = `# Tieline contract guide
 
@@ -68,7 +70,12 @@ During deterministic setup, interactive \`tieline init\` asks which coding
 agents should receive this onboarding and authoring skill. While the spec has
 no Stories,
 \`tieline status --json\` exposes concise structured onboarding state and
-\`tieline init .\` as the skill-install entry point.
+\`${ONBOARDING_SKILL_INSTALL_COMMAND}\` as the skill-install entry point.
+That command is interactive. An agent running init without a terminal must
+append \`--yes --agent <id>\` (supported IDs: ${SUPPORTED_SKILL_AGENTS.map(
+  (agent) => `\`${agent.id}\``
+).join(", ")}),
+or append \`--skip-skill-install\` when it is only reconfiguring the runtime.
 
 Coverage describes whether every AC has direct implementation, test, or help
 links. Freshness separately describes whether linked repository content still

--- a/src/tieline/status.ts
+++ b/src/tieline/status.ts
@@ -40,12 +40,14 @@ export interface TielineStatus {
     required: true;
     skill: "tieline";
     instruction: typeof ONBOARDING_AGENT_INSTRUCTION;
-    install_command: "tieline init .";
+    install_command: typeof ONBOARDING_SKILL_INSTALL_COMMAND;
   } | null;
 }
 
 export const ONBOARDING_AGENT_INSTRUCTION =
   "Ask your agent to use the installed tieline skill to onboard this repository. In Claude Code, run /tieline; in Codex, run $tieline.";
+export const ONBOARDING_SKILL_INSTALL_COMMAND =
+  "npx -y tieline@latest init .";
 
 function configured(value: string | undefined): boolean {
   return Boolean(value?.trim());
@@ -103,7 +105,7 @@ export function getTielineStatus(
           required: true,
           skill: "tieline",
           instruction: ONBOARDING_AGENT_INSTRUCTION,
-          install_command: "tieline init .",
+          install_command: ONBOARDING_SKILL_INSTALL_COMMAND,
         } as const)
       : null;
   const nextAction =


### PR DESCRIPTION
## Summary

`npx -y tieline@latest init` will no longer finish with `Skill: not installed` unless the caller explicitly chooses `--skip-skill-install`. Interactive setup requires at least one selected agent. Headless setup requires either `--agent <id>` or the explicit skip flag, and it fails before workspace mutation when neither is present.

This also keeps the full onboarding path coherent. Existing clones follow the same rule when local setup is incomplete, agent-led runtime reconfiguration preserves the already-installed skill, and every recovery surface points to `npx -y tieline@latest init .`.

## Validation

- Reproduced the published non-TTY failure mode before the fix.
- Confirmed interactive init installs the selected skill and hands off to `/tieline`.
- `npm run test:tieline`
- `npm test`
- `npx tsx src/cli.ts check . --base origin/main`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
