### PR TITLE
fix(onboarding): require repository-wide initial coverage

### DIFF
--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -690,7 +690,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -58,7 +58,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -102,7 +102,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -156,7 +156,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -200,7 +200,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -265,7 +265,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -309,7 +309,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -353,7 +353,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -408,7 +408,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -452,7 +452,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -516,7 +516,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -769,7 +769,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "7b89e8547fcf8eed63948567cbd098e3b8822d60d33e963babcb9ce2b26f61a5",
+                "reviewed_content_hash": "cd1155c2f158e90eebf1764f98d0d087ec1330fcbff27caeffc993ee8d05d56f",
                 "target": {
                   "kind": "code",
                   "path": "skills/tieline/references/onboarding.md",
@@ -779,7 +779,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "1ec80f27c5965132ffd5226de0282446a6851c41038373beb3f7e5a65f1eef25",
+                "reviewed_content_hash": "19b56b59ced8904f033db9c6f04a2f7730682d6f6ff025f37a867065d5d4a42d",
                 "target": {
                   "kind": "code",
                   "path": "skills/tieline/SKILL.md",
@@ -820,7 +820,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -833,6 +833,50 @@
             "rationale": null,
             "scenarios": [],
             "stable_id": "RUNTIME-002-AC4",
+            "supersedes": null
+          },
+          {
+            "aliases": [],
+            "applies_to": null,
+            "contract_hash": "3eb8f069073282db940d4d0d6d82ac6784517b5db18c137045575e84854b0360",
+            "criterion": "Tieline semantic onboarding must produce a repository-wide evidence-backed initial contract by assessing every configured source root and discovered application boundary, covering or explaining every high-confidence observable behavior cluster, and treating path mapping only as a gap diagnostic.",
+            "links": [
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "cd1155c2f158e90eebf1764f98d0d087ec1330fcbff27caeffc993ee8d05d56f",
+                "target": {
+                  "kind": "code",
+                  "path": "skills/tieline/references/onboarding.md",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "19b56b59ced8904f033db9c6f04a2f7730682d6f6ff025f37a867065d5d4a42d",
+                "target": {
+                  "kind": "code",
+                  "path": "skills/tieline/SKILL.md",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "tests",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
+                "target": {
+                  "framework_hint": "custom-script",
+                  "kind": "test",
+                  "path": "scripts/test-tieline.ts",
+                  "repository": "tieline"
+                }
+              }
+            ],
+            "position": 4,
+            "rationale": "A valid small seed can hide most of a monorepo, while maximizing mapped files would reward implementation-shaped criteria instead of coherent product behavior.",
+            "scenarios": [],
+            "stable_id": "RUNTIME-002-AC5",
             "supersedes": null
           }
         ],
@@ -907,6 +951,6 @@
   },
   "input": {
     "path": ".tieline/spec/runtime.yaml",
-    "sha256": "7b444fd069d9a66b42582f48a276ae80b4be14cd5798220bb407c6b958025993"
+    "sha256": "b99800a1de30f84ec450b22b0fbc845697c2a280253593441f817eb513b6b144"
   }
 }

--- a/.tieline/spec/runtime.yaml
+++ b/.tieline/spec/runtime.yaml
@@ -445,6 +445,29 @@ capability:
                 repository: tieline
                 path: scripts/test-tieline.ts
                 framework_hint: custom-script
+        - key: RUNTIME-002-AC5
+          criterion: Tieline semantic onboarding must produce a repository-wide evidence-backed initial contract by assessing every configured source root and discovered application boundary, covering or explaining every high-confidence observable behavior cluster, and treating path mapping only as a gap diagnostic.
+          rationale: A valid small seed can hide most of a monorepo, while maximizing mapped files would reward implementation-shaped criteria instead of coherent product behavior.
+          links:
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: skills/tieline/SKILL.md
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: skills/tieline/references/onboarding.md
+            - relation: tests
+              provenance: authored
+              target:
+                kind: test
+                repository: tieline
+                path: scripts/test-tieline.ts
+                framework_hint: custom-script
     - key: RUNTIME-003
       title: Verify the lifecycle as one system
       actor: maintainer

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -1503,6 +1503,46 @@ capability:
     onboardingReference,
     /Discover these repository sources directly/
   );
