### PR TITLE
fix(onboarding): generate topology during setup

### DIFF
--- a/.tieline/manifest/CONTRACT.json
+++ b/.tieline/manifest/CONTRACT.json
@@ -690,7 +690,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "d2a60226274bae38aab88de645cbeeaded31050be1be57b7e8ed9e8e9bad44c5",
+                "reviewed_content_hash": "2868362406816135715d4cab5409c025e0d6a1ba92a9efe672dfe041848525fc",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/.tieline/manifest/RUNTIME.json
+++ b/.tieline/manifest/RUNTIME.json
@@ -58,7 +58,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "d2a60226274bae38aab88de645cbeeaded31050be1be57b7e8ed9e8e9bad44c5",
+                "reviewed_content_hash": "2868362406816135715d4cab5409c025e0d6a1ba92a9efe672dfe041848525fc",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -102,7 +102,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "d2a60226274bae38aab88de645cbeeaded31050be1be57b7e8ed9e8e9bad44c5",
+                "reviewed_content_hash": "2868362406816135715d4cab5409c025e0d6a1ba92a9efe672dfe041848525fc",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -156,7 +156,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "d2a60226274bae38aab88de645cbeeaded31050be1be57b7e8ed9e8e9bad44c5",
+                "reviewed_content_hash": "2868362406816135715d4cab5409c025e0d6a1ba92a9efe672dfe041848525fc",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -200,7 +200,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "d2a60226274bae38aab88de645cbeeaded31050be1be57b7e8ed9e8e9bad44c5",
+                "reviewed_content_hash": "2868362406816135715d4cab5409c025e0d6a1ba92a9efe672dfe041848525fc",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -265,7 +265,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "d2a60226274bae38aab88de645cbeeaded31050be1be57b7e8ed9e8e9bad44c5",
+                "reviewed_content_hash": "2868362406816135715d4cab5409c025e0d6a1ba92a9efe672dfe041848525fc",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -309,7 +309,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "d2a60226274bae38aab88de645cbeeaded31050be1be57b7e8ed9e8e9bad44c5",
+                "reviewed_content_hash": "2868362406816135715d4cab5409c025e0d6a1ba92a9efe672dfe041848525fc",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -353,7 +353,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "d2a60226274bae38aab88de645cbeeaded31050be1be57b7e8ed9e8e9bad44c5",
+                "reviewed_content_hash": "2868362406816135715d4cab5409c025e0d6a1ba92a9efe672dfe041848525fc",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -408,7 +408,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "d2a60226274bae38aab88de645cbeeaded31050be1be57b7e8ed9e8e9bad44c5",
+                "reviewed_content_hash": "2868362406816135715d4cab5409c025e0d6a1ba92a9efe672dfe041848525fc",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -452,7 +452,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "d2a60226274bae38aab88de645cbeeaded31050be1be57b7e8ed9e8e9bad44c5",
+                "reviewed_content_hash": "2868362406816135715d4cab5409c025e0d6a1ba92a9efe672dfe041848525fc",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -516,7 +516,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "d2a60226274bae38aab88de645cbeeaded31050be1be57b7e8ed9e8e9bad44c5",
+                "reviewed_content_hash": "2868362406816135715d4cab5409c025e0d6a1ba92a9efe672dfe041848525fc",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -769,7 +769,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "cd1155c2f158e90eebf1764f98d0d087ec1330fcbff27caeffc993ee8d05d56f",
+                "reviewed_content_hash": "6981645df4af3f3f705fcaccc22eeec27bebe40efc4b29a83434454a2617f796",
                 "target": {
                   "kind": "code",
                   "path": "skills/tieline/references/onboarding.md",
@@ -820,7 +820,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "d2a60226274bae38aab88de645cbeeaded31050be1be57b7e8ed9e8e9bad44c5",
+                "reviewed_content_hash": "2868362406816135715d4cab5409c025e0d6a1ba92a9efe672dfe041848525fc",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -844,7 +844,7 @@
               {
                 "provenance": "authored",
                 "relation": "implements",
-                "reviewed_content_hash": "cd1155c2f158e90eebf1764f98d0d087ec1330fcbff27caeffc993ee8d05d56f",
+                "reviewed_content_hash": "6981645df4af3f3f705fcaccc22eeec27bebe40efc4b29a83434454a2617f796",
                 "target": {
                   "kind": "code",
                   "path": "skills/tieline/references/onboarding.md",
@@ -864,7 +864,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "d2a60226274bae38aab88de645cbeeaded31050be1be57b7e8ed9e8e9bad44c5",
+                "reviewed_content_hash": "2868362406816135715d4cab5409c025e0d6a1ba92a9efe672dfe041848525fc",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",
@@ -919,7 +919,7 @@
               {
                 "provenance": "authored",
                 "relation": "tests",
-                "reviewed_content_hash": "d2a60226274bae38aab88de645cbeeaded31050be1be57b7e8ed9e8e9bad44c5",
+                "reviewed_content_hash": "2868362406816135715d4cab5409c025e0d6a1ba92a9efe672dfe041848525fc",
                 "target": {
                   "framework_hint": "custom-script",
                   "kind": "test",

--- a/skills/tieline/references/onboarding.md
+++ b/skills/tieline/references/onboarding.md
@@ -135,7 +135,18 @@ size, while avoiding duplicate or speculative definitions.
     surfaces. It is not a proxy for semantic completeness: do not create an AC
     per file or chase 100 percent path coverage, but investigate concentrated
     unmapped areas before declaring the baseline complete.
-11. Validate and compile the contract.
+11. Validate and compile the contract, then compile and validate the repository
+    topology:
+
+    ```sh
+    tieline contract validate .
+    tieline contract compile .
+    tieline code compile . --json
+    tieline code validate . --json
+    ```
+
+    Review and include the generated `.tieline/topology/graph.json` in the
+    onboarding pull request.
 12. Read [grading.md](grading.md) and grade the initial contract. With no manifest
    at the comparison base, every authored link enters the grading scope as
    `link_added`. You authored every one of them, so dispatch fresh subagents

--- a/tests/unit/runtime/test-tieline.ts
+++ b/tests/unit/runtime/test-tieline.ts
@@ -1855,6 +1855,11 @@ capability:
     /until no known high-confidence behavior remains unrepresented\s+or unexplained/i,
     "semantic onboarding must continue discovery until the behavioral gap audit is clear"
   );
+  assert.match(
+    onboardingReference,
+    /tieline contract validate \.\s*[\s\S]*tieline contract compile \.\s*[\s\S]*tieline code compile \. --json[\s\S]*tieline code validate \. --json/i,
+    "semantic onboarding must compile and validate the topology graph after the initial contract"
+  );
   assert.match(onboardingReference, /Ask focused questions only/);
   assert.match(
     onboardingReference,


### PR DESCRIPTION
## Summary

First-run semantic onboarding now generates and validates the repository topology graph alongside the initial contract. The onboarding pull request therefore includes `.tieline/topology/graph.json` without requiring a later manual compile.

## Validation

- `npm run check`
- Submitted-diff guardrail grade: passed with no violations

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
