### PR TITLE
fix(skill): require semantic closeout before handoff

### DIFF
--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -690,7 +690,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
+                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -1153,7 +1153,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "65d2177a53cc8384741af8f3aa7b9c3b1f39e47c10929a915305b25d70137aad",
+                "reviewed_content_hash": "fec9050cd5ef0c87ea32187cef60f1302a2c8d4001909a3e7faa894389e8d3e0",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -690,7 +690,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -690,7 +690,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
+                "reviewed_content_hash": "1abf23d58e0179ef7fe4c48b755a87dd1d21d38998afe2673c4a5468aec69d82",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/MATCHING.json
+++ b/.tieline/manifest/MATCHING.json
@@ -175,7 +175,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "65d2177a53cc8384741af8f3aa7b9c3b1f39e47c10929a915305b25d70137aad",
+                "reviewed_content_hash": "fec9050cd5ef0c87ea32187cef60f1302a2c8d4001909a3e7faa894389e8d3e0",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/RETRIEVAL.json
+++ b/.tieline/manifest/RETRIEVAL.json
@@ -150,7 +150,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "65d2177a53cc8384741af8f3aa7b9c3b1f39e47c10929a915305b25d70137aad",
+                "reviewed_content_hash": "fec9050cd5ef0c87ea32187cef60f1302a2c8d4001909a3e7faa894389e8d3e0",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -58,7 +58,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
+                "reviewed_content_hash": "1abf23d58e0179ef7fe4c48b755a87dd1d21d38998afe2673c4a5468aec69d82",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -102,7 +102,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
+                "reviewed_content_hash": "1abf23d58e0179ef7fe4c48b755a87dd1d21d38998afe2673c4a5468aec69d82",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -156,7 +156,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
+                "reviewed_content_hash": "1abf23d58e0179ef7fe4c48b755a87dd1d21d38998afe2673c4a5468aec69d82",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -200,7 +200,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
+                "reviewed_content_hash": "1abf23d58e0179ef7fe4c48b755a87dd1d21d38998afe2673c4a5468aec69d82",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -265,7 +265,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
+                "reviewed_content_hash": "1abf23d58e0179ef7fe4c48b755a87dd1d21d38998afe2673c4a5468aec69d82",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -309,7 +309,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
+                "reviewed_content_hash": "1abf23d58e0179ef7fe4c48b755a87dd1d21d38998afe2673c4a5468aec69d82",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -353,7 +353,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
+                "reviewed_content_hash": "1abf23d58e0179ef7fe4c48b755a87dd1d21d38998afe2673c4a5468aec69d82",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -408,7 +408,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
+                "reviewed_content_hash": "1abf23d58e0179ef7fe4c48b755a87dd1d21d38998afe2673c4a5468aec69d82",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -452,7 +452,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
+                "reviewed_content_hash": "1abf23d58e0179ef7fe4c48b755a87dd1d21d38998afe2673c4a5468aec69d82",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -516,7 +516,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
+                "reviewed_content_hash": "1abf23d58e0179ef7fe4c48b755a87dd1d21d38998afe2673c4a5468aec69d82",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -779,7 +779,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "4581891dd1d0be7dcd1f2e7d022c4c0fb3dd75e3d4b9e52c606ea99bab2c0646",
+                "reviewed_content_hash": "5796051eed0faf078a8bbc13bbc7d79e22ea0bd4088769ccc05bc1e466d78e23",
                 "target": {
                   "kind": "code",
                   "path": "skills/tieline/SKILL.md",
@@ -820,7 +820,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
+                "reviewed_content_hash": "1abf23d58e0179ef7fe4c48b755a87dd1d21d38998afe2673c4a5468aec69d82",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -854,7 +854,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "4581891dd1d0be7dcd1f2e7d022c4c0fb3dd75e3d4b9e52c606ea99bab2c0646",
+                "reviewed_content_hash": "5796051eed0faf078a8bbc13bbc7d79e22ea0bd4088769ccc05bc1e466d78e23",
                 "target": {
                   "kind": "code",
                   "path": "skills/tieline/SKILL.md",
@@ -864,7 +864,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
+                "reviewed_content_hash": "1abf23d58e0179ef7fe4c48b755a87dd1d21d38998afe2673c4a5468aec69d82",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -888,7 +888,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "4581891dd1d0be7dcd1f2e7d022c4c0fb3dd75e3d4b9e52c606ea99bab2c0646",
+                "reviewed_content_hash": "5796051eed0faf078a8bbc13bbc7d79e22ea0bd4088769ccc05bc1e466d78e23",
                 "target": {
                   "kind": "code",
                   "path": "skills/tieline/SKILL.md",
@@ -919,7 +919,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
+                "reviewed_content_hash": "1abf23d58e0179ef7fe4c48b755a87dd1d21d38998afe2673c4a5468aec69d82",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -58,7 +58,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -102,7 +102,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -156,7 +156,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -200,7 +200,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -265,7 +265,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -309,7 +309,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -353,7 +353,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -408,7 +408,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -452,7 +452,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -516,7 +516,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -769,7 +769,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "7b89e8547fcf8eed63948567cbd098e3b8822d60d33e963babcb9ce2b26f61a5",
+                "reviewed_content_hash": "cd1155c2f158e90eebf1764f98d0d087ec1330fcbff27caeffc993ee8d05d56f",
                 "target": {
                   "kind": "code",
                   "path": "skills/tieline/references/onboarding.md",
@@ -779,7 +779,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "1ec80f27c5965132ffd5226de0282446a6851c41038373beb3f7e5a65f1eef25",
+                "reviewed_content_hash": "19b56b59ced8904f033db9c6f04a2f7730682d6f6ff025f37a867065d5d4a42d",
                 "target": {
                   "kind": "code",
                   "path": "skills/tieline/SKILL.md",
@@ -820,7 +820,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "c2c0526f7de9b732030a70b06149b97c862ebf4661e16ed9b5377f9cd66ae97e",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -833,6 +833,50 @@
             "rationale": null,
             "scenarios": [],
             "stable_id": "RUNTIME-002-AC4",
+            "supersedes": null
+          },
+          {
+            "aliases": [],
+            "applies_to": null,
+            "contract_hash": "3eb8f069073282db940d4d0d6d82ac6784517b5db18c137045575e84854b0360",
+            "criterion": "Tieline semantic onboarding must produce a repository-wide evidence-backed initial contract by assessing every configured source root and discovered application boundary, covering or explaining every high-confidence observable behavior cluster, and treating path mapping only as a gap diagnostic.",
+            "links": [
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "cd1155c2f158e90eebf1764f98d0d087ec1330fcbff27caeffc993ee8d05d56f",
+                "target": {
+                  "kind": "code",
+                  "path": "skills/tieline/references/onboarding.md",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "19b56b59ced8904f033db9c6f04a2f7730682d6f6ff025f37a867065d5d4a42d",
+                "target": {
+                  "kind": "code",
+                  "path": "skills/tieline/SKILL.md",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "tests",
+                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
+                "target": {
+                  "framework_hint": "custom-script",
+                  "kind": "test",
+                  "path": "scripts/test-tieline.ts",
+                  "repository": "tieline"
+                }
+              }
+            ],
+            "position": 4,
+            "rationale": "A valid small seed can hide most of a monorepo, while maximizing mapped files would reward implementation-shaped criteria instead of coherent product behavior.",
+            "scenarios": [],
+            "stable_id": "RUNTIME-002-AC5",
             "supersedes": null
           }
         ],
@@ -907,6 +951,6 @@
   },
   "input": {
     "path": ".tieline/spec/runtime.yaml",
-    "sha256": "7b444fd069d9a66b42582f48a276ae80b4be14cd5798220bb407c6b958025993"
+    "sha256": "b99800a1de30f84ec450b22b0fbc845697c2a280253593441f817eb513b6b144"
   }
 }

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -58,7 +58,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
+                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -102,7 +102,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
+                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -156,7 +156,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
+                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -200,7 +200,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
+                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -265,7 +265,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
+                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -309,7 +309,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
+                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -353,7 +353,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
+                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -408,7 +408,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
+                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -452,7 +452,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
+                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -516,7 +516,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
+                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -617,7 +617,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "65d2177a53cc8384741af8f3aa7b9c3b1f39e47c10929a915305b25d70137aad",
+                "reviewed_content_hash": "fec9050cd5ef0c87ea32187cef60f1302a2c8d4001909a3e7faa894389e8d3e0",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -779,7 +779,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "19b56b59ced8904f033db9c6f04a2f7730682d6f6ff025f37a867065d5d4a42d",
+                "reviewed_content_hash": "4581891dd1d0be7dcd1f2e7d022c4c0fb3dd75e3d4b9e52c606ea99bab2c0646",
                 "target": {
                   "kind": "code",
                   "path": "skills/tieline/SKILL.md",
@@ -789,7 +789,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "d5ffff1580e8f76d657f72e75699ca93729908ec82915017567cc34bbe546d48",
+                "reviewed_content_hash": "94be8b91f0f800d0e5428794490172d74057451522a3622673f8352e6db6fc30",
                 "target": {
                   "kind": "code",
                   "path": "src/prompts.ts",
@@ -809,7 +809,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "65d2177a53cc8384741af8f3aa7b9c3b1f39e47c10929a915305b25d70137aad",
+                "reviewed_content_hash": "fec9050cd5ef0c87ea32187cef60f1302a2c8d4001909a3e7faa894389e8d3e0",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -820,7 +820,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
+                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -854,7 +854,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "19b56b59ced8904f033db9c6f04a2f7730682d6f6ff025f37a867065d5d4a42d",
+                "reviewed_content_hash": "4581891dd1d0be7dcd1f2e7d022c4c0fb3dd75e3d4b9e52c606ea99bab2c0646",
                 "target": {
                   "kind": "code",
                   "path": "skills/tieline/SKILL.md",
@@ -864,7 +864,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "869d5788439a3a0b47070b478128ce2ffc6bd768ef9456b9c55693189bf8cc2b",
+                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -877,6 +877,61 @@
             "rationale": "A valid small seed can hide most of a monorepo, while maximizing mapped files would reward implementation-shaped criteria instead of coherent product behavior.",
             "scenarios": [],
             "stable_id": "RUNTIME-002-AC5",
+            "supersedes": null
+          },
+          {
+            "aliases": [],
+            "applies_to": null,
+            "contract_hash": "f52c8c4680d86e1514fe4b30575c2384553cc33da00d718f873f2ec070bb3484",
+            "criterion": "Tieline's project-installed skill and equivalent MCP prompt must make semantic closeout discoverable before handoff or branch publication, classify every changed behavior cluster including relevant untracked files, directly apply and validate justified contract changes within the authorized commit or publication boundary, and rerun after later implementation changes.",
+            "links": [
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "4581891dd1d0be7dcd1f2e7d022c4c0fb3dd75e3d4b9e52c606ea99bab2c0646",
+                "target": {
+                  "kind": "code",
+                  "path": "skills/tieline/SKILL.md",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "implements",
+                "reviewed_content_hash": "94be8b91f0f800d0e5428794490172d74057451522a3622673f8352e6db6fc30",
+                "target": {
+                  "kind": "code",
+                  "path": "src/prompts.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "tests",
+                "reviewed_content_hash": "fec9050cd5ef0c87ea32187cef60f1302a2c8d4001909a3e7faa894389e8d3e0",
+                "target": {
+                  "framework_hint": "custom-script",
+                  "kind": "test",
+                  "path": "scripts/smoke.ts",
+                  "repository": "tieline"
+                }
+              },
+              {
+                "provenance": "authored",
+                "relation": "tests",
+                "reviewed_content_hash": "17a648e1d12e53225e8c6c5314a1eff235d4919494a066e8c9edef6d1f85e6a8",
+                "target": {
+                  "framework_hint": "custom-script",
+                  "kind": "test",
+                  "path": "scripts/test-tieline.ts",
+                  "repository": "tieline"
+                }
+              }
+            ],
+            "position": 5,
+            "rationale": "The semantic workflow supplies the cross-agent trigger, while the resulting pull-request diff remains the review and approval surface.",
+            "scenarios": [],
+            "stable_id": "RUNTIME-002-AC6",
             "supersedes": null
           }
         ],
@@ -951,6 +1006,6 @@
   },
   "input": {
     "path": ".tieline/spec/runtime.yaml",
-    "sha256": "b99800a1de30f84ec450b22b0fbc845697c2a280253593441f817eb513b6b144"
+    "sha256": "443044e6966cdfce43219c2189a9daf592edd75f1a53ab472537204c3c566106"
   }
 }

--- a/.tieline/spec/runtime.yaml
+++ b/.tieline/spec/runtime.yaml
@@ -468,6 +468,36 @@ capability:
                 repository: tieline
                 path: scripts/test-tieline.ts
                 framework_hint: custom-script
+        - key: RUNTIME-002-AC6
+          criterion: Tieline's project-installed skill and equivalent MCP prompt must make semantic closeout discoverable before handoff or branch publication, classify every changed behavior cluster including relevant untracked files, directly apply and validate justified contract changes within the authorized commit or publication boundary, and rerun after later implementation changes.
+          rationale: The semantic workflow supplies the cross-agent trigger, while the resulting pull-request diff remains the review and approval surface.
+          links:
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: skills/tieline/SKILL.md
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: src/prompts.ts
+            - relation: tests
+              provenance: authored
+              target:
+                kind: test
+                repository: tieline
+                path: scripts/test-tieline.ts
+                framework_hint: custom-script
+            - relation: tests
+              provenance: authored
+              target:
+                kind: test
+                repository: tieline
+                path: scripts/smoke.ts
+                framework_hint: custom-script
     - key: RUNTIME-003
       title: Verify the lifecycle as one system
       actor: maintainer

--- a/.tieline/spec/runtime.yaml
+++ b/.tieline/spec/runtime.yaml
@@ -445,6 +445,29 @@ capability:
                 repository: tieline
                 path: scripts/test-tieline.ts
                 framework_hint: custom-script
+        - key: RUNTIME-002-AC5
+          criterion: Tieline semantic onboarding must produce a repository-wide evidence-backed initial contract by assessing every configured source root and discovered application boundary, covering or explaining every high-confidence observable behavior cluster, and treating path mapping only as a gap diagnostic.
+          rationale: A valid small seed can hide most of a monorepo, while maximizing mapped files would reward implementation-shaped criteria instead of coherent product behavior.
+          links:
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: skills/tieline/SKILL.md
+            - relation: implements
+              provenance: authored
+              target:
+                kind: code
+                repository: tieline
+                path: skills/tieline/references/onboarding.md
+            - relation: tests
+              provenance: authored
+              target:
+                kind: test
+                repository: tieline
+                path: scripts/test-tieline.ts
+                framework_hint: custom-script
     - key: RUNTIME-003
       title: Verify the lifecycle as one system
       actor: maintainer

--- a/README.md
+++ b/README.md
@@ -359,6 +359,14 @@ npx --yes --package=skillfish@latest skillfish add knoxgraeme/tieline \
   --json
 ```
 
+The installed skill runs semantic closeout before implementation handoff,
+commit, push, or pull-request creation and updates. It classifies each changed
+behavior cluster, directly updates and compiles justified contract changes, and
+reruns if the implementation diff changes. The pull-request diff is the review
+surface; the agent does not stop at a comment and wait for separate approval to
+write the contract. The deterministic Contract workflow still validates the
+result and never invokes a model or authors branch changes.
+
 If a requested install fails or does not finish within two minutes, the
 workspace and private runtime profile remain ready. Tieline terminates the
 installer, exits non-zero, and prints a retry command using its stable agent

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -129,6 +129,14 @@ try {
     prompts.prompts.map((prompt) => prompt.name),
     ["tieline", "tieline_author"]
   );
+  const tielinePromptMetadata = prompts.prompts.find(
+    (prompt) => prompt.name === "tieline"
+  );
+  assert.match(tielinePromptMetadata?.title ?? "", /close out branch semantics/i);
+  assert.match(
+    tielinePromptMetadata?.description ?? "",
+    /before implementation handoff, commit, push, or pull-request publication/i
+  );
   const tielinePrompt = await client.getPrompt({ name: "tieline" });
   const promptText = String(
     tielinePrompt.messages[0]?.content.type === "text"

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -1526,12 +1526,12 @@ capability:
   );
   assert.match(
     tielineSkill,
-    /push that follow-up without asking again only when[\s\S]*explicitly includes push or opening or updating a pull request[\s\S]*pull request for the branch is already open/i,
+    /push that follow-up without asking again only when[\s\S]*explicitly includes push or opening or updating a pull request[\s\S]*pull request for the branch is already open and the active request is not[\s\S]*commit-only/i,
     "already-authorized push and PR flows must carry follow-up closeout changes without another approval round"
   );
   assert.match(
     tielineSkill,
-    /commit-only workflow[\s\S]*stops\s+after the local follow-up commit and must not push/i,
+    /commit-only request always overrides the open-pull-request[\s\S]*exception:[\s\S]*stop after the local follow-up commit and do not push/i,
     "commit-only closeout must preserve the local-only authorization ceiling"
   );
   assert.match(

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -1503,6 +1503,46 @@ capability:
     onboardingReference,
     /Discover these repository sources directly/
   );
+  assert.match(
+    onboardingReference,
+    /maximum coherent, accurate coverage/i,
+    "semantic onboarding must optimize for repository-wide behavioral coverage"
+  );
+  assert.match(
+    onboardingReference,
+    /every configured\s+source root[\s\S]*each discovered (?:application|app), service, worker, CLI, and\s+shared package boundary/i,
+    "semantic onboarding must assess every monorepo boundary before authoring"
+  );
+  assert.match(
+    onboardingReference,
+    /working coverage ledger[\s\S]*cover[\s\S]*exclude/i,
+    "semantic onboarding must account for discovered behavior rather than stopping at a valid seed"
+  );
+  assert.match(
+    onboardingReference,
+    /Repeated evidence increases confidence[\s\S]*not a prerequisite for\s+inclusion/i,
+    "one strong repository source must be enough to preserve observable behavior"
+  );
+  assert.match(
+    onboardingReference,
+    /mapping coverage[\s\S]*not a proxy for semantic completeness/i,
+    "path mapping must diagnose possible gaps without becoming the coverage objective"
+  );
+  assert.match(
+    onboardingReference,
+    /small contract for a large or multi-application repository is a reassessment\s+signal/i,
+    "suspiciously narrow monorepo output must trigger another discovery pass"
+  );
+  assert.match(
+    onboardingReference,
+    /Audit semantic coverage before completion[\s\S]*every coverage-ledger\s+row[\s\S]*each high-confidence behavior cluster must\s+be represented by a Story and AC or have an explicit exclusion reason[\s\S]*every application boundary must have been assessed/i,
+    "semantic onboarding must reconcile every discovered high-confidence behavior before completion"
+  );
+  assert.match(
+    onboardingReference,
+    /until no known high-confidence behavior remains unrepresented\s+or unexplained/i,
+    "semantic onboarding must continue discovery until the behavioral gap audit is clear"
+  );
   assert.match(onboardingReference, /Ask focused questions only/);
   assert.match(
     onboardingReference,

--- a/scripts/test-tieline.ts
+++ b/scripts/test-tieline.ts
@@ -1500,6 +1500,46 @@ capability:
   assert.match(tielineSkill, /not_assessed[\s\S]*not semantic proof/i);
   assert.match(tielineSkill, /linked test[\s\S]*not a claim that it ran or passed/i);
   assert.match(
+    tielineSkill,
+    /before handing off implementation, committing, pushing, or opening or updating a pull request/i,
+    "the installed skill must trigger semantic closeout before implementation leaves the agent"
+  );
+  assert.match(
+    tielineSkill,
+    /project installation of this skill, or explicit invocation through the\s+equivalent MCP prompt, is the trigger[\s\S]*do not add a separate\s+`\.tieline\/config\.json` existence check/i,
+    "the installed skill and equivalent MCP prompt must trigger closeout without a redundant config guard"
+  );
+  assert.match(
+    tielineSkill,
+    /covered[\s\S]*exclude[\s\S]*update[\s\S]*add[\s\S]*unresolved/i,
+    "semantic closeout must classify every changed behavior cluster"
+  );
+  assert.match(
+    tielineSkill,
+    /edit the repository YAML and compile its manifest\s+directly[\s\S]*do not post a comment or request separate approval first/i,
+    "justified contract changes must be reviewable branch changes rather than comment-only proposals"
+  );
+  assert.match(
+    tielineSkill,
+    /git ls-files --others --exclude-standard[\s\S]*relevant untracked file[\s\S]*behavior cluster[\s\S]*exclusion reason/i,
+    "semantic closeout must classify behavior in new untracked files"
+  );
+  assert.match(
+    tielineSkill,
+    /push that follow-up without asking again only when[\s\S]*explicitly includes push or opening or updating a pull request[\s\S]*pull request for the branch is already open/i,
+    "already-authorized push and PR flows must carry follow-up closeout changes without another approval round"
+  );
+  assert.match(
+    tielineSkill,
+    /commit-only workflow[\s\S]*stops\s+after the local follow-up commit and must not push/i,
+    "commit-only closeout must preserve the local-only authorization ceiling"
+  );
+  assert.match(
+    tielineSkill,
+    /implementation diff changes after closeout[\s\S]*run closeout again/i,
+    "later implementation changes must invalidate an earlier semantic closeout"
+  );
+  assert.match(
     onboardingReference,
     /Discover these repository sources directly/
   );
@@ -1766,6 +1806,11 @@ capability:
   assert.match(
     readme,
     /npx --yes --package=skillfish@latest skillfish add knoxgraeme\/tieline/
+  );
+  assert.match(
+    readme,
+    /installed skill runs semantic closeout[\s\S]*pull-request diff is the review\s+surface/i,
+    "README must explain that project skill installation supplies the semantic handoff hook"
   );
   assert.match(readme, /--agent codex[\s\S]*--agent claude-code/);
   assert.match(readme, /--skill-scope project/);

--- a/skills/tieline/SKILL.md
+++ b/skills/tieline/SKILL.md
@@ -108,9 +108,10 @@ Planning-only and grading-only flows keep their earlier stopping points.
    implementation was already committed, create a focused local follow-up
    commit. Push that follow-up without asking again only when the active workflow
    explicitly includes push or opening or updating a pull request, or when a
-   pull request for the branch is already open. A commit-only workflow stops
-   after the local follow-up commit and must not push. This authority covers only
-   the in-scope contract and generated artifacts.
+   pull request for the branch is already open and the active request is not
+   commit-only. A commit-only request always overrides the open-pull-request
+   exception: stop after the local follow-up commit and do not push. This
+   authority covers only the in-scope contract and generated artifacts.
 6. If the implementation diff changes after closeout, run closeout again against
    the new final diff before handoff or publication.
 

--- a/skills/tieline/SKILL.md
+++ b/skills/tieline/SKILL.md
@@ -27,7 +27,9 @@ visible action is the orientation and setup exchange in onboarding.md — the
 not before it. Init records auto-detected values, so
 verify rather than interrogate: confirm detected identity with the user and
 correct `.tieline/config.json` when a detection is wrong, but never ask for
-anything the repository can answer.
+anything the repository can answer. Treat the initial contract as a
+repository-wide semantic baseline, not a narrow seed that merely makes the
+workspace non-empty.
 
 ## Orient to this repository
 

--- a/skills/tieline/SKILL.md
+++ b/skills/tieline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tieline
-description: Semantically onboard an initialized Tieline repository, or author, plan, implement, grade, and reconcile Tieline User Stories and Acceptance Criteria. Use after `tieline init` to inspect configured context and create the first repository-specific capabilities, Stories, and ACs; also use to refine planning Stories/ACs or Backlog Items in Postgres, materialize planning records into repository YAML, connect branch work to product behavior, grade changed contract evidence, resolve likely duplicate definitions, or prepare a semantic contract change for pull-request review.
+description: Semantically onboard an initialized Tieline repository, or author, plan, implement, grade, and reconcile Tieline User Stories and Acceptance Criteria. Use after `tieline init` to inspect configured context and create the first repository-specific capabilities, Stories, and ACs. Use before handing off implementation, committing, pushing, or opening or updating a pull request so final branch work receives semantic closeout. Also use to refine planning Stories/ACs or Backlog Items in Postgres, materialize planning records into repository YAML, connect branch work to product behavior, grade changed contract evidence, resolve likely duplicate definitions, or prepare a semantic contract change for pull-request review.
 ---
 
 # Tieline
@@ -67,6 +67,52 @@ An Observation is evidence, not a required starting point. A flow may begin
 from an Observation, Backlog Item, planning Story, existing AC, or branch diff.
 The remaining sections apply only to onboarding, planning, implementation, and
 reconciliation; the grading-only flow returns after its report.
+
+## Close out branch semantics before handoff
+
+For any flow that changes implementation or the repository-owned contract, run
+semantic closeout against the final branch diff before handing off
+implementation, committing, pushing, or opening or updating a pull request.
+Project installation of this skill, or explicit invocation through the
+equivalent MCP prompt, is the trigger; do not add a separate
+`.tieline/config.json` existence check before deciding whether closeout applies.
+Planning-only and grading-only flows keep their earlier stopping points.
+
+1. Determine the comparison base as described under **Materialize or reconcile
+   repository behavior**, then inspect the tracked diff, the reconcile output,
+   and the untracked-file inventory from
+   `git ls-files --others --exclude-standard`. Because the tracked diff and
+   reconcile output omit untracked paths, read every relevant untracked file and
+   fold its observable behavior into a behavior cluster below, or retain an
+   exclusion reason. Group related changes by coherent, externally observable
+   behavior rather than by file, package, or internal implementation layer.
+2. Classify every changed behavior cluster as exactly one of:
+   - `covered`: an accepted AC already expresses the behavior accurately and its
+     evidence links still identify the right implementation or tests.
+   - `exclude`: the cluster is internal-only, generated, test-only, or otherwise
+     does not change observable product behavior. Retain the reason in the
+     closeout report; do not create an AC merely to eliminate an unmapped file.
+   - `update`: an accepted Story, AC, scenario, rationale, or evidence link must
+     change to remain truthful.
+   - `add`: distinct observable behavior is not represented by an accepted AC.
+   - `unresolved`: a material ambiguity prevents an accurate decision. Surface
+     the exact ambiguity instead of silently choosing another disposition.
+3. For every `update` or `add`, edit the repository YAML and compile its manifest
+   directly. Do not post a comment or request separate approval first. The
+   pull-request diff is the review surface and merge is approval.
+4. Complete the validation, coverage, reconciliation, check, and grading steps
+   below. Report the disposition of each cluster, including exclusions and any
+   unresolved item.
+5. When the active workflow already includes a commit, push, or pull-request
+   update, include closeout artifacts in the same pending commit. If the
+   implementation was already committed, create a focused local follow-up
+   commit. Push that follow-up without asking again only when the active workflow
+   explicitly includes push or opening or updating a pull request, or when a
+   pull request for the branch is already open. A commit-only workflow stops
+   after the local follow-up commit and must not push. This authority covers only
+   the in-scope contract and generated artifacts.
+6. If the implementation diff changes after closeout, run closeout again against
+   the new final diff before handoff or publication.
 
 ## Read exact intent before discovery
 
@@ -180,6 +226,9 @@ branch and let normal PR review accept or reject it.
 ## Completion
 
 Leave the branch with valid YAML and a byte-current `.tieline/manifest/`.
+For implementation and repository-contract flows, completion also requires a
+semantic-closeout disposition for every changed behavior cluster against the
+final diff; later implementation changes invalidate the earlier closeout.
 Warnings are review input, not a second gate. Do not claim that linked tests ran;
 test links are framework-agnostic evidence locators only.
 

--- a/skills/tieline/references/onboarding.md
+++ b/skills/tieline/references/onboarding.md
@@ -76,32 +76,73 @@ a human first sees them. Verify, do not re-ask.
 
 ## Author the initial contract
 
-1. Build a context inventory from the configured sources, README, product and
-   architecture documentation, public code entry points, source-root package
-   metadata, and tests. Discover these repository sources directly instead of
-   asking the user to enumerate them.
-2. Treat configured sources according to `.tieline/config.json`: use inline
+Optimize this first pass for maximum coherent, accurate coverage of the
+repository's observable behavior. "Initial" means the first repository-wide
+semantic baseline, not the smallest valid seed. There is no default Story or
+AC count and no brevity target: let evidence-backed behavior determine the
+size, while avoiding duplicate or speculative definitions.
+
+1. Map the repository before defining capabilities. Assess every configured
+   source root and each discovered application, service, worker, CLI, and
+   shared package boundary. Use workspace and package metadata to find them;
+   then inspect their README and architecture documentation, public entry
+   points, UI routes, APIs, commands and tools, events, scheduled jobs,
+   deployment surfaces, schemas and migrations, and tests. A shared package is
+   in semantic scope when it exposes observable behavior or enforces a product
+   invariant across applications. Discover these repository sources directly
+   instead of asking the user to enumerate them.
+2. Build a working coverage ledger for every assessed boundary. Record its
+   actors, public interfaces, coherent behavior clusters, strongest evidence
+   paths, and a disposition of `cover`, `exclude` with a reason, or
+   `unresolved`. Keep discovery in bounded passes so repository size or context
+   pressure does not silently narrow the scope.
+3. Treat configured sources according to `.tieline/config.json`: use inline
    descriptions as product framing, read local files, and fetch websites only
    when `allow_external_fetch` is `true`. Record which sources were actually
    inspected and which were unavailable.
-3. Infer repository-specific capability boundaries, actors, user goals,
-   benefits, observable behavior, and existing terminology. Prefer evidence
-   repeated across product documentation, public interfaces, and tests.
-4. Ask focused questions only when unresolved product meaning would materially
+4. Infer repository-specific capability boundaries, actors, user goals,
+   benefits, observable behavior, and existing terminology. Triangulate product
+   documentation, public interfaces, schemas, and tests when possible.
+   Repeated evidence increases confidence but is not a prerequisite for
+   inclusion when one authoritative repository source clearly establishes an
+   observable outcome.
+5. Cover the whole product surface, not only its primary end-user path. Include
+   distinct admin, operator, seller, developer, and machine actors when the
+   repository supports them, plus cross-cutting behavior such as identity and
+   tenancy, billing and usage, validation and cryptography, persistence
+   invariants, scheduling and delivery, and observability when repository
+   evidence makes those outcomes part of the product contract. Group by user
+   or business outcome rather than mirroring the directory tree.
+6. Ask focused questions only when unresolved product meaning would materially
    change a capability boundary or acceptance criterion. Do not ask for context
    that can be discovered from the repository.
-5. Search for likely duplicate IDs and behavior using the local YAML and
+7. Search for likely duplicate IDs and behavior using the local YAML and
    manifest plus database-backed semantic matching when available.
-6. Author the initial capabilities, Stories, and ACs under `.tieline/spec/`.
-   Never create generic starter content merely to make the directory non-empty.
-7. Validate and compile the contract.
-8. Read [grading.md](grading.md) and grade the initial contract. With no manifest
+8. Author the initial capabilities, Stories, and ACs under `.tieline/spec/`.
+   Give each AC one observable outcome. Do not compress independent behaviors
+   into a few broad ACs to keep the contract small, and never create generic
+   starter content merely to make the directory non-empty.
+9. Audit semantic coverage before completion. Reconcile every coverage-ledger
+   row with the authored contract: each high-confidence behavior cluster must
+   be represented by a Story and AC or have an explicit exclusion reason, and
+   every application boundary must have been assessed. Compare the result back
+   to the discovered public interfaces, tests, and cross-cutting invariants. A
+   small contract for a large or multi-application repository is a reassessment
+   signal, not proof that only a small product spine matters; run another
+   discovery pass until no known high-confidence behavior remains unrepresented
+   or unexplained.
+10. Use repository mapping coverage only as a diagnostic for possible missed
+    surfaces. It is not a proxy for semantic completeness: do not create an AC
+    per file or chase 100 percent path coverage, but investigate concentrated
+    unmapped areas before declaring the baseline complete.
+11. Validate and compile the contract.
+12. Read [grading.md](grading.md) and grade the initial contract. With no manifest
    at the comparison base, every authored link enters the grading scope as
    `link_added`. You authored every one of them, so dispatch fresh subagents
    batched by artifact path, passing only the emitted scope entries and never
    the authoring rationale; a link none of your reasoning can defend to a cold
    reader should be graded down, not argued for.
-9. Close with the completion report shaped by
+13. Close with the completion report shaped by
    [report.md](references/report.md): `.tieline/review.html` is the
    deliverable and leads the reply, followed by at most three
    needs-your-review bullets and two caveats. Do not enumerate the authored

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -44,9 +44,10 @@ export function registerPrompts(server: McpServer): void {
   server.registerPrompt(
     "tieline",
     {
-      title: "Onboard, author, grade, or reconcile with Tieline",
+      title:
+        "Onboard, author, grade, reconcile, or close out branch semantics with Tieline",
       description:
-        "Onboard repository behavior, shape planning Stories/ACs, grade evidence, or reconcile a branch while preserving Tieline authority boundaries.",
+        "Onboard repository behavior, shape planning Stories/ACs, grade evidence, reconcile a branch, or close out semantic changes before implementation handoff, commit, push, or pull-request publication while preserving Tieline authority boundaries.",
     },
     tielinePrompt
   );


### PR DESCRIPTION
## Summary

Following the repository-wide onboarding coverage added in #43, this codifies the ongoing closeout step in Tieline's project-installed skill.

- Require semantic closeout before implementation handoff, commit, push, or pull-request publication.
- Classify every changed behavior cluster, including relevant untracked files, as `covered`, `exclude`, `update`, `add`, or `unresolved`.
- Apply and compile justified contract updates directly so the pull-request diff remains the review surface, while preserving commit-only versus push authorization boundaries.
- Advertise the same trigger through the MCP prompt and rerun closeout whenever the implementation diff changes.

The existing Contract workflow remains deterministic and model-free; this PR does not add a semantic GitHub Action or require an app token.

## Validation

- `npm test`
- `npm run test:tieline`
- `npm run test:smoke`
- `tieline contract validate .` — 16 Stories, 52 Acceptance Criteria, zero warnings
- `tieline contract coverage .` — 52/52 Acceptance Criteria linked; 83/86 eligible repository files mapped
- `tieline contract reconcile . --base origin/main` — zero unclaimed source files
- `tieline check . --base origin/main` — current manifest, zero broken links, zero changes to consider
- Semantic grading — 25 scoped links: 7 supported, 18 partial, 0 unsupported
- Correctness, testing, and agent-native review — all actionable findings applied

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required. This changes installed agent instructions, MCP prompt metadata, repository contract content, and tests; it does not change a deployed service path.

Validation owner: PR reviewer. Validation window: CI for this pull request.

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