+  assert.match(
+    onboardingReference,
+    /maximum coherent, accurate coverage/i,
+    "semantic onboarding must optimize for repository-wide behavioral coverage"
+  );
+  assert.match(
+    onboardingReference,
+    /every configured\s+source root[\s\S]*each discovered (?:application|app), service, worker, CLI, and\s+shared package boundary/i,
+    "semantic onboarding must assess every monorepo boundary before authoring"
+  );
+  assert.match(
+    onboardingReference,
+    /working coverage ledger[\s\S]*cover[\s\S]*exclude/i,
+    "semantic onboarding must account for discovered behavior rather than stopping at a valid seed"
+  );
+  assert.match(
+    onboardingReference,
+    /Repeated evidence increases confidence[\s\S]*not a prerequisite for\s+inclusion/i,
+    "one strong repository source must be enough to preserve observable behavior"
+  );
+  assert.match(
+    onboardingReference,
+    /mapping coverage[\s\S]*not a proxy for semantic completeness/i,
+    "path mapping must diagnose possible gaps without becoming the coverage objective"
+  );
+  assert.match(
+    onboardingReference,
+    /small contract for a large or multi-application repository is a reassessment\s+signal/i,
+    "suspiciously narrow monorepo output must trigger another discovery pass"
+  );
+  assert.match(
+    onboardingReference,
+    /Audit semantic coverage before completion[\s\S]*every coverage-ledger\s+row[\s\S]*each high-confidence behavior cluster must\s+be represented by a Story and AC or have an explicit exclusion reason[\s\S]*every application boundary must have been assessed/i,
+    "semantic onboarding must reconcile every discovered high-confidence behavior before completion"
+  );
+  assert.match(
+    onboardingReference,
+    /until no known high-confidence behavior remains unrepresented\s+or unexplained/i,
+    "semantic onboarding must continue discovery until the behavioral gap audit is clear"
+  );
   assert.match(onboardingReference, /Ask focused questions only/);
   assert.match(
     onboardingReference,

--- a/skills/tieline/SKILL.md
+++ b/skills/tieline/SKILL.md
@@ -27,7 +27,9 @@ visible action is the orientation and setup exchange in onboarding.md — the
 not before it. Init records auto-detected values, so
 verify rather than interrogate: confirm detected identity with the user and
 correct `.tieline/config.json` when a detection is wrong, but never ask for
-anything the repository can answer.
+anything the repository can answer. Treat the initial contract as a
+repository-wide semantic baseline, not a narrow seed that merely makes the
+workspace non-empty.
 
 ## Orient to this repository
 

--- a/skills/tieline/references/onboarding.md
+++ b/skills/tieline/references/onboarding.md
@@ -76,32 +76,73 @@ a human first sees them. Verify, do not re-ask.
 
 ## Author the initial contract
 
-1. Build a context inventory from the configured sources, README, product and
-   architecture documentation, public code entry points, source-root package
-   metadata, and tests. Discover these repository sources directly instead of
-   asking the user to enumerate them.
-2. Treat configured sources according to `.tieline/config.json`: use inline
+Optimize this first pass for maximum coherent, accurate coverage of the
+repository's observable behavior. "Initial" means the first repository-wide
+semantic baseline, not the smallest valid seed. There is no default Story or
+AC count and no brevity target: let evidence-backed behavior determine the
+size, while avoiding duplicate or speculative definitions.
+
+1. Map the repository before defining capabilities. Assess every configured
+   source root and each discovered application, service, worker, CLI, and
+   shared package boundary. Use workspace and package metadata to find them;
+   then inspect their README and architecture documentation, public entry
+   points, UI routes, APIs, commands and tools, events, scheduled jobs,
+   deployment surfaces, schemas and migrations, and tests. A shared package is
+   in semantic scope when it exposes observable behavior or enforces a product
+   invariant across applications. Discover these repository sources directly
+   instead of asking the user to enumerate them.
+2. Build a working coverage ledger for every assessed boundary. Record its
+   actors, public interfaces, coherent behavior clusters, strongest evidence
+   paths, and a disposition of `cover`, `exclude` with a reason, or
+   `unresolved`. Keep discovery in bounded passes so repository size or context
+   pressure does not silently narrow the scope.
+3. Treat configured sources according to `.tieline/config.json`: use inline
    descriptions as product framing, read local files, and fetch websites only
    when `allow_external_fetch` is `true`. Record which sources were actually
    inspected and which were unavailable.
-3. Infer repository-specific capability boundaries, actors, user goals,
-   benefits, observable behavior, and existing terminology. Prefer evidence
-   repeated across product documentation, public interfaces, and tests.
-4. Ask focused questions only when unresolved product meaning would materially
+4. Infer repository-specific capability boundaries, actors, user goals,
+   benefits, observable behavior, and existing terminology. Triangulate product
+   documentation, public interfaces, schemas, and tests when possible.
+   Repeated evidence increases confidence but is not a prerequisite for
+   inclusion when one authoritative repository source clearly establishes an
+   observable outcome.
+5. Cover the whole product surface, not only its primary end-user path. Include
+   distinct admin, operator, seller, developer, and machine actors when the
+   repository supports them, plus cross-cutting behavior such as identity and
+   tenancy, billing and usage, validation and cryptography, persistence
+   invariants, scheduling and delivery, and observability when repository
+   evidence makes those outcomes part of the product contract. Group by user
+   or business outcome rather than mirroring the directory tree.
+6. Ask focused questions only when unresolved product meaning would materially
    change a capability boundary or acceptance criterion. Do not ask for context
    that can be discovered from the repository.
-5. Search for likely duplicate IDs and behavior using the local YAML and
+7. Search for likely duplicate IDs and behavior using the local YAML and
    manifest plus database-backed semantic matching when available.
-6. Author the initial capabilities, Stories, and ACs under `.tieline/spec/`.
-   Never create generic starter content merely to make the directory non-empty.
-7. Validate and compile the contract.
-8. Read [grading.md](grading.md) and grade the initial contract. With no manifest
+8. Author the initial capabilities, Stories, and ACs under `.tieline/spec/`.
+   Give each AC one observable outcome. Do not compress independent behaviors
+   into a few broad ACs to keep the contract small, and never create generic
+   starter content merely to make the directory non-empty.
+9. Audit semantic coverage before completion. Reconcile every coverage-ledger
+   row with the authored contract: each high-confidence behavior cluster must
+   be represented by a Story and AC or have an explicit exclusion reason, and
+   every application boundary must have been assessed. Compare the result back
+   to the discovered public interfaces, tests, and cross-cutting invariants. A
+   small contract for a large or multi-application repository is a reassessment
+   signal, not proof that only a small product spine matters; run another
+   discovery pass until no known high-confidence behavior remains unrepresented
+   or unexplained.
+10. Use repository mapping coverage only as a diagnostic for possible missed
+    surfaces. It is not a proxy for semantic completeness: do not create an AC
+    per file or chase 100 percent path coverage, but investigate concentrated
+    unmapped areas before declaring the baseline complete.
+11. Validate and compile the contract.
+12. Read [grading.md](grading.md) and grade the initial contract. With no manifest
    at the comparison base, every authored link enters the grading scope as
    `link_added`. You authored every one of them, so dispatch fresh subagents
    batched by artifact path, passing only the emitted scope entries and never
    the authoring rationale; a link none of your reasoning can defend to a cold
    reader should be graded down, not argued for.
-9. Close with the completion report shaped by
+13. Close with the completion report shaped by
    [report.md](references/report.md): `.tieline/review.html` is the
    deliverable and leads the reply, followed by at most three
    needs-your-review bullets and two caveats. Do not enumerate the authored


### PR DESCRIPTION
## Summary

Semantic onboarding could stop after finding one coherent product spine, leaving most observable behavior in a monorepo undocumented. It now treats the initial contract as a repository-wide baseline: agents assess every source root and application boundary, maintain a coverage ledger, and continue until each high-confidence behavior is covered or explicitly excluded.

Repository mapping remains a diagnostic rather than the completion target, so broader semantic coverage does not turn into one Acceptance Criterion per file. Regression assertions protect the inventory, audit, evidence, and stopping rules, and Tieline's own contract now records the guarantee.

## Validation

- `npm test`
- `npm run test:tieline`
- `tieline contract validate .` — 16 Stories, 51 Acceptance Criteria, zero warnings
- `tieline contract coverage .` — 51/51 Acceptance Criteria linked; 83/86 eligible repository paths mapped
- Correctness, testing, and agent-native review — no remaining actionable findings
