### PR TITLE
docs: clarify assurance and code topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ source code → Tree-sitter → graph.json → symbols and static dependents
 ```
 
 Explicit blast-radius analysis starts from the supplied locators. A Git-base comparison instead
-seeds every symbol in changed files plus the endpoints of changed edges. Both follow static
-dependents, then perform the authored locator-to-AC join. Cycles, external dependencies,
+seeds every symbol in changed files plus the endpoints of changed edges. Both traverse static
+edges in the selected direction—dependents by default, or dependencies when requested—then
+perform the authored locator-to-AC join. Cycles, external dependencies,
 ambiguity, and traversal limits remain visible. The result is a bounded impact signal, not a
 runtime call graph or a guarantee of breakage.
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 <p align="center">
   <a href="#how-it-works">How it works</a> ·
   <a href="#quickstart">Quickstart</a> ·
-  <a href="#ac-aware-blast-radius">Blast radius</a> ·
-  <a href="#for-agents">For agents</a> ·
+  <a href="#how-the-code-graph-works">Code graph</a> ·
+  <a href="#what-agents-can-ask">Agent queries</a> ·
   <a href="docs/setup.md">Docs</a>
 </p>
 
@@ -33,22 +33,68 @@ state of `main`.
 
 ## How it works
 
-1. **An agent proposes intent.** The Tieline skill reads product context, code, schemas, and tests,
-   then drafts or updates Stories, ACs, and evidence links for review.
-2. **Parsers ground the links.** Tree-sitter extracts canonical symbols, source ranges, and bounded
-   snippets. Conservative resolvers write the committed topology graph without hiding ambiguous
-   or unresolved relationships.
-3. **A fresh agent grades the evidence.** The grader receives one AC, its current evidence, and the
-   only citations it may use. Deterministic verification rejects stale or invented citations.
-4. **Review establishes acceptance.** The authored YAML, compiled manifest, topology, and code
-   change travel together. Merge accepts that version of the relationship.
-5. **Tieline keeps it reviewable.** The skill updates intent as behavior changes, while
-   `tieline check` flags changed evidence, broken links, invalid contracts, and stale artifacts.
-6. **Follow features from request to production** In addition to production state, Tieline can store 'Observations' like feature requests, ideas or bug reports. Observations are stored in postgres outside of the codebase, and give agents context on both the current state and future direction. 
+1. **An agent proposes intent.** The Tieline skill reads product context and code, then drafts or
+   updates Stories, ACs, and evidence links for review.
+2. **Parsers ground code links.** Tree-sitter extracts canonical symbols, source ranges, and bounded
+   snippets. Conservative resolvers preserve ambiguous and unresolved relationships as diagnostics.
+3. **A fresh agent grades the evidence.** The grader receives one AC, its current evidence, and a
+   closed citation list. Deterministic verification rejects stale or invented citations.
+4. **Review establishes acceptance.** The YAML, compiled manifest, topology, and code change travel
+   together. Merge accepts that version of the relationship.
+5. **Checks make drift visible.** The skill updates intent as behavior changes, while `tieline check`
+   flags changed evidence, broken links, invalid contracts, and stale artifacts.
+
+Optional Postgres storage adds Observations such as feature requests, ideas, and bugs, giving agents
+context on both accepted behavior and future direction.
 
 [How evidence, authority, and freshness work →](docs/concepts.md)
 
-## Example Capability
+## What Tieline can prove
+
+Each signal has a narrow meaning. Tieline exposes the boundary instead of presenting static or
+agent-generated evidence as formal proof:
+
+| Signal | What it establishes | What it does not establish |
+| --- | --- | --- |
+| `authored` link | An explicit contract claim was accepted through repository review | Permanent semantic correctness |
+| Resolved selector | The current symbol can be identified precisely | That its implementation satisfies the AC |
+| `hash_current` | The evidence still matches the bytes accepted in the manifest | That the original review was correct |
+| Grade | A fresh agent judged current allowed evidence as supported, partial, or unsupported | Formal proof or test execution |
+| Blast-radius result | Static code dependents and their linked ACs may be impacted | Runtime reachability or guaranteed breakage |
+
+## How the code graph works
+
+`.tieline/topology/graph.json` is a committed, derived snapshot of the repository's source
+structure. `tieline code compile` uses Tree-sitter parsers to build it; later reads query the
+snapshot without starting a parser or writing to Postgres.
+
+| Layer | Role |
+| --- | --- |
+| Stored file hashes | Identify the exact source bytes represented by the snapshot |
+| Stored locator-bearing symbols | Identify code assets for traversal and authored joins |
+| Stored resolved adjacency edges | Trace static dependencies and dependents |
+| Stored unresolved dependency frontiers | Keep ambiguous imports and unsupported boundaries visible |
+| Query-time AC join (not stored) | Match visited paths and selectors to authored AC links |
+
+Source ranges, source snippets, raw reference and resolution facts, and parser diagnostics are not
+duplicated in `graph.json`.
+
+```text
+source code → Tree-sitter → graph.json → symbols and static dependents
+                                      + authored AC links
+                                      ↓
+                              AC-aware blast radius
+```
+
+Explicit blast-radius analysis starts from the supplied locators. A Git-base comparison instead
+seeds every symbol in changed files plus the endpoints of changed edges. Both follow static
+dependents, then perform the authored locator-to-AC join. Cycles, external dependencies,
+ambiguity, and traversal limits remain visible. The result is a bounded impact signal, not a
+runtime call graph or a guarantee of breakage.
+
+[Topology and blast-radius commands →](docs/cli.md#derived-code-topology-and-blast-radius)
+
+## What the contract looks like
 
 ```yaml
 version: 1
