### PR TITLE
Add automated npm publish workflow and bump version to 0.1.29

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  id-token: write # required for npm trusted publishing (OIDC)
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Upgrade npm to an OIDC-capable version
+        run: npm install -g npm@latest
+
+      - name: Install locked dependencies
+        run: npm ci
+
+      - name: Determine whether this version is already published
+        id: version
+        run: |
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          if npm view "$name@$version" version >/dev/null 2>&1; then
+            echo "$name@$version is already on npm; skipping publish."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "$name@$version is not on npm; will publish."
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        if: steps.version.outputs.should_publish == 'true'
+        run: npm publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tieline",
-  "version": "0.1.15",
+  "version": "0.1.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tieline",
-      "version": "0.1.15",
+      "version": "0.1.29",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tieline",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tieline",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tieline",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Living Story/AC contract and semantic graph grounded in code, tests, help content, and organizational evidence.",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tieline",
-  "version": "0.1.15",
+  "version": "0.1.29",
   "description": "Living Story/AC contract and semantic graph grounded in code, tests, help content, and organizational evidence.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Merging a version bump to `main` now publishes to npm automatically: a new `Publish` workflow reads the `package.json` version, skips if that version is already on the registry, and otherwise runs `npm publish`. It authenticates via GitHub OIDC trusted publishing — no long-lived `NPM_TOKEN` in repository secrets, and provenance is generated automatically. Because merging a version bump now ships a release, the effective publish gate becomes branch protection on `main`. This PR also bumps the version to `0.1.29` to exercise the workflow (`0.1.28` is already published, so it would have no-op'd).

**Validation:** Not runnable before merge — the workflow only fires on push to `main` and relies on the repo's npm Trusted Publisher config; the first merge is the live test.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