@@ -101,28 +147,7 @@ Restart your agent, then run the /tieline skill to begin onboarding. The skill p
 
 Postgres is optional. Use it to allow all your agents to query the current state of your product, and to record 'Observations' like feature requests alongside the products current state. The postgres DB gets updated with each merge. See [Setup's post-merge sync](docs/setup.md#post-merge-contract-sync) for configuration.
 
-## AC-aware blast radius
-
-The authored intent graph and derived code topology remain separate until they meet at an exact
-path and symbol:
-
-```text
-Capability → Story → AC → path/selector
-                              ↕ exact locator
-                graph.json: symbol → static dependents
-                              ↓
-                    ACs that may be impacted
-```
-
-`tieline code compile` parses the checkout into the committed `graph.json` snapshot. Blast-radius
-analysis starts with changed symbols, follows static imports and references, then joins the
-visited locators to authored AC links. Reads query the snapshot rather than reparsing the code.
-Ambiguous imports, external dependencies, cycles, and traversal limits remain visible, so the
-result is a bounded impact signal rather than a claim about runtime behavior.
-
-[Topology and blast-radius commands →](docs/cli.md#derived-code-topology-and-blast-radius)
-
-## For agents
+## What agents can ask
 
 | Ask | Tool |
 | --- | --- |
@@ -138,7 +163,7 @@ Observations and shape backlog Stories.
 
 [Full MCP reference →](docs/mcp.md)
 
-## Keeping the contract current
+## How the contract stays current
 
 During implementation, the Tieline skill proposes new Stories and ACs when behavior was added,
 updates existing definitions when behavior changed, reconciles evidence links, grades changed
@@ -156,7 +181,7 @@ the affected ACs for agent or human review. After merge, an idempotent sync publ
 
 [GitHub Actions example](docs/examples/tieline-check.yml) · [CLI reference](docs/cli.md)
 
-## Documentation
+## Where to learn more
 
 | Guide | Contents |
 | --- | --- |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -2,7 +2,7 @@
 
 [README](../README.md) · [Setup](setup.md) · **Concepts** · [CLI](cli.md) · [MCP](mcp.md) · [Operations](operations.md)
 
-## The hierarchy
+## How the contract is structured
 
 ```text
 Capability → User Story → Acceptance Criteria → zero or more Scenarios
@@ -25,9 +25,10 @@ coarse fallback.
 An AC stands on its own. A Scenario is useful when a condition, edge case, or concrete example
 would make the outcome easier to review; it is not required for the AC to be valid.
 
-## From proposed intent to accepted evidence
+## How evidence becomes accepted
 
-Tieline combines agent judgment with deterministic checks. Each layer has a narrower job:
+From proposed intent to accepted evidence, Tieline combines agent judgment with deterministic
+checks. Each layer has a narrower job:
 
 1. The Tieline skill reads configured product context, repository documentation, source entry
    points, schemas, migrations, and tests, then proposes Capabilities, Stories, ACs, and links.
@@ -43,17 +44,10 @@ Tieline combines agent judgment with deterministic checks. Each layer has a narr
 6. A separate code topology can follow static dependents and join visited locators back to the
    accepted AC links, producing an AC-aware possible blast radius.
 
-The resulting assurance is deliberately specific:
+The [README assurance table](../README.md#what-tieline-can-prove) summarizes what each signal
+establishes and where its claims stop.
 
-| Signal | Establishes | Does not establish |
-| --- | --- | --- |
-| `authored` link | An explicit contract claim was accepted through repository review | Permanent semantic correctness |
-| Resolved selector | The current symbol can be identified precisely | That its implementation satisfies the AC |
-| `hash_current` | The evidence still matches the bytes accepted in the manifest | That the original review was correct |
-| Grade | A fresh agent judged current allowed evidence as supported, partial, or unsupported | Formal proof or test execution |
-| Blast-radius result | Static code dependents and their linked ACs may be impacted | Runtime reachability or guaranteed breakage |
-
-## Authority model
+## Who can change each record
 
 A Story stays the same kind of record as it moves from planning to delivery. Its lifecycle
 determines which system may change it:
@@ -73,7 +67,7 @@ planning tools.
 Observations and Backlog Items do not turn into repository records. Repository YAML may retain
 stable `motivated_by` pointers without copying their source payloads.
 
-## The four planes
+## How the data is separated
 
 - **Contract plane** — strict repository YAML for accepted Stories and ACs; planning Stories and
   ACs live in Postgres while they remain `backlog`.
@@ -84,7 +78,7 @@ stable `motivated_by` pointers without copying their source payloads.
 - **Governance plane** — repository history, pull-request review, sync checkpoints, conflicts, and
   audit events.
 
-## Where things live
+## Where data lives
 
 | Location | Contents |
 | --- | --- |
@@ -95,7 +89,7 @@ stable `motivated_by` pointers without copying their source payloads.
 The private config location can be changed through `TIELINE_CONFIG_HOME`, `XDG_CONFIG_HOME`, or
 the platform-specific application-data directory.
 
-## Contract YAML
+## What contract YAML contains
 
 ```yaml
 version: 1
@@ -143,7 +137,7 @@ Stable IDs are identity, not search prose. Aliases support alternate language, a
 distinguishes legitimately different behavior, and `supersedes` converges definitions without
 deleting history.
 
-## The compiled manifest
+## What the compiled manifest contains
 
 Compilation writes `.tieline/manifest/`, one file per capability plus a small index:
 
@@ -162,11 +156,12 @@ stale shards for capabilities the specification no longer declares.
 The manifest intentionally repeats normalized contract content. YAML is the authoring source;
 the manifest is the deterministic, hash-bearing read model used by local tools, CI, and sync.
 
-## The derived topology
+## What the code topology contains
 
-`tieline code compile` writes `.tieline/topology/graph.json`. It records current symbols,
-references, resolved static edges, diagnostics, and unresolved frontiers for supported source
-languages. Reads query this committed snapshot without starting a parser or writing to Postgres.
+`tieline code compile` writes `.tieline/topology/graph.json`. It records source hashes,
+locator-bearing symbols, resolved static adjacency edges, and unresolved dependency frontiers for
+supported source languages. Reads query this committed snapshot without starting a parser or
+writing to Postgres.
 
 The topology is not a second source of product truth. It describes code-to-code relationships;
 the contract describes accepted intent-to-code relationships. Exact repository/path/selector
@@ -176,7 +171,7 @@ Repository sync and topology compilation are separate operations. A main-branch 
 compile and commit the reviewed topology with code changes, then sync the accepted contract and
 topology projection after merge when Postgres-backed access is configured.
 
-## Coverage and freshness
+## How coverage and freshness work
 
 Implementation-link and test-link coverage are independently `none`, `partial`, or `complete` for
 repository-owned Stories. Only direct AC links count; Story-level fallback links remain

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -253,7 +253,7 @@ pull-request diff remains the review and acceptance surface.
 
 While the spec has no Stories, `npx -y tieline@latest status --json` reports that onboarding is
 required and includes the skill invocation. Open `.tieline/review.html` after onboarding to review
-the contract as cards, then follow [Keeping the contract current](../README.md#keeping-the-contract-current)
+the contract as cards, then follow [How the contract stays current](../README.md#how-the-contract-stays-current)
 to add the CI check.
 
 For the contract lifecycle and assurance boundaries, read [Concepts](concepts.md). For individual


### PR DESCRIPTION
## Summary

Readers can now see how Tieline grounds intent in code and where each assurance signal stops. The README makes the committed topology graph a first-class part of the product story, explains its exact stored/query-time boundary, and shows how static dependents join back to authored Acceptance Criteria for advisory blast-radius analysis.

The Concepts guide now points to the shared assurance table and uses the same How/What/Where heading pattern as the README. The setup guide follows the renamed lifecycle anchor.

Related: #53

## Validation

- `npm test`
- `npm run test:tieline`
- `git diff --check -- README.md docs/concepts.md docs/setup.md`
- Compound Engineering review completed; both topology-accuracy findings were applied with no residual findings

## Post-deploy monitoring

No additional operational monitoring is required because this changes documentation only.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
